### PR TITLE
feat(gh-stack): carry a scope in conventional titles

### DIFF
--- a/plugins/gh-stack/README.md
+++ b/plugins/gh-stack/README.md
@@ -92,11 +92,13 @@ branches and pull requests via the GitHub CLI.
     trailing separator is added (`scott` → `scott/`), and a value that
     cannot form a branch according to `git check-ref-format --branch` is
     rejected.
-  - **Conventional Commits** — layer names read `feat: add rate limiting`
-    and the type leads the branch slug (`scott/feat-add-rate-limiting`).
-    Suggest asks the agent for a Conventional Commits title, and Magic Stack
-    tells it to write commits, PR titles, and branch names the same way.
-    Off, a name slugifies whole, as before.
+  - **Conventional Commits** — layer and PR titles read
+    `feat(api): add rate limiting`, with the scope optional. The type leads
+    the branch slug and the scope is dropped from it
+    (`scott/feat-add-rate-limiting`), since a scope repeats what the slug
+    already says. Suggest asks the agent for a Conventional Commits title,
+    and Magic Stack tells it to write commits, PR titles, and branch names
+    the same way. Off, a name slugifies whole, as before.
 
   Both are stored in the plugin's kv (one global row) and travel on the
   `getStack` payload, so the popup opens without a second round trip and a

--- a/plugins/gh-stack/app.tsx
+++ b/plugins/gh-stack/app.tsx
@@ -491,8 +491,8 @@ function LayerComposer({
             placeholder={
               conventional
                 ? mode === "init"
-                  ? 'e.g. "feat: add rate limiting to the API"'
-                  : 'e.g. "feat: add metrics for the rate limiter"'
+                  ? 'e.g. "feat(api): add rate limiting"'
+                  : 'e.g. "feat(api): add rate limiter metrics"'
                 : mode === "init"
                   ? 'e.g. "Add rate limiting to the API"'
                   : 'e.g. "Add metrics for the rate limiter"'
@@ -644,8 +644,10 @@ function SettingsDialog({
   }, [open]);
 
   // What the composer would build from an example title under this draft.
+  // The conventional example carries a scope, since that is the part the
+  // branch slug drops — showing it here makes that visible.
   const exampleTitle = conventional
-    ? "feat: add rate limiting to the API"
+    ? "feat(api): add rate limiting"
     : "Add rate limiting to the API";
   const examplePrefix = prefix.trim() || detectedPrefix || "";
   const exampleBranch = `${examplePrefix}${deriveBranchName(exampleTitle, conventional)}`;
@@ -703,9 +705,11 @@ function SettingsDialog({
                 Conventional Commits
               </span>
               <p className="text-xs text-muted-foreground">
-                Titles read <span className="font-mono">feat: …</span>, and the
-                type leads the branch slug. Suggest and Magic Stack follow the
-                same convention.
+                Layer and PR titles read{" "}
+                <span className="font-mono">feat(scope): …</span>, with the
+                scope optional. The type leads the branch slug; the scope is
+                not part of it. Suggest and Magic Stack follow the same
+                convention.
               </p>
             </div>
             <div className="pt-0.5">

--- a/plugins/gh-stack/server.ts
+++ b/plugins/gh-stack/server.ts
@@ -216,8 +216,9 @@ const settingsSchema = z.object({
   // Namespace put in front of every derived branch ("scott/"). Empty means
   // "match the branches already in the workspace" (the detected prefix).
   branchPrefix: z.string().catch(""),
-  // Layer names read as Conventional Commits ("feat: add rate limiting"), and
-  // the derived branch carries the type ("scott/feat-add-rate-limiting").
+  // Layer and PR titles read as Conventional Commits, scope optional
+  // ("feat(api): add rate limiting"). The derived branch carries the type but
+  // not the scope ("scott/feat-add-rate-limiting").
   conventionalCommits: z.boolean().catch(false),
 });
 
@@ -816,7 +817,7 @@ function suggestNamePrompt(conventional: boolean): string {
   return [
     "Inspect the current work in this workspace: uncommitted changes (git status, git diff) and commits not yet on the default branch.",
     conventional
-      ? "Then reply with ONLY one Conventional Commits title that describes the work as a whole — `type: subject`, type one of feat, fix, docs, refactor, perf, test, build, ci, chore; subject in imperative mood, lower case, no trailing period; at most 60 characters in total."
+      ? "Then reply with ONLY one Conventional Commits title that describes the work as a whole — `type(scope): subject`, type one of feat, fix, docs, refactor, perf, test, build, ci, chore; scope is the part of the codebase the work touches (a package, module, or directory name, lower case) and is omitted when the work spans several or none fits; subject in imperative mood, lower case, no trailing period; at most 60 characters in total."
       : "Then reply with ONLY one PR-style title that describes the work as a whole — imperative mood, at most 60 characters, no quotes, no trailing period.",
     "Your entire final message must be just the title, nothing else.",
   ].join("\n");
@@ -842,7 +843,7 @@ function conventionsLines(settings: Settings, detectedPrefix: string | null): st
   }
   if (settings.conventionalCommits) {
     lines.push(
-      "Write every commit message and PR title as a Conventional Commit (`type: subject`, type one of feat, fix, docs, refactor, perf, test, build, ci, chore), and lead each branch slug with the same type (e.g. `feat-add-rate-limiting`).",
+      "Write every commit message and PR title as a Conventional Commit — `type(scope): subject`, type one of feat, fix, docs, refactor, perf, test, build, ci, chore. The scope names the part of the codebase the layer touches (a package, module, or directory name, lower case); omit it when the layer spans several or none fits. Lead each branch slug with the type only, not the scope (`feat(api): add rate limiting` → `feat-add-rate-limiting`).",
     );
   }
   return lines;

--- a/plugins/gh-stack/test/branch-name.test.ts
+++ b/plugins/gh-stack/test/branch-name.test.ts
@@ -17,6 +17,29 @@ test("deriveBranchName applies the same naming policy to UI and server callers",
   assert.equal(deriveBranchName("the and to", false), "");
 });
 
+// The branch carries the type but not the scope: a scope names the area the
+// slug already describes, so repeating it only lengthens the ref.
+test("deriveBranchName keeps the type and drops the scope", () => {
+  assert.equal(
+    deriveBranchName("feat(api): add rate limiting", true),
+    "feat-add-rate-limiting",
+  );
+  assert.equal(
+    deriveBranchName("fix(gh-stack): stop double counting", true),
+    "fix-stop-double-counting",
+  );
+  // A scope with punctuation or spaces still leaves the slug untouched.
+  assert.equal(
+    deriveBranchName("refactor(plugins/amp): split provisioning", true),
+    "refactor-split-provisioning",
+  );
+  // Without the setting, the whole title slugifies — scope included.
+  assert.equal(
+    deriveBranchName("feat(api): add rate limiting", false),
+    "feat-api-add-rate-limiting",
+  );
+});
+
 test("normalizeBranchPrefix trims and adds a namespace separator", () => {
   assert.deepEqual(normalizeBranchPrefix(" scott "), { prefix: "scott/" });
   assert.deepEqual(normalizeBranchPrefix("team_"), { prefix: "team_" });


### PR DESCRIPTION
The Conventional Commits setting documented and asked for `type: subject`,
with no mention of a scope. Branch derivation already parsed and dropped
`(scope)`, so the convention the panel taught was narrower than the one it
supported.

State the full form everywhere it appears — the settings copy, the composer
placeholders, the Suggest prompt, and the Magic Stack instructions — as
`type(scope): subject`, scope optional and omitted when the work spans several
areas or none fits. The settings example carries a scope so the branch preview
beneath it visibly drops one.

Pin the drop in tests: the type leads the slug, the scope never enters it, and
with the setting off the whole title slugifies as before.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>