### PR TITLE
feat(agent-proxy): show core state in the sidebar instead of a homepage card

### DIFF
--- a/plugins/agent-proxy/README.md
+++ b/plugins/agent-proxy/README.md
@@ -9,7 +9,15 @@ exposes management UI inside bb.
 
 - **Core lifecycle** — download/update the release binary (sha256-verified,
   never auto-swapped), autostart on plugin load, crash restart with backoff,
-  manual stop stays stopped. Home page + homepage card + `bb agent-proxy` CLI.
+  manual stop stays stopped. Home page + sidebar indicators + `bb agent-proxy` CLI.
+- **Sidebar state** — the "Agent Proxy" row in bb's main sidebar is tinted by
+  core state (green running, amber pulsing while starting/stopping, red
+  crashed, dimmed stopped). bb renders that row itself and reads `navPanel`
+  title/icon once, so a content script sets one `data-agent-proxy-state`
+  attribute on it and `app.css` does the rest. Pushed instantly from
+  `useCoreStatus` while a panel is mounted, with a 5s poll as the floor. It
+  depends on host DOM internals (`[data-testid="plugin-nav-sidebar-items"]`
+  and the row label), so it degrades to painting nothing if either changes.
 - **OAuth** — Claude and Codex browser flows via the core's management API;
   auth-file list with enable/disable, delete, quota state, and quota reset.
 - **Providers** — upstream credential collections (`claude-api-key`,

--- a/plugins/agent-proxy/app.css
+++ b/plugins/agent-proxy/app.css
@@ -1,1 +1,44 @@
-/* Host theme tokens cover everything this plugin renders; no overrides yet. */
+/* Host theme tokens cover everything this plugin renders inside its own panel.
+   The rules below are the one exception: they colour this plugin's row in bb's
+   main sidebar by core state. `components/sidebar-nav-status.ts` is the only
+   writer of `data-agent-proxy-state`, so nothing else in the app can match. */
+
+[data-agent-proxy-state] > svg {
+  transition: color 150ms ease, opacity 150ms ease;
+}
+
+[data-agent-proxy-state="running"] > svg {
+  color: #10b981;
+}
+
+[data-agent-proxy-state="starting"] > svg,
+[data-agent-proxy-state="stopping"] > svg {
+  color: #f59e0b;
+  animation: agent-proxy-pulse 1.4s ease-in-out infinite;
+}
+
+[data-agent-proxy-state="crashed"] > svg {
+  color: var(--destructive, #ef4444);
+}
+
+[data-agent-proxy-state="stopped"] > svg,
+[data-agent-proxy-state="not-installed"] > svg {
+  opacity: 0.45;
+}
+
+@keyframes agent-proxy-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-agent-proxy-state] > svg {
+    animation: none;
+    transition: none;
+  }
+}

--- a/plugins/agent-proxy/app.tsx
+++ b/plugins/agent-proxy/app.tsx
@@ -1,15 +1,18 @@
 import "./app.css";
 import { definePluginApp, useBbNavigate } from "@bb/plugin-sdk/app";
-import { toast } from "sonner";
 import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
-import { StatusBadge } from "@/components/status-badge";
+import { CORE_STATE_STYLES } from "@/components/status-badge";
+import { mountSidebarNavStatus } from "@/components/sidebar-nav-status";
 import { useCoreStatus } from "@/components/use-core-status";
 import { HomePage } from "@/components/pages/home";
 import { OAuthPage } from "@/components/pages/oauth";
 import { ProvidersPage } from "@/components/pages/providers";
 import { UsagePage } from "@/components/pages/usage";
 import { AgentsPage } from "@/components/pages/agents";
+import type { CoreStatus } from "./server";
+
+/** The sidebar row's label. The content script finds the row by this text. */
+const NAV_TITLE = "Agent Proxy";
 
 const PAGES: { key: string; label: string; component: () => React.JSX.Element }[] = [
   { key: "", label: "Home", component: HomePage },
@@ -18,6 +21,26 @@ const PAGES: { key: string; label: string; component: () => React.JSX.Element }[
   { key: "usage", label: "Usage", component: UsagePage },
   { key: "agents", label: "Agents", component: AgentsPage },
 ];
+
+/** One muted line: colored dot, state, and port. The full controls live on Home. */
+function SidebarIndicator({ status }: { status: CoreStatus | null }) {
+  const style = status ? CORE_STATE_STYLES[status.state] : null;
+  const text = !style
+    ? "…"
+    : status && status.state !== "not-installed"
+      ? `${style.label} · :${status.port}`
+      : style.label;
+
+  return (
+    <div
+      className="flex items-center gap-2 border-b border-border px-3 py-2 text-xs text-muted-foreground"
+      title={style ? `CLIProxyAPI core — ${text}` : "CLIProxyAPI core — loading"}
+    >
+      <span className={cn("size-1.5 shrink-0 rounded-full", style?.dot ?? "bg-muted-foreground/40")} />
+      <span className="truncate">{text}</span>
+    </div>
+  );
+}
 
 function AgentProxyPanel({ subPath }: { subPath: string }) {
   const navigate = useBbNavigate();
@@ -29,14 +52,7 @@ function AgentProxyPanel({ subPath }: { subPath: string }) {
   return (
     <div className="flex h-full min-h-0">
       <aside className="flex w-48 shrink-0 flex-col border-r border-border">
-        <div className="border-b border-border p-3">
-          {status ? (
-            <StatusBadge state={status.state} />
-          ) : (
-            <span className="text-sm text-muted-foreground">…</span>
-          )}
-          <div className="mt-0.5 text-xs text-muted-foreground">port {status?.port ?? "…"}</div>
-        </div>
+        <SidebarIndicator status={status} />
         <nav className="flex-1 overflow-y-auto p-2">
           {PAGES.map((page) => (
             <button
@@ -64,55 +80,16 @@ function AgentProxyPanel({ subPath }: { subPath: string }) {
   );
 }
 
-function HomepageCard() {
-  const navigate = useBbNavigate();
-  const { status, rpc, refresh } = useCoreStatus();
-
-  const toggle = async () => {
-    if (!status) return;
-    try {
-      await rpc.call(status.state === "running" || status.state === "starting" ? "stop" : "start");
-      await refresh();
-    } catch (cause) {
-      toast.error(String(cause instanceof Error ? cause.message : cause));
-    }
-  };
-
-  return (
-    <div className="flex items-center gap-3 rounded-lg border border-border bg-card p-3">
-      <div className="min-w-0 flex-1">
-        {status ? <StatusBadge state={status.state} /> : <span className="text-sm text-muted-foreground">…</span>}
-        <div className="mt-0.5 truncate text-xs text-muted-foreground">
-          {status
-            ? status.state === "not-installed"
-              ? "CLIProxyAPI core is not installed yet"
-              : `${status.endpoints.openai} · v${status.installedVersion ?? "?"}`
-            : ""}
-        </div>
-      </div>
-      {status && status.state !== "not-installed" ? (
-        <Button size="sm" variant="outline" onClick={() => void toggle()}>
-          {status.state === "running" || status.state === "starting" ? "Stop" : "Start"}
-        </Button>
-      ) : null}
-      <Button size="sm" onClick={() => navigate.toPluginPanel("agent-proxy", { subPath: "" })}>
-        Open
-      </Button>
-    </div>
-  );
-}
-
 export default definePluginApp((app) => {
   app.slots.navPanel({
     id: "agent-proxy",
-    title: "Agent Proxy",
+    title: NAV_TITLE,
     icon: "Server",
     path: "agent-proxy",
     component: AgentProxyPanel,
   });
-  app.slots.homepageSection({
-    id: "agent-proxy-status",
-    title: "Agent Proxy",
-    component: HomepageCard,
+  app.contentScripts.register({
+    id: "sidebar-nav-status",
+    mount: ({ signal }) => mountSidebarNavStatus({ title: NAV_TITLE, signal }),
   });
 });

--- a/plugins/agent-proxy/components/sidebar-nav-status.ts
+++ b/plugins/agent-proxy/components/sidebar-nav-status.ts
@@ -1,0 +1,115 @@
+import type { CoreStatus } from "../server";
+
+/**
+ * Paints core state onto this plugin's row in bb's main sidebar.
+ *
+ * bb renders that row itself from the `navPanel` registration — title and icon
+ * are read once, and no slot accepts a live component — so a content script is
+ * the only way to reflect state there. We locate the row by its label and set
+ * one data attribute on it; `app.css` owns the visuals.
+ *
+ * Everything here degrades to a no-op: a missing container, a renamed row, or a
+ * failed request leaves the sidebar exactly as the host drew it.
+ */
+const PLUGIN_ID = "agent-proxy";
+const NAV_ROWS = '[data-testid="plugin-nav-sidebar-items"]';
+const STATE_ATTR = "data-agent-proxy-state";
+const POLL_MS = 5_000;
+
+/** Broadcast by `useCoreStatus` so a mounted panel updates the row instantly. */
+export const STATUS_EVENT = "agent-proxy:core-status";
+
+export type CoreState = CoreStatus["state"];
+
+/** The row's sibling "…" button carries this suffix; skip it when matching. */
+function isOptionsButton(button: Element): boolean {
+  return button.getAttribute("aria-label")?.endsWith("panel options") === true;
+}
+
+function findNavRow(container: Element, title: string): HTMLElement | null {
+  for (const button of container.querySelectorAll("button")) {
+    if (isOptionsButton(button)) continue;
+    if (button.textContent?.trim() === title) return button;
+  }
+  return null;
+}
+
+async function fetchState(signal: AbortSignal): Promise<CoreState | null> {
+  const response = await fetch(`/api/v1/plugins/${PLUGIN_ID}/rpc/status`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "null",
+    signal,
+  });
+  if (!response.ok) return null;
+  const body = (await response.json()) as { result?: CoreStatus };
+  return body.result?.state ?? null;
+}
+
+export function mountSidebarNavStatus({ title, signal }: { title: string; signal: AbortSignal }) {
+  let state: CoreState | null = null;
+  let container: Element | null = null;
+  let row: HTMLElement | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  // Scoped to the nav container, never the document: the row moves when the
+  // user reorders or hides panels, but chat streaming must not trigger us.
+  const observer = new MutationObserver(() => paint());
+
+  function paint() {
+    const nextContainer = document.querySelector(NAV_ROWS);
+    if (nextContainer !== container) {
+      observer.disconnect();
+      container = nextContainer;
+      if (container) observer.observe(container, { childList: true, subtree: true });
+    }
+
+    const nextRow = container ? findNavRow(container, title) : null;
+    if (nextRow !== row) {
+      row?.removeAttribute(STATE_ATTR);
+      row = nextRow;
+    }
+    if (!row) return;
+    if (state) row.setAttribute(STATE_ATTR, state);
+    else row.removeAttribute(STATE_ATTR);
+  }
+
+  function apply(next: CoreState | null) {
+    if (next === state) {
+      paint(); // the row itself may have moved
+      return;
+    }
+    state = next;
+    paint();
+  }
+
+  const onPush = (event: Event) => {
+    const detail = (event as CustomEvent<CoreState>).detail;
+    if (typeof detail === "string") apply(detail);
+  };
+  window.addEventListener(STATUS_EVENT, onPush, { signal });
+
+  // The push above only fires while a panel is mounted, so poll as the floor.
+  const tick = async () => {
+    if (signal.aborted) return;
+    if (!document.hidden) {
+      try {
+        apply(await fetchState(signal));
+      } catch {
+        // Transient: keep the last known state and try again next tick.
+      }
+    } else {
+      paint();
+    }
+    if (!signal.aborted) timer = setTimeout(() => void tick(), POLL_MS);
+  };
+  void tick();
+
+  return () => {
+    observer.disconnect();
+    if (timer !== null) clearTimeout(timer);
+    row?.removeAttribute(STATE_ATTR);
+    row = null;
+    container = null;
+  };
+}

--- a/plugins/agent-proxy/components/status-badge.tsx
+++ b/plugins/agent-proxy/components/status-badge.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/lib/utils";
 import type { CoreStatus } from "../server";
 
-const STYLES: Record<CoreStatus["state"], { dot: string; label: string }> = {
+export const CORE_STATE_STYLES: Record<CoreStatus["state"], { dot: string; label: string }> = {
   "not-installed": { dot: "bg-muted-foreground", label: "Not installed" },
   stopped: { dot: "bg-muted-foreground", label: "Stopped" },
   starting: { dot: "bg-amber-500", label: "Starting…" },
@@ -11,7 +11,7 @@ const STYLES: Record<CoreStatus["state"], { dot: string; label: string }> = {
 };
 
 export function StatusBadge({ state, className }: { state: CoreStatus["state"]; className?: string }) {
-  const style = STYLES[state];
+  const style = CORE_STATE_STYLES[state];
   return (
     <span className={cn("inline-flex items-center gap-1.5 text-sm text-foreground", className)}>
       <span className={cn("size-2 rounded-full", style.dot)} />

--- a/plugins/agent-proxy/components/use-core-status.ts
+++ b/plugins/agent-proxy/components/use-core-status.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRealtime, useRpc } from "@bb/plugin-sdk/app";
+import { STATUS_EVENT } from "./sidebar-nav-status";
 import type { CoreStatus, rpcContract } from "../server";
 
 /** Core status: realtime-pushed on every supervisor transition, with a slow
@@ -16,6 +17,8 @@ export function useCoreStatus(pollMs = 30_000) {
       if (!aliveRef.current) return;
       setStatus(next);
       setError(null);
+      // Hand the realtime transition to the sidebar row, which has no hooks.
+      window.dispatchEvent(new CustomEvent(STATUS_EVENT, { detail: next.state }));
     } catch (cause) {
       if (aliveRef.current) setError(String(cause instanceof Error ? cause.message : cause));
     }


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>