### PR TITLE
feat(gh-stack): show stashes held on a layer

### DIFF
--- a/plugins/gh-stack/app.tsx
+++ b/plugins/gh-stack/app.tsx
@@ -218,13 +218,24 @@ function BranchChips({ branch }: { branch: StackBranch }) {
           needs rebase
         </span>
       ) : null}
-      {branch.hasStash ? (
+      {/* Two different facts share one chip. A pending auto-stash is the
+          louder one — those changes come back on checkout — so it wins the
+          wording when both hold. */}
+      {branch.hasStash || (branch.stashCount ?? 0) > 0 ? (
         <span
           className={`${chip} inline-flex items-center gap-1 border-border text-muted-foreground`}
-          title="Tracked changes for this layer are stored in a plugin stash and will return when the layer is checked out."
+          title={
+            branch.hasStash
+              ? "Tracked changes for this layer are stored in a plugin stash and will return when the layer is checked out."
+              : `${branch.stashCount} stash ${branch.stashCount === 1 ? "entry was" : "entries were"} made on this branch. Restore them yourself with git stash.`
+          }
         >
           <Icon name="Archive" className="size-3" aria-hidden />
-          stashed
+          {branch.hasStash
+            ? "stashed"
+            : branch.stashCount === 1
+              ? "1 stash"
+              : `${branch.stashCount} stashes`}
         </span>
       ) : null}
       {!settled && (branch.aheadOfRemote === null || branch.behindRemote === null) ? (

--- a/plugins/gh-stack/lib/smart-checkout.ts
+++ b/plugins/gh-stack/lib/smart-checkout.ts
@@ -295,6 +295,31 @@ export async function activeAutoStashOwners(
   );
 }
 
+// "On <branch>: …" / "WIP on <branch>: …" — how Git records the branch a
+// stash was taken from. Anchored, so a branch name appearing later in a
+// hand-written message cannot be mistaken for the owner.
+const STASH_BRANCH = /^(?:WIP on|On) ([^:]+):/;
+
+// How many stash entries exist per branch, counting every entry Git holds —
+// this plugin's auto-stashes as well as ones made by hand or by another tool.
+// Null when the stash list could not be read, so the caller can tell "no
+// stashes" from "unknown".
+export async function stashCountsByBranch(
+  deps: StashInspectionDependencies,
+): Promise<Map<string, number> | null> {
+  const result = await deps.runGit(["stash", "list", "--format=%gs"]);
+  if (result.code !== 0) return null;
+  const counts = new Map<string, number>();
+  for (const line of result.stdout.split("\n")) {
+    const match = STASH_BRANCH.exec(line.trim());
+    if (!match) continue;
+    const branch = match[1].trim();
+    if (!branch) continue;
+    counts.set(branch, (counts.get(branch) ?? 0) + 1);
+  }
+  return counts;
+}
+
 async function markEntryHandled(
   entry: StashEntry,
   deps: SmartCheckoutDependencies,

--- a/plugins/gh-stack/server.ts
+++ b/plugins/gh-stack/server.ts
@@ -32,6 +32,7 @@ import {
 import {
   activeAutoStashOwners,
   checkoutWithAutoStash,
+  stashCountsByBranch,
 } from "./lib/smart-checkout";
 import { resolveWorkspaceKey } from "./lib/workspace-key";
 import {
@@ -116,8 +117,13 @@ const branchOutSchema = z.object({
   isMerged: z.boolean(),
   isQueued: z.boolean(),
   needsRebase: z.boolean(),
-  // True while tracked changes for this branch wait in a plugin auto-stash.
+  // True while tracked changes for this branch wait in a plugin auto-stash,
+  // which the plugin restores on checkout.
   hasStash: z.boolean(),
+  // Stash entries Git holds for this branch, whoever made them — this
+  // plugin's auto-stashes, `git stash` by hand, another tool. Zero when there
+  // are none; null when the stash list could not be read.
+  stashCount: z.number().int().nonnegative().nullable(),
   pr: prOutSchema.nullable(),
   // Present and true only when the returned draft value is an optimistic
   // server overlay over a GitHub read that has not caught up yet.
@@ -1501,7 +1507,7 @@ export default async function plugin(bb: BbPluginApi) {
       mutationVersion: workspaceMutationVersions.get(workspace.key) ?? 0,
     });
 
-    const [result, pending, defaultBranch, headPrefix, stashOwners] =
+    const [result, pending, defaultBranch, headPrefix, stashOwners, stashCounts] =
       await Promise.all([
         runGh(["stack", "view", "--json"], cwd, 30_000),
         pendingChangeSet(cwd),
@@ -1510,6 +1516,9 @@ export default async function plugin(bb: BbPluginApi) {
         activeAutoStashOwners({
           runGit: (args, timeoutMs) => runGit(args, cwd, timeoutMs),
           blockedStashOids: blockedAutoStashOids,
+        }),
+        stashCountsByBranch({
+          runGit: (args, timeoutMs) => runGit(args, cwd, timeoutMs),
         }),
       ]);
     const inspected = parseStackViewResult(result);
@@ -1584,6 +1593,7 @@ export default async function plugin(bb: BbPluginApi) {
           return {
             ...branch,
             hasStash: stashOwners?.has(branch.name) ?? false,
+            stashCount: stashCounts?.get(branch.name) ?? (stashCounts ? 0 : null),
             pr: null,
             diff: await diffPromise,
             aheadOfRemote: await aheadPromise,
@@ -1609,6 +1619,7 @@ export default async function plugin(bb: BbPluginApi) {
           ...branch,
           isMerged,
           hasStash: stashOwners?.has(branch.name) ?? false,
+          stashCount: stashCounts?.get(branch.name) ?? (stashCounts ? 0 : null),
           pr: {
             ...branch.pr,
             state,

--- a/plugins/gh-stack/test/smart-checkout.test.ts
+++ b/plugins/gh-stack/test/smart-checkout.test.ts
@@ -7,6 +7,7 @@ import { test } from "node:test";
 import {
   activeAutoStashOwners,
   checkoutWithAutoStash,
+  stashCountsByBranch,
   type CommandResult,
   type SmartCheckoutDependencies,
 } from "../lib/smart-checkout.ts";
@@ -218,4 +219,61 @@ test("a restore conflict preserves the stash and records durable recovery state"
   } finally {
     rmSync(cwd, { recursive: true, force: true });
   }
+});
+
+test("stash counts group every entry by the branch it was made on", async () => {
+  const cwd = repository();
+  try {
+    const deps = dependencies(cwd);
+    assert.deepEqual(await stashCountsByBranch(deps), new Map());
+
+    // Two on `source`, one made by hand and one by the plugin's own path.
+    writeFileSync(join(cwd, "manual.txt"), "hand edit\n");
+    gitOk(cwd, ["stash", "push", "-m", "by hand"]);
+    writeFileSync(join(cwd, "carry.txt"), "second edit\n");
+    gitOk(cwd, ["stash", "push"]);
+
+    gitOk(cwd, ["checkout", "target"]);
+    writeFileSync(join(cwd, "manual.txt"), "target edit\n");
+    gitOk(cwd, ["stash", "push", "-m", "on target"]);
+
+    assert.deepEqual(
+      await stashCountsByBranch(deps),
+      new Map([
+        ["source", 2],
+        ["target", 1],
+      ]),
+    );
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+// The owner is read from Git's own "On <branch>:" prefix, so a branch name
+// inside a hand-written message must not be counted as an owner.
+test("stash counts read the branch prefix, not the message body", async () => {
+  const cwd = repository();
+  try {
+    writeFileSync(join(cwd, "manual.txt"), "hand edit\n");
+    gitOk(cwd, ["stash", "push", "-m", "On target: notes about target"]);
+    assert.deepEqual(
+      await stashCountsByBranch(dependencies(cwd)),
+      new Map([["source", 1]]),
+    );
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("an unreadable stash list reports unknown rather than zero", async () => {
+  const counts = await stashCountsByBranch({
+    runGit: async () => ({
+      code: 128,
+      stdout: "",
+      stderr: "fatal: not a git repository",
+      failedToSpawn: false,
+      timedOut: false,
+    }),
+  });
+  assert.equal(counts, null);
 });


### PR DESCRIPTION
The stash chip only lit for a pending plugin auto-stash — one the plugin will
restore on the next checkout. Every other stash was invisible: a repository
could hold several entries on a layer and the panel gave no sign, which is
how they get forgotten.

Count entries per branch from `git stash list`, reading the branch out of
Git's own "On <branch>:" prefix so a name written inside a hand-made message
is not mistaken for the owner. A read failure reports unknown rather than
zero, so a broken git call cannot hide a stash.

The chip now covers both facts and says which one it means: a pending
auto-stash keeps "stashed" and its promise of automatic restore, while other
entries read "N stashes" and point at git stash.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>