### PR TITLE
fix(gh-stack): draw panel chrome from theme tokens

### DIFF
--- a/plugins/gh-stack/app.tsx
+++ b/plugins/gh-stack/app.tsx
@@ -187,14 +187,17 @@ function StatusPill({
 }
 
 // +N −M, in the diff colors. The file names live in the tree below the row,
-// so the chip carries the line counts alone.
+// so the chip carries the line counts alone. The colors are the host's own
+// diff tokens — the same ones the changed-file tree paints its rows with — so
+// a row total and the files under it never read as two different greens.
+const ADDED_COLOR = "var(--diffs-addition-color, #3fb950)";
+const DELETED_COLOR = "var(--diffs-deletion-color, #f85149)";
+
 function DeltaChip({ change }: { change: ChangeSet }) {
   return (
     <span className="inline-flex shrink-0 items-center gap-1.5 font-mono text-xs leading-4 tabular-nums">
-      <span className="text-green-600 dark:text-green-400">
-        +{change.additions}
-      </span>
-      <span className="text-red-600 dark:text-red-400">−{change.deletions}</span>
+      <span style={{ color: ADDED_COLOR }}>+{change.additions}</span>
+      <span style={{ color: DELETED_COLOR }}>−{change.deletions}</span>
     </span>
   );
 }
@@ -263,7 +266,7 @@ function RailRow({
     >
       {accent ? (
         <div
-          className="absolute -left-2 top-1 bottom-1 w-1 rounded-md bg-blue-500"
+          className="absolute -left-2 top-1 bottom-1 w-1 rounded-md bg-primary"
           aria-hidden
         />
       ) : null}
@@ -526,6 +529,7 @@ function LayerComposer({
           <Button
             type="submit"
             size="sm"
+            variant="secondary"
             className="h-7"
             disabled={!canSubmit}
           >
@@ -565,7 +569,7 @@ function Switch({
       aria-label={label}
       disabled={disabled}
       onClick={() => onChange(!checked)}
-      className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-input transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 ${
+      className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-border transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 ${
         checked ? "bg-foreground" : "bg-muted"
       }`}
     >
@@ -1365,7 +1369,7 @@ function StackPanel({ threadId }: { threadId: string }) {
             <span className="text-muted-foreground">
               <Octicon path={OCTICONS.dot} />
             </span>
-            <span className="justify-self-start rounded-md bg-blue-500/10 px-1.5 py-0.5 font-mono text-xs leading-[18px] text-muted-foreground">
+            <span className="justify-self-start rounded-md bg-muted px-1.5 py-0.5 font-mono text-xs leading-[18px] text-muted-foreground">
               {base ?? "trunk"}
             </span>
           </div>
@@ -1375,9 +1379,14 @@ function StackPanel({ threadId }: { threadId: string }) {
       {stack ? (
         <div className="space-y-2">
           <div className="flex flex-wrap items-center gap-2">
+            {/* Secondary, not the default fill: that variant is
+                bg-foreground, the brightest surface the theme has, and a row
+                of them out-shouts the stack they act on. Merge keeps its own
+                color — it is the irreversible one. */}
             <span className="flex-1 min-w-fit" title={`Sync — ${syncSubtitle}`}>
               <Button
                 size="sm"
+                variant="secondary"
                 className="w-full"
                 onClick={() => void runAction("sync")}
                 disabled={mutationsDisabled || !syncNeeded}
@@ -1398,6 +1407,7 @@ function StackPanel({ threadId }: { threadId: string }) {
             <span className="flex-1 min-w-fit" title={`Submit — ${submitEffect}`}>
               <Button
                 size="sm"
+                variant="secondary"
                 className="w-full"
                 onClick={() => void runAction(needsRestack ? "sync-submit" : "submit")}
                 disabled={mutationsDisabled || !submitNeeded}

--- a/plugins/gh-stack/components/ui/button.tsx
+++ b/plugins/gh-stack/components/ui/button.tsx
@@ -15,8 +15,10 @@ const buttonVariants = cva(
           "bg-foreground text-background hover:bg-foreground/90",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        // --border, not --input: see the note in input.tsx. Every bordered
+        // surface in a panel should draw the same line.
         outline:
-          "border border-input bg-transparent hover:bg-state-hover hover:text-foreground",
+          "border border-border bg-transparent hover:bg-state-hover hover:text-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost:

--- a/plugins/gh-stack/components/ui/input.tsx
+++ b/plugins/gh-stack/components/ui/input.tsx
@@ -8,6 +8,12 @@ import {
 import { cn } from "../../lib/utils";
 import { CONTROL_HOVER_TRANSITION } from "./motion.js";
 
+// The edge is --border, not --input. A theme may define --input as the well's
+// fill rather than an edge color (bb's own token contract says exactly that:
+// "the fill is the load-bearing role … the visible edge comes from --border /
+// --ring"), in which case border-input paints a different line from every
+// other bordered surface in the panel — the file tree above all, which this
+// field sits directly against.
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
   ({ className, type, ...props }, ref) => {
     return (
@@ -15,7 +21,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
         type={type}
         autoComplete="off"
         className={cn(
-          `flex w-full rounded-md border border-input bg-transparent px-3 py-1 ${CONTROL_HOVER_TRANSITION} file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50`,
+          `flex w-full rounded-md border border-border bg-transparent px-3 py-1 ${CONTROL_HOVER_TRANSITION} file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50`,
           COARSE_POINTER_INPUT_HEIGHT_CLASS,
           COARSE_POINTER_TEXT_BASE_CLASS,
           className,


### PR DESCRIPTION
Several controls painted colors the active theme never chose. The accent rail
and trunk chip used Tailwind's fixed blue; the diff counts used fixed
green/red while the file tree beside them used the host's --diffs-* tokens, so
the same figure appeared in two shades; text fields and the settings switch
drew their edge from --input, which a theme may define as a fill rather than a
border (bb's own token contract says exactly that), leaving them mismatched
against every other bordered surface.

Point all of them at the tokens: --primary and --muted for the rail and chip,
the --diffs-* pair for the counts, --border for control edges.

Sync, Submit, and Stack also drop the default button variant, which is
bg-foreground — the brightest surface the theme has, and far too loud for
routine actions. Merge keeps its own color as the irreversible one.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>