### PR TITLE
feat(agent-proxy): default to the upstream latest release

### DIFF
--- a/plugins/agent-proxy/README.md
+++ b/plugins/agent-proxy/README.md
@@ -1,8 +1,8 @@
 # bb-plugin-agent-proxy
 
 EasyCLIProxyAPI, rebuilt as a bb plugin. Owns a local
-[CLIProxyAPI fork](https://github.com/smsunarto/CLIProxyAPI/tree/fix/claude-advisor-server-tool)
-core on the bb server machine: resolves the configured branch to an immutable
+[CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI)
+core on the bb server machine: resolves the configured ref to an immutable
 commit, builds it with the local Go toolchain, installs it as a persistent
 operating-system service, and exposes management UI inside bb. It uses
 `launchd` on macOS and user `systemd` on Linux. The proxy continues to run
@@ -18,9 +18,10 @@ after bb exits. Windows is not supported.
   crash. Manual Stop disables the service until Start or the autostart setting
   enables it again. Home page + sidebar indicators + `bb agent-proxy` CLI.
 - **Advanced source settings** — change the GitHub repository and branch from
-  the Advanced page. The defaults remain
-  `smsunarto/CLIProxyAPI#fix/claude-advisor-server-tool`. Saving a source does
-  not change the running binary; Install core resolves and builds it.
+  the Advanced page. The defaults are `router-for-me/CLIProxyAPI#latest`, where
+  the `latest` ref resolves to the newest published GitHub release (drafts and
+  prereleases excluded) and then to that tag's commit. Saving a source does not
+  change the running binary; Install core resolves and builds it.
 - **Sidebar state** — the "Agent Proxy" row in bb's main sidebar is tinted by
   core state (green running, amber pulsing while starting/stopping, red
   crashed, dimmed stopped). bb renders that row itself and reads `navPanel`
@@ -72,8 +73,9 @@ remain under the core directory.
 - `autostart` (default on) — keep the login service enabled; it starts at login
   and remains active when bb is closed
 - `port` (default 8317)
-- `sourceRepository` (default `smsunarto/CLIProxyAPI`) — public GitHub source
-- `sourceBranch` (default `fix/claude-advisor-server-tool`) — branch, tag, or commit
+- `sourceRepository` (default `router-for-me/CLIProxyAPI`) — public GitHub source
+- `sourceBranch` (default `latest`) — `latest` for the newest published release,
+  or a branch, tag, or commit
 - `managementKey` (secret, optional) — overrides the generated key
 
 Autostart changes apply immediately. Port/key changes stop the service,

--- a/plugins/agent-proxy/components/pages/advanced.tsx
+++ b/plugins/agent-proxy/components/pages/advanced.tsx
@@ -130,12 +130,14 @@ export function AdvancedPage() {
               id="agent-proxy-source-ref"
               value={branch}
               disabled={saved === null || saving}
-              placeholder="main"
+              placeholder="latest"
               spellCheck={false}
               onChange={(event) => setBranch(event.target.value)}
             />
             <span className="block text-xs text-muted-foreground">
-              A branch, tag, or full commit SHA. Branch names can contain slashes.
+              Use <span className="font-medium text-foreground">latest</span> for the newest
+              published release, or give a branch, tag, or full commit SHA. Branch names can
+              contain slashes.
             </span>
           </label>
 

--- a/plugins/agent-proxy/lib/core-install.ts
+++ b/plugins/agent-proxy/lib/core-install.ts
@@ -19,6 +19,9 @@ import type { Paths } from "./paths.ts";
 import {
   commitApiUrl,
   DEFAULT_CORE_SOURCE,
+  isLatestReleaseRef,
+  latestReleaseApiUrl,
+  parseLatestReleaseTag,
   parseSourceRevision,
   type CoreSource,
   type SourceRevision,
@@ -56,21 +59,42 @@ function requestSignal(signal: AbortSignal | undefined, timeoutMs: number): Abor
   return signal ? AbortSignal.any([signal, timeout]) : timeout;
 }
 
+export async function fetchLatestReleaseTag(
+  repo: string,
+  fetchImpl: typeof fetch = fetch,
+  signal?: AbortSignal,
+): Promise<string> {
+  const response = await fetchImpl(latestReleaseApiUrl(repo), {
+    headers: GH_HEADERS,
+    signal: requestSignal(signal, 30_000),
+  });
+  if (!response.ok) {
+    throw new Error(`${repo} has no published release (HTTP ${response.status})`);
+  }
+  return parseLatestReleaseTag(await response.json());
+}
+
+/** Resolves the configured ref to an immutable commit. The "latest" sentinel
+    first becomes the newest release tag, so the recorded version names that
+    release instead of a moving branch. */
 export async function fetchSourceRevision(
   source: CoreSource = DEFAULT_CORE_SOURCE,
   fetchImpl: typeof fetch = fetch,
   signal?: AbortSignal,
 ): Promise<SourceRevision> {
-  const response = await fetchImpl(commitApiUrl(source), {
+  const resolved: CoreSource = isLatestReleaseRef(source.ref)
+    ? { repo: source.repo, ref: await fetchLatestReleaseTag(source.repo, fetchImpl, signal) }
+    : source;
+  const response = await fetchImpl(commitApiUrl(resolved), {
     headers: GH_HEADERS,
     signal: requestSignal(signal, 30_000),
   });
   if (!response.ok) {
     throw new Error(
-      `CLIProxyAPI source ${source.repo}#${source.ref} not found (HTTP ${response.status})`,
+      `CLIProxyAPI source ${resolved.repo}#${resolved.ref} not found (HTTP ${response.status})`,
     );
   }
-  return parseSourceRevision(await response.json(), source);
+  return parseSourceRevision(await response.json(), resolved);
 }
 
 /** The binary file is the source of truth; a surviving marker without a binary

--- a/plugins/agent-proxy/lib/release.ts
+++ b/plugins/agent-proxy/lib/release.ts
@@ -1,8 +1,15 @@
-// Pure helpers for resolving the CLIProxyAPI fork source. No IO here — the
-// install pipeline injects fetch.
+// Pure helpers for resolving the CLIProxyAPI source. No IO here — the install
+// pipeline injects fetch.
 
-export const CORE_REPO = "smsunarto/CLIProxyAPI";
-export const CORE_REF = "fix/claude-advisor-server-tool";
+/**
+ * Ref sentinel: resolve the repository's newest published release rather than
+ * a fixed branch or tag. A repository that also carries a branch literally
+ * named "latest" cannot be reached by name; pin it by commit instead.
+ */
+export const LATEST_RELEASE_REF = "latest";
+
+export const CORE_REPO = "router-for-me/CLIProxyAPI";
+export const CORE_REF = LATEST_RELEASE_REF;
 
 export interface CoreSource {
   repo: string;
@@ -94,8 +101,29 @@ export function normalizeCoreSource(repo: string, ref: string): CoreSource {
   return { repo: normalizeCoreRepo(repo), ref: normalizeCoreRef(ref) };
 }
 
+export function isLatestReleaseRef(ref: string): boolean {
+  return ref.trim().toLowerCase() === LATEST_RELEASE_REF;
+}
+
 export function commitApiUrl(source: CoreSource = DEFAULT_CORE_SOURCE): string {
   return `https://api.github.com/repos/${source.repo}/commits/${encodeURIComponent(source.ref)}`;
+}
+
+export function latestReleaseApiUrl(repo: string): string {
+  return `https://api.github.com/repos/${repo}/releases/latest`;
+}
+
+/** GitHub's releases/latest already excludes drafts and prereleases, so the
+    tag it reports is the newest release a user would download by hand. */
+export function parseLatestReleaseTag(json: unknown): string {
+  if (typeof json !== "object" || json === null) {
+    throw new Error("malformed GitHub release response");
+  }
+  const tag = (json as Record<string, unknown>).tag_name;
+  if (typeof tag !== "string" || tag.trim().length === 0) {
+    throw new Error("GitHub release response has no tag_name");
+  }
+  return normalizeCoreRef(tag);
 }
 
 export function sourceArchiveUrl(repo: string, commit: string): string {

--- a/plugins/agent-proxy/skills/agent-proxy/SKILL.md
+++ b/plugins/agent-proxy/skills/agent-proxy/SKILL.md
@@ -10,8 +10,9 @@ machine as a persistent operating-system service: `launchd` on macOS, user
 `systemd` on Linux. Windows is not supported. The core stays available when bb
 is closed. It aggregates OAuth accounts (Claude, Codex) and upstream API keys
 behind local endpoints with protocol conversion. The default source is
-`smsunarto/CLIProxyAPI#fix/claude-advisor-server-tool`; the plugin's Advanced
-page can select another public GitHub repository and branch.
+`router-for-me/CLIProxyAPI#latest`, where `latest` means the newest published
+GitHub release; the plugin's Advanced page can select another public GitHub
+repository and ref.
 
 ## Endpoints
 

--- a/plugins/agent-proxy/test/core-install.test.ts
+++ b/plugins/agent-proxy/test/core-install.test.ts
@@ -24,6 +24,7 @@ import { buildPaths } from "../lib/paths.ts";
 import { CORE_REF, CORE_REPO, type SourceRevision } from "../lib/release.ts";
 
 const COMMIT = "9e593b74486a79b6117c1ffd5bcdc7e9ec3881b4";
+const RELEASE_TAG = "v7.2.127";
 
 function makeFixture() {
   const dir = mkdtempSync(join(tmpdir(), "agent-proxy-install-"));
@@ -40,11 +41,13 @@ function makeFixture() {
   execFileSync("tar", ["-czf", archivePath, "-C", archiveSrc, rootName]);
 
   const archiveBytes = readFileSync(archivePath);
+  // Installs always carry a resolved ref: the "latest" sentinel has already
+  // become a release tag by the time a revision exists.
   const revision: SourceRevision = {
     repo: CORE_REPO,
-    ref: CORE_REF,
+    ref: RELEASE_TAG,
     commit: COMMIT,
-    version: `${CORE_REF}@${COMMIT.slice(0, 12)}`,
+    version: `${RELEASE_TAG}@${COMMIT.slice(0, 12)}`,
     archiveUrl: `https://example.com/${COMMIT}.tar.gz`,
   };
 
@@ -85,10 +88,47 @@ test("fetchSourceRevision resolves the configured ref to an immutable commit", a
       }),
     );
   };
-  const revision = await fetchSourceRevision({ repo: CORE_REPO, ref: CORE_REF }, fetchImpl);
-  assert.match(requested, /commits\/fix%2Fclaude-advisor-server-tool$/);
+  const revision = await fetchSourceRevision({ repo: CORE_REPO, ref: "main" }, fetchImpl);
+  assert.match(requested, /commits\/main$/);
   assert.equal(revision.commit, COMMIT);
-  assert.equal(revision.version, `${CORE_REF}@${COMMIT.slice(0, 12)}`);
+  assert.equal(revision.version, `main@${COMMIT.slice(0, 12)}`);
+});
+
+test("fetchSourceRevision resolves the latest sentinel through the release tag", async () => {
+  const requested: string[] = [];
+  const fetchImpl: typeof fetch = (input) => {
+    const url = String(input);
+    requested.push(url);
+    const body = url.endsWith("/releases/latest")
+      ? JSON.stringify({ tag_name: "v7.2.127" })
+      : JSON.stringify({ sha: COMMIT });
+    return Promise.resolve(
+      new Response(body, { headers: { "content-type": "application/json" } }),
+    );
+  };
+  const revision = await fetchSourceRevision({ repo: CORE_REPO, ref: CORE_REF }, fetchImpl);
+  assert.deepEqual(requested, [
+    `https://api.github.com/repos/${CORE_REPO}/releases/latest`,
+    `https://api.github.com/repos/${CORE_REPO}/commits/v7.2.127`,
+  ]);
+  assert.equal(revision.ref, "v7.2.127");
+  assert.equal(revision.version, `v7.2.127@${COMMIT.slice(0, 12)}`);
+});
+
+test("fetchSourceRevision reports a repository with no published release", async () => {
+  const fetchImpl: typeof fetch = () => Promise.resolve(new Response("missing", { status: 404 }));
+  await assert.rejects(
+    fetchSourceRevision({ repo: "owner/repo", ref: "latest" }, fetchImpl),
+    /owner\/repo has no published release/,
+  );
+});
+
+test("fetchSourceRevision reports a repository with no published release", async () => {
+  const fetchImpl: typeof fetch = () => Promise.resolve(new Response("missing", { status: 404 }));
+  await assert.rejects(
+    fetchSourceRevision({ repo: "owner/repo", ref: "latest" }, fetchImpl),
+    /owner\/repo has no published release/,
+  );
 });
 
 test("fetchSourceRevision reports a missing ref", async () => {
@@ -127,7 +167,7 @@ test("successful update atomically switches binary and revision together", async
   seedInstalled(paths, "7.2.127");
   await installCore(paths, revision, { fetchImpl, buildSource });
   assert.equal(installedVersion(paths), revision.version);
-  assert.match(readFileSync(paths.binPath, "utf8"), /claude-advisor-server-tool/);
+  assert.match(readFileSync(paths.binPath, "utf8"), new RegExp(`${RELEASE_TAG}@`));
 });
 
 test("build failure leaves the previous binary active", async () => {

--- a/plugins/agent-proxy/test/release.test.ts
+++ b/plugins/agent-proxy/test/release.test.ts
@@ -5,9 +5,13 @@ import {
   DEFAULT_CORE_SOURCE,
   CORE_REF,
   CORE_REPO,
+  isLatestReleaseRef,
+  latestReleaseApiUrl,
+  LATEST_RELEASE_REF,
   normalizeCoreRef,
   normalizeCoreRepo,
   normalizeCoreSource,
+  parseLatestReleaseTag,
   parseSourceRevision,
   sourceArchiveUrl,
   sourceVersion,
@@ -15,16 +19,37 @@ import {
 
 const COMMIT = "9e593b74486a79b6117c1ffd5bcdc7e9ec3881b4";
 
-test("source constants target the advisor fix branch", () => {
-  assert.equal(CORE_REPO, "smsunarto/CLIProxyAPI");
-  assert.equal(CORE_REF, "fix/claude-advisor-server-tool");
+test("source constants target the upstream latest release", () => {
+  assert.equal(CORE_REPO, "router-for-me/CLIProxyAPI");
+  assert.equal(CORE_REF, LATEST_RELEASE_REF);
   assert.deepEqual(DEFAULT_CORE_SOURCE, { repo: CORE_REPO, ref: CORE_REF });
+});
+
+test("the latest sentinel is recognized whatever the case", () => {
+  for (const ref of ["latest", "Latest", " LATEST "]) {
+    assert.equal(isLatestReleaseRef(ref), true);
+  }
+  for (const ref of ["main", "v7.2.127", "latest-stable"]) {
+    assert.equal(isLatestReleaseRef(ref), false);
+  }
+  assert.equal(
+    latestReleaseApiUrl(CORE_REPO),
+    "https://api.github.com/repos/router-for-me/CLIProxyAPI/releases/latest",
+  );
+});
+
+test("parseLatestReleaseTag reads and validates the release tag", () => {
+  assert.equal(parseLatestReleaseTag({ tag_name: " v7.2.127 " }), "v7.2.127");
+  assert.throws(() => parseLatestReleaseTag(null), /malformed/);
+  assert.throws(() => parseLatestReleaseTag({}), /tag_name/);
+  assert.throws(() => parseLatestReleaseTag({ tag_name: "   " }), /tag_name/);
+  assert.throws(() => parseLatestReleaseTag({ tag_name: "bad ref" }), /branch or ref/);
 });
 
 test("commitApiUrl safely encodes branch names", () => {
   assert.equal(
     commitApiUrl(),
-    "https://api.github.com/repos/smsunarto/CLIProxyAPI/commits/fix%2Fclaude-advisor-server-tool",
+    "https://api.github.com/repos/router-for-me/CLIProxyAPI/commits/latest",
   );
   assert.equal(
     commitApiUrl({ repo: "router-for-me/CLIProxyAPI", ref: "feature/a b" }),
@@ -47,27 +72,30 @@ test("repository settings normalize supported GitHub source forms", () => {
 });
 
 test("branch settings accept Git refs and reject unsafe names", () => {
-  assert.equal(normalizeCoreRef(" fix/claude-advisor-server-tool "), CORE_REF);
+  assert.equal(normalizeCoreRef(" fix/claude-advisor-server-tool "), "fix/claude-advisor-server-tool");
   assert.equal(normalizeCoreRef(COMMIT), COMMIT);
   for (const invalid of ["", "feature branch", "../main", "main..next", "topic@{1}", ".hidden"]) {
     assert.throws(() => normalizeCoreRef(invalid), /branch or ref/);
   }
-  assert.deepEqual(normalizeCoreSource("smsunarto/CLIProxyAPI", CORE_REF), {
+  assert.deepEqual(normalizeCoreSource("router-for-me/CLIProxyAPI", CORE_REF), {
     repo: CORE_REPO,
     ref: CORE_REF,
   });
 });
 
 test("source revision is pinned to the resolved commit", () => {
-  const revision = parseSourceRevision({ sha: COMMIT.toUpperCase() });
+  // The install pipeline resolves "latest" to a release tag before this call,
+  // so the version names the release rather than the sentinel.
+  const source = { repo: CORE_REPO, ref: "v7.2.127" };
+  const revision = parseSourceRevision({ sha: COMMIT.toUpperCase() }, source);
   assert.deepEqual(revision, {
     repo: CORE_REPO,
-    ref: CORE_REF,
+    ref: "v7.2.127",
     commit: COMMIT,
-    version: `${CORE_REF}@9e593b74486a`,
+    version: "v7.2.127@9e593b74486a",
     archiveUrl: `https://codeload.github.com/${CORE_REPO}/tar.gz/${COMMIT}`,
   });
-  assert.equal(sourceVersion(CORE_REF, COMMIT), `${CORE_REF}@9e593b74486a`);
+  assert.equal(sourceVersion("v7.2.127", COMMIT), "v7.2.127@9e593b74486a");
   assert.equal(sourceArchiveUrl(CORE_REPO, COMMIT), revision.archiveUrl);
 });
 


### PR DESCRIPTION
The default source pointed at a personal fork branch carrying two advisor
fixes. Point it back at router-for-me/CLIProxyAPI and add a "latest" ref
sentinel that resolves through releases/latest, which excludes drafts and
prereleases, and then to that tag's commit.

The recorded version names the release instead of a moving branch, and a
fork or branch stays selectable from the Advanced page.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>