### PR TITLE
chore(gh-stack): rename the stack panel tab

### DIFF
--- a/plugins/gh-stack/app.tsx
+++ b/plugins/gh-stack/app.tsx
@@ -1576,7 +1576,7 @@ function StackPanel({ threadId }: { threadId: string }) {
 export default definePluginApp((app) => {
   app.slots.threadPanelAction({
     id: "stack",
-    title: "Stack",
+    title: "GitHub Stack",
     icon: "Layers",
     component: StackPanel,
   });


### PR DESCRIPTION
"Stack" alone says nothing about which stack. Name the host it belongs to, so
the tab reads as GitHub's stacked pull requests rather than a generic panel.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>