### PR TITLE
build(scripts): add a stack layer splitter

### DIFF
--- a/scripts/split-layers.test.ts
+++ b/scripts/split-layers.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+const SCRIPT = join(import.meta.dir, "split-layers.ts");
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "bb-split-layers-test-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      rm(directory, { recursive: true, force: true }),
+    ),
+  );
+});
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" });
+}
+
+async function repository(): Promise<string> {
+  const cwd = await temporaryDirectory();
+  git(cwd, ["init", "-b", "main"]);
+  git(cwd, ["config", "user.name", "Split Layers Test"]);
+  git(cwd, ["config", "user.email", "split-layers@example.com"]);
+  await mkdir(join(cwd, "src"), { recursive: true });
+  await writeFile(join(cwd, "src/solo.txt"), "base solo\n");
+  await writeFile(join(cwd, "src/shared.txt"), "base shared\n");
+  git(cwd, ["add", "."]);
+  git(cwd, ["commit", "-m", "test: base"]);
+  return cwd;
+}
+
+// The finished state both scenarios split: solo.txt owned by one layer,
+// shared.txt built up across two.
+async function fixtures(): Promise<string> {
+  const work = await temporaryDirectory();
+  for (const [path, content] of [
+    ["final/src/solo.txt", "final solo\n"],
+    ["final/src/shared.txt", "line one\nline two\n"],
+    ["stage-l1/shared.txt", "line one\n"],
+  ] as const) {
+    await mkdir(dirname(join(work, path)), { recursive: true });
+    await writeFile(join(work, path), content);
+  }
+  await writeFile(
+    join(work, "manifest.json"),
+    JSON.stringify({
+      snapshotDir: join(work, "final"),
+      branchMode: "git",
+      layers: [
+        {
+          branch: "split/one",
+          message: "feat(one): start shared",
+          stage: { "src/shared.txt": join(work, "stage-l1/shared.txt") },
+        },
+        {
+          branch: "split/two",
+          message: "feat(two): finish shared, own solo",
+          files: ["src/solo.txt", "src/shared.txt"],
+        },
+      ],
+    }),
+  );
+  return join(work, "manifest.json");
+}
+
+function runScript(
+  cwd: string,
+  manifest: string,
+): { code: number; output: string } {
+  try {
+    const output = execFileSync("bun", [SCRIPT, manifest], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { code: 0, output };
+  } catch (error) {
+    const err = error as { status?: number; stdout?: string; stderr?: string };
+    return { code: err.status ?? 1, output: `${err.stdout ?? ""}${err.stderr ?? ""}` };
+  }
+}
+
+describe("split-layers", () => {
+  test("builds layers bottom-up and the top matches the snapshot", async () => {
+    const cwd = await repository();
+    const manifest = await fixtures();
+
+    const result = runScript(cwd, manifest);
+    expect(result.output).toContain("OK — top of stack matches the snapshot");
+    expect(result.code).toBe(0);
+
+    // Layer one holds only the intermediate shared state.
+    expect(git(cwd, ["show", "split/one:src/shared.txt"])).toBe("line one\n");
+    expect(git(cwd, ["show", "split/one:src/solo.txt"])).toBe("base solo\n");
+    expect(git(cwd, ["log", "-1", "--format=%s", "split/one"])).toBe(
+      "feat(one): start shared\n",
+    );
+
+    // Layer two finishes both files and matches the snapshot.
+    expect(git(cwd, ["show", "split/two:src/shared.txt"])).toBe(
+      "line one\nline two\n",
+    );
+    expect(git(cwd, ["show", "split/two:src/solo.txt"])).toBe("final solo\n");
+    // Stacked: layer one is an ancestor of layer two.
+    expect(() =>
+      git(cwd, ["merge-base", "--is-ancestor", "split/one", "split/two"]),
+    ).not.toThrow();
+  });
+
+  test("refuses a dirty tree before creating anything", async () => {
+    const cwd = await repository();
+    const manifest = await fixtures();
+    await writeFile(join(cwd, "src/solo.txt"), "uncommitted\n");
+
+    const result = runScript(cwd, manifest);
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("working tree is dirty");
+    expect(() => git(cwd, ["rev-parse", "--verify", "split/one"])).toThrow();
+  });
+
+  test("refuses when a layer branch already exists", async () => {
+    const cwd = await repository();
+    const manifest = await fixtures();
+    git(cwd, ["branch", "split/two"]);
+
+    const result = runScript(cwd, manifest);
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("branch already exists: split/two");
+    expect(() => git(cwd, ["rev-parse", "--verify", "split/one"])).toThrow();
+  });
+
+  test("refuses a snapshot file no layer finishes", async () => {
+    const cwd = await repository();
+    const work = await temporaryDirectory();
+    await mkdir(join(work, "final/src"), { recursive: true });
+    await writeFile(join(work, "final/src/solo.txt"), "final solo\n");
+    const manifest = join(work, "manifest.json");
+    await writeFile(
+      manifest,
+      JSON.stringify({
+        snapshotDir: join(work, "final"),
+        branchMode: "git",
+        layers: [{ branch: "split/one", message: "feat: partial", files: [] }],
+      }),
+    );
+
+    const result = runScript(cwd, manifest);
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("no layer lists in `files`");
+  });
+});

--- a/scripts/split-layers.ts
+++ b/scripts/split-layers.ts
@@ -1,0 +1,186 @@
+#!/usr/bin/env bun
+/**
+ * split-layers — build stacked branches from a snapshot of finished work.
+ *
+ *   bun scripts/split-layers.ts <manifest.json>
+ *
+ * The manifest names a snapshot directory holding the FINAL state of every
+ * file the split owns, and the layers to build from it, bottom to top:
+ *
+ *   {
+ *     "snapshotDir": "/tmp/split/final",
+ *     "branchMode": "gh-stack",            // default; "git" uses checkout -b
+ *     "verify": "bun run typecheck",       // optional, runs after each layer
+ *     "layers": [
+ *       {
+ *         "branch": "scott/fix-foo",
+ *         "message": "fix(x): subject\n\nBody.",
+ *         "files": ["plugins/x/a.ts"],     // copied whole from snapshotDir
+ *         "stage": {                       // full INTERMEDIATE states for
+ *           "plugins/x/b.ts": "/tmp/split/l1/b.ts"  // files a later layer
+ *         }                                // finishes
+ *       }
+ *     ]
+ *   }
+ *
+ * A file only one layer touches goes in that layer's `files`. A file two
+ * layers share gets a full intermediate copy per earlier layer via `stage`,
+ * and the last layer lists it in `files` so it ends at the snapshot.
+ * Byte-exact copies beat patches and anchored string edits, which drift.
+ *
+ * The script refuses a dirty tree (stash unrelated work first) and existing
+ * layer branches, and after the last layer byte-compares every snapshot file
+ * against the working tree. On a mid-run failure it stops in place; delete
+ * the branches it created and re-run.
+ */
+import { execFileSync } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+
+interface Layer {
+  branch: string;
+  message: string;
+  files?: string[];
+  stage?: Record<string, string>;
+}
+
+interface Manifest {
+  snapshotDir: string;
+  branchMode?: "gh-stack" | "git";
+  verify?: string;
+  layers: Layer[];
+}
+
+function fail(message: string): never {
+  console.error(`split-layers: ${message}`);
+  process.exit(1);
+}
+
+function run(command: string, args: string[]): string {
+  try {
+    return execFileSync(command, args, { encoding: "utf8" });
+  } catch (error) {
+    const err = error as { stdout?: string; stderr?: string };
+    fail(
+      `\`${command} ${args.join(" ")}\` failed\n${err.stderr ?? ""}${err.stdout ?? ""}`.trim(),
+    );
+  }
+}
+
+function branchExists(branch: string): boolean {
+  try {
+    execFileSync(
+      "git",
+      ["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`],
+      { encoding: "utf8" },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function snapshotFiles(root: string): string[] {
+  return (readdirSync(root, { recursive: true }) as string[]).filter((entry) =>
+    statSync(join(root, entry)).isFile(),
+  );
+}
+
+const manifestPath = process.argv[2];
+if (!manifestPath) fail("usage: bun scripts/split-layers.ts <manifest.json>");
+const manifestDir = dirname(resolve(manifestPath));
+const abs = (p: string) => (isAbsolute(p) ? p : resolve(manifestDir, p));
+
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as Manifest;
+const snapshotDir = abs(manifest.snapshotDir);
+const branchMode = manifest.branchMode ?? "gh-stack";
+if (!existsSync(snapshotDir)) fail(`snapshot directory missing: ${snapshotDir}`);
+if (!manifest.layers?.length) fail("manifest has no layers");
+
+// ---- Preflight: every failure here happens before any mutation. ----------
+const dirty = run("git", ["status", "--porcelain"]).trim();
+if (dirty) {
+  fail(
+    `working tree is dirty — stash work that is not part of this split first:\n${dirty}`,
+  );
+}
+const known = new Set(snapshotFiles(snapshotDir));
+if (known.size === 0) fail("snapshot directory holds no files");
+for (const layer of manifest.layers) {
+  if (!layer.branch || !layer.message) {
+    fail(`layer missing branch or message: ${JSON.stringify(layer)}`);
+  }
+  if (branchExists(layer.branch)) {
+    fail(`branch already exists: ${layer.branch}`);
+  }
+  for (const file of layer.files ?? []) {
+    if (!known.has(file)) fail(`${layer.branch}: not in snapshot: ${file}`);
+  }
+  for (const [target, source] of Object.entries(layer.stage ?? {})) {
+    if (!known.has(target)) {
+      fail(`${layer.branch}: staged target not in snapshot: ${target}`);
+    }
+    if (!existsSync(abs(source))) {
+      fail(`${layer.branch}: staged source missing: ${source}`);
+    }
+  }
+}
+// Every snapshot file must land somewhere, or the top cannot match it.
+const assigned = new Set(manifest.layers.flatMap((layer) => layer.files ?? []));
+const unassigned = [...known].filter((file) => !assigned.has(file));
+if (unassigned.length > 0) {
+  fail(
+    `snapshot files no layer lists in \`files\` (each must reach its final state):\n  ${unassigned.join("\n  ")}`,
+  );
+}
+
+// ---- Build, bottom to top. -----------------------------------------------
+if (branchMode === "gh-stack") run("gh", ["stack", "top"]);
+for (const layer of manifest.layers) {
+  console.log(`\n== ${layer.branch}`);
+  if (branchMode === "gh-stack") run("gh", ["stack", "add", layer.branch]);
+  else run("git", ["checkout", "-b", layer.branch]);
+
+  for (const file of layer.files ?? []) {
+    mkdirSync(dirname(file), { recursive: true });
+    copyFileSync(join(snapshotDir, file), file);
+  }
+  for (const [target, source] of Object.entries(layer.stage ?? {})) {
+    mkdirSync(dirname(target), { recursive: true });
+    copyFileSync(abs(source), target);
+  }
+
+  if (!run("git", ["status", "--porcelain"]).trim()) {
+    fail(`${layer.branch}: layer changes nothing`);
+  }
+  if (manifest.verify) {
+    try {
+      execFileSync("sh", ["-c", manifest.verify], { stdio: "inherit" });
+    } catch {
+      fail(`${layer.branch}: verify failed: ${manifest.verify}`);
+    }
+  }
+  run("git", ["add", "-A"]);
+  run("git", ["commit", "-m", layer.message]);
+  console.log(`   committed ${run("git", ["rev-parse", "--short", "HEAD"]).trim()}`);
+}
+
+// ---- Prove the top matches the snapshot, byte for byte. ------------------
+let mismatched = 0;
+for (const file of known) {
+  const finished = readFileSync(join(snapshotDir, file));
+  const inTree = existsSync(file) ? readFileSync(file) : null;
+  if (inTree === null || !finished.equals(inTree)) {
+    console.error(`DIFF  ${file}`);
+    mismatched++;
+  }
+}
+if (mismatched > 0) fail(`${mismatched} file(s) differ from the snapshot`);
+console.log(`\nOK — top of stack matches the snapshot (${known.size} files)`);


### PR DESCRIPTION
Splitting finished work into stacked layers by hand means re-editing files
with anchored string replacements — fragile against drift, non-idempotent on
partial failure, and slow: the last split of ~330 lines across six concerns
took ~40 tool calls, two of them recovering from exactly those failures.

split-layers builds the stack from a manifest instead. It takes a snapshot
directory holding the final state of every file, assigns whole files to the
layer that owns them, and takes full intermediate copies for files two layers
share — byte-exact states rather than patches. It refuses a dirty tree and
existing branches before touching anything, optionally verifies each layer,
and byte-compares the finished top against the snapshot so a lossless split
is proven rather than assumed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>