### PR TITLE
feat(agent-proxy): install published release binaries

### DIFF
--- a/plugins/agent-proxy/README.md
+++ b/plugins/agent-proxy/README.md
@@ -2,18 +2,22 @@
 
 EasyCLIProxyAPI, rebuilt as a bb plugin. Owns a local
 [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI)
-core on the bb server machine: resolves the configured ref to an immutable
-commit, builds it with the local Go toolchain, installs it as a persistent
+core on the bb server machine: installs the published release archive for the
+platform, or builds the resolved commit with the local Go toolchain when the
+ref ships none, runs it as a persistent
 operating-system service, and exposes management UI inside bb. It uses
 `launchd` on macOS and user `systemd` on Linux. The proxy continues to run
 after bb exits. Windows is not supported.
 
 ## Features
 
-- **Core lifecycle** — download a commit-pinned source archive from the
-  configured public GitHub repository and branch, validate it, build it with
-  Go, and publish the binary behind a stable pointer only after a successful
-  build. The pointer swap is atomic. A persistent operating-system service
+- **Core lifecycle** — two install paths behind one Install core button. A ref
+  that names a published release downloads that release's archive for the
+  platform and verifies its sha256 against the release's own `checksums.txt`;
+  any other ref (branch, commit, fork) downloads a commit-pinned source archive
+  and builds it with Go. Either way the binary is published behind a stable
+  pointer only after it lands. The pointer swap is atomic. A persistent
+  operating-system service
   starts it at login, keeps it alive after bb exits, and restarts it after a
   crash. Manual Stop disables the service until Start or the autostart setting
   enables it again. Home page + sidebar indicators + `bb agent-proxy` CLI.
@@ -21,7 +25,7 @@ after bb exits. Windows is not supported.
   the Advanced page. The defaults are `router-for-me/CLIProxyAPI#latest`, where
   the `latest` ref resolves to the newest published GitHub release (drafts and
   prereleases excluded) and then to that tag's commit. Saving a source does not
-  change the running binary; Install core resolves and builds it.
+  change the running binary; Install core resolves and installs it.
 - **Sidebar state** — the "Agent Proxy" row in bb's main sidebar is tinted by
   core state (green running, amber pulsing while starting/stopping, red
   crashed, dimmed stopped). bb renders that row itself and reads `navPanel`
@@ -96,11 +100,12 @@ bun run build       # bb plugin build .
 bb plugin install . # register in place; then: bb plugin dev
 ```
 
-Installing or updating the core also requires Go 1.26 or newer. The Advanced
-page accepts `owner/repository`, an HTTPS `github.com` URL, or a
-`git@github.com` source. `bb agent-proxy install <ref>` can temporarily build
-another branch, tag, or commit from the configured repository without changing
-the saved source.
+Go 1.26 or newer is required only for source builds — that is, for any ref that
+ships no release archive for the platform. Installing a published release needs
+no toolchain. The Advanced page accepts `owner/repository`, an HTTPS
+`github.com` URL, or a `git@github.com` source. `bb agent-proxy install <ref>`
+can temporarily install another branch, tag, or commit from the configured
+repository without changing the saved source.
 
 Persistent services support macOS (`launchd`) and Linux (user `systemd`). The
 bb UI and `bb agent-proxy` commands require a running bb server,
@@ -108,6 +113,7 @@ but traffic through `127.0.0.1:8317` does not. Plugin reload, disable, and bb
 shutdown stop only the plugin status monitor; they do not stop the operating-
 system service.
 
-Note: the core binary is quarantine-free because the local Go toolchain writes
-it directly; if macOS Gatekeeper ever kills it on launch, run
+Note: the core binary is quarantine-free either way — the Go toolchain writes
+it directly, and a downloaded release archive is fetched and extracted without
+LaunchServices. If macOS Gatekeeper ever kills it on launch, run
 `xattr -d com.apple.quarantine <core/bin/cli-proxy-api>`.

--- a/plugins/agent-proxy/lib/core-install.ts
+++ b/plugins/agent-proxy/lib/core-install.ts
@@ -1,8 +1,9 @@
 import { spawn } from "node:child_process";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   chmodSync,
   copyFileSync,
+  createReadStream,
   createWriteStream,
   existsSync,
   lstatSync,
@@ -21,9 +22,13 @@ import {
   DEFAULT_CORE_SOURCE,
   isLatestReleaseRef,
   latestReleaseApiUrl,
-  parseLatestReleaseTag,
+  parseChecksums,
+  parseRelease,
   parseSourceRevision,
+  pickReleaseBinary,
+  releaseTagApiUrl,
   type CoreSource,
+  type Release,
   type SourceRevision,
 } from "./release.ts";
 
@@ -59,32 +64,48 @@ function requestSignal(signal: AbortSignal | undefined, timeoutMs: number): Abor
   return signal ? AbortSignal.any([signal, timeout]) : timeout;
 }
 
-export async function fetchLatestReleaseTag(
+/** Null when the tag names no release. A missing releases/latest is an error
+    instead: the user asked for the newest release by name. */
+export async function fetchRelease(
   repo: string,
+  ref: string,
   fetchImpl: typeof fetch = fetch,
   signal?: AbortSignal,
-): Promise<string> {
-  const response = await fetchImpl(latestReleaseApiUrl(repo), {
-    headers: GH_HEADERS,
-    signal: requestSignal(signal, 30_000),
-  });
-  if (!response.ok) {
-    throw new Error(`${repo} has no published release (HTTP ${response.status})`);
+): Promise<Release | null> {
+  const latest = isLatestReleaseRef(ref);
+  const response = await fetchImpl(
+    latest ? latestReleaseApiUrl(repo) : releaseTagApiUrl(repo, ref),
+    { headers: GH_HEADERS, signal: requestSignal(signal, 30_000) },
+  );
+  if (response.status === 404) {
+    if (latest) throw new Error(`${repo} has no published release (HTTP 404)`);
+    return null;
   }
-  return parseLatestReleaseTag(await response.json());
+  if (!response.ok) {
+    throw new Error(`GitHub release lookup for ${repo}#${ref} failed (HTTP ${response.status})`);
+  }
+  return parseRelease(await response.json());
 }
 
-/** Resolves the configured ref to an immutable commit. The "latest" sentinel
-    first becomes the newest release tag, so the recorded version names that
-    release instead of a moving branch. */
+/**
+ * Resolves the configured ref to an immutable commit, and to a published
+ * archive when one exists for this platform. The "latest" sentinel becomes the
+ * newest release tag first, so the recorded version names that release instead
+ * of a moving branch. A commit SHA never names a release, so it skips the
+ * release lookup entirely.
+ */
 export async function fetchSourceRevision(
   source: CoreSource = DEFAULT_CORE_SOURCE,
   fetchImpl: typeof fetch = fetch,
   signal?: AbortSignal,
 ): Promise<SourceRevision> {
-  const resolved: CoreSource = isLatestReleaseRef(source.ref)
-    ? { repo: source.repo, ref: await fetchLatestReleaseTag(source.repo, fetchImpl, signal) }
-    : source;
+  const release = /^[0-9a-f]{40}$/i.test(source.ref)
+    ? null
+    : await fetchRelease(source.repo, source.ref, fetchImpl, signal);
+  const resolved: CoreSource =
+    release && isLatestReleaseRef(source.ref)
+      ? { repo: source.repo, ref: release.tag }
+      : source;
   const response = await fetchImpl(commitApiUrl(resolved), {
     headers: GH_HEADERS,
     signal: requestSignal(signal, 30_000),
@@ -94,7 +115,11 @@ export async function fetchSourceRevision(
       `CLIProxyAPI source ${resolved.repo}#${resolved.ref} not found (HTTP ${response.status})`,
     );
   }
-  return parseSourceRevision(await response.json(), resolved);
+  return parseSourceRevision(
+    await response.json(),
+    resolved,
+    release ? pickReleaseBinary(release) : null,
+  );
 }
 
 /** The binary file is the source of truth; a surviving marker without a binary
@@ -167,6 +192,22 @@ async function downloadTo(
   }
   const body = Readable.fromWeb(response.body as unknown as import("node:stream/web").ReadableStream);
   await pipeline(body, createWriteStream(dest), { signal: requestAbort });
+}
+
+async function sha256File(path: string, signal?: AbortSignal): Promise<string> {
+  const hash = createHash("sha256");
+  await pipeline(
+    createReadStream(path),
+    async function* (source) {
+      for await (const chunk of source) {
+        signal?.throwIfAborted();
+        hash.update(chunk as Buffer);
+        yield;
+      }
+    },
+    { signal },
+  );
+  return hash.digest("hex");
 }
 
 function runTar(args: string[], signal?: AbortSignal): Promise<string> {
@@ -278,7 +319,117 @@ async function validateSourceArchive(archive: string, signal?: AbortSignal): Pro
   return [...roots][0]!;
 }
 
-/** Download → verify → extract → publish. Any failure leaves the previously
+/** Refuse paths that can escape staging and links that can redirect extraction
+    outside it. Require the one upstream executable at the archive root. */
+async function validateBinaryArchive(
+  archive: string,
+  executable: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const entries = (await runTar(["-tzf", archive], signal)).split("\n").filter(Boolean);
+  let binaryCount = 0;
+  for (const entry of entries) {
+    const normalized = normalizedArchivePath(entry);
+    if (entry.startsWith("/") || normalized.split("/").includes("..")) {
+      throw new Error(`unsafe archive path: ${entry}`);
+    }
+    if (normalized === executable) binaryCount += 1;
+  }
+  if (binaryCount !== 1) {
+    throw new Error(`archive must contain exactly one root ${executable} executable`);
+  }
+
+  const verbose = await runTar(["-tvzf", archive], signal);
+  for (const line of verbose.split("\n")) {
+    if (line.startsWith("l") || line.startsWith("h")) {
+      throw new Error("archive contains an unsafe link entry");
+    }
+  }
+}
+
+interface StageOptions {
+  staging: string;
+  candidateBinary: string;
+  revision: SourceRevision;
+  fetchImpl: typeof fetch;
+  onProgress: (stage: InstallStage) => void;
+  signal?: AbortSignal;
+}
+
+/** Published release path: the archive is only trusted after its sha256
+    matches the release's own checksums.txt. No Go toolchain is involved. */
+async function stagePublishedBinary(options: StageOptions): Promise<void> {
+  const { staging, candidateBinary, revision, fetchImpl, onProgress, signal } = options;
+  const binary = revision.binary!;
+  const executable = basename(candidateBinary);
+
+  onProgress("downloading");
+  const archivePath = join(staging, binary.assetName);
+  await downloadTo(binary.assetUrl, archivePath, fetchImpl, signal);
+
+  onProgress("verifying");
+  const checksumsResponse = await fetchImpl(binary.checksumsUrl, {
+    headers: { "User-Agent": GH_HEADERS["User-Agent"] },
+    redirect: "follow",
+    signal: requestSignal(signal, 30_000),
+  });
+  if (!checksumsResponse.ok) {
+    throw new Error(`checksums.txt download failed: HTTP ${checksumsResponse.status}`);
+  }
+  const expected = parseChecksums(await checksumsResponse.text()).get(binary.assetName);
+  if (!expected) {
+    throw new Error(
+      `checksums.txt has no entry for ${binary.assetName}; refusing unverified install`,
+    );
+  }
+  const actual = await sha256File(archivePath, signal);
+  if (actual !== expected) {
+    throw new Error(
+      `checksum mismatch for ${binary.assetName}: expected ${expected}, got ${actual}`,
+    );
+  }
+
+  onProgress("extracting");
+  await validateBinaryArchive(archivePath, executable, signal);
+  const extractDir = join(staging, "extract");
+  ensureDir(extractDir);
+  await runTar(["-xzf", archivePath, "-C", extractDir], signal);
+  const extracted = join(extractDir, executable);
+  if (!lstatSync(extracted).isFile()) {
+    throw new Error(`no CLIProxyAPI binary found inside ${binary.assetName}`);
+  }
+  renameSync(extracted, candidateBinary);
+}
+
+/** Source path: any ref that names no published archive, including branches,
+    commits, and forks. Requires the local Go toolchain. */
+async function stageSourceBuild(
+  options: StageOptions & { buildSource: (options: BuildSourceOptions) => Promise<void> },
+): Promise<void> {
+  const { staging, candidateBinary, revision, fetchImpl, onProgress, signal } = options;
+
+  onProgress("downloading");
+  const archivePath = join(staging, `CLIProxyAPI-${revision.commit}.tar.gz`);
+  await downloadTo(revision.archiveUrl, archivePath, fetchImpl, signal);
+
+  onProgress("verifying");
+  const sourceRootName = await validateSourceArchive(archivePath, signal);
+
+  onProgress("extracting");
+  await runTar(["-xzf", archivePath, "-C", staging], signal);
+  const sourceDir = join(staging, sourceRootName);
+  if (!lstatSync(join(sourceDir, "go.mod")).isFile()) {
+    throw new Error("CLIProxyAPI source archive has no root go.mod");
+  }
+
+  onProgress("building");
+  await options.buildSource({ sourceDir, outputPath: candidateBinary, revision, signal });
+  if (!lstatSync(candidateBinary).isFile()) {
+    throw new Error("go build did not produce the CLIProxyAPI executable");
+  }
+}
+
+/** Download → verify → stage → publish. Any failure leaves the previously
     installed binary untouched; staging is always cleaned up. */
 export async function installCore(
   paths: Paths,
@@ -287,35 +438,25 @@ export async function installCore(
 ): Promise<string> {
   const fetchImpl = deps.fetchImpl ?? fetch;
   const onProgress = deps.onProgress ?? (() => {});
-  const buildSource = deps.buildSource ?? runGoBuild;
-  const archiveName = `CLIProxyAPI-${revision.commit}.tar.gz`;
   const staging = join(paths.coreDir, `tmp-${process.pid}-${randomUUID()}`);
   let landedRelease: string | null = null;
   let pointerCommitted = false;
   ensureDir(staging);
   try {
-    onProgress("downloading");
-    const archivePath = join(staging, archiveName);
-    await downloadTo(revision.archiveUrl, archivePath, fetchImpl, deps.signal);
-
-    onProgress("verifying");
-    const sourceRootName = await validateSourceArchive(archivePath, deps.signal);
-
-    onProgress("extracting");
-    await runTar(["-xzf", archivePath, "-C", staging], deps.signal);
-    const sourceDir = join(staging, sourceRootName);
-    if (!lstatSync(join(sourceDir, "go.mod")).isFile()) {
-      throw new Error("CLIProxyAPI source archive has no root go.mod");
-    }
-
     const candidateRelease = join(staging, "release");
     ensureDir(candidateRelease);
     const candidateBinary = join(candidateRelease, basename(paths.binPath));
-    onProgress("building");
-    await buildSource({ sourceDir, outputPath: candidateBinary, revision, signal: deps.signal });
-    if (!lstatSync(candidateBinary).isFile()) {
-      throw new Error("go build did not produce the CLIProxyAPI executable");
-    }
+    const stage: StageOptions = {
+      staging,
+      candidateBinary,
+      revision,
+      fetchImpl,
+      onProgress,
+      signal: deps.signal,
+    };
+    if (revision.binary) await stagePublishedBinary(stage);
+    else await stageSourceBuild({ ...stage, buildSource: deps.buildSource ?? runGoBuild });
+
     chmodSync(candidateBinary, 0o755);
     writeAtomic(join(candidateRelease, ".version"), `${revision.version}\n`);
     ensureDir(paths.versionsDir);

--- a/plugins/agent-proxy/lib/release.ts
+++ b/plugins/agent-proxy/lib/release.ts
@@ -22,12 +22,37 @@ export const DEFAULT_CORE_SOURCE: CoreSource = {
 };
 const INVALID_REF_CHARACTERS = new Set(["~", "^", ":", "?", "*", "[", "\\"]);
 
+export interface ReleaseAsset {
+  name: string;
+  url: string;
+}
+
+export interface Release {
+  tag: string;
+  assets: ReleaseAsset[];
+}
+
+/** The published archive for this platform plus the checksums file that must
+    verify it. Both are required; a release missing either is built from
+    source instead. */
+export interface ReleaseBinary {
+  assetName: string;
+  assetUrl: string;
+  checksumsUrl: string;
+}
+
+/**
+ * A resolved install target. The commit is always known, so a build from
+ * source is always possible; `binary` is set only when the ref names a
+ * published release that ships an archive for this platform.
+ */
 export interface SourceRevision {
   repo: string;
   ref: string;
   commit: string;
   version: string;
   archiveUrl: string;
+  binary: ReleaseBinary | null;
 }
 
 export function normalizeCoreRepo(value: string): string {
@@ -113,17 +138,74 @@ export function latestReleaseApiUrl(repo: string): string {
   return `https://api.github.com/repos/${repo}/releases/latest`;
 }
 
+export function releaseTagApiUrl(repo: string, tag: string): string {
+  return `https://api.github.com/repos/${repo}/releases/tags/${encodeURIComponent(tag)}`;
+}
+
+export function normalizeVersion(version: string): string {
+  return version.replace(/^v/, "");
+}
+
 /** GitHub's releases/latest already excludes drafts and prereleases, so the
     tag it reports is the newest release a user would download by hand. */
-export function parseLatestReleaseTag(json: unknown): string {
+export function parseRelease(json: unknown): Release {
   if (typeof json !== "object" || json === null) {
     throw new Error("malformed GitHub release response");
   }
-  const tag = (json as Record<string, unknown>).tag_name;
-  if (typeof tag !== "string" || tag.trim().length === 0) {
+  const record = json as Record<string, unknown>;
+  if (typeof record.tag_name !== "string" || record.tag_name.trim().length === 0) {
     throw new Error("GitHub release response has no tag_name");
   }
-  return normalizeCoreRef(tag);
+  const assets: ReleaseAsset[] = [];
+  if (Array.isArray(record.assets)) {
+    for (const entry of record.assets) {
+      if (typeof entry !== "object" || entry === null) continue;
+      const asset = entry as Record<string, unknown>;
+      if (typeof asset.name === "string" && typeof asset.browser_download_url === "string") {
+        assets.push({ name: asset.name, url: asset.browser_download_url });
+      }
+    }
+  }
+  return { tag: normalizeCoreRef(record.tag_name), assets };
+}
+
+/** Release archives are CLIProxyAPI_<ver>_<os>_<arch>.tar.gz; upstream uses
+    aarch64 (not arm64) and ships tar.gz only for darwin and linux. Anything
+    else returns null and falls back to a source build. */
+export function releaseAssetName(
+  version: string,
+  platform: NodeJS.Platform = process.platform,
+  arch: NodeJS.Architecture = process.arch,
+): string | null {
+  if (platform !== "darwin" && platform !== "linux") return null;
+  const archName = arch === "arm64" ? "aarch64" : arch === "x64" ? "amd64" : null;
+  if (!archName) return null;
+  return `CLIProxyAPI_${normalizeVersion(version)}_${platform}_${archName}.tar.gz`;
+}
+
+/** Null whenever this platform's archive or checksums.txt is absent — the
+    caller then builds the same commit from source. */
+export function pickReleaseBinary(
+  release: Release,
+  platform: NodeJS.Platform = process.platform,
+  arch: NodeJS.Architecture = process.arch,
+): ReleaseBinary | null {
+  const name = releaseAssetName(release.tag, platform, arch);
+  if (name === null) return null;
+  const asset = release.assets.find((candidate) => candidate.name === name);
+  const checksums = release.assets.find((candidate) => candidate.name === "checksums.txt");
+  if (!asset || !checksums) return null;
+  return { assetName: asset.name, assetUrl: asset.url, checksumsUrl: checksums.url };
+}
+
+/** checksums.txt lines are "<sha256>  <filename>". */
+export function parseChecksums(text: string): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const line of text.split("\n")) {
+    const match = /^([0-9a-fA-F]{64})\s+\*?(.+)$/.exec(line.trim());
+    if (match) map.set(match[2]!.trim(), match[1]!.toLowerCase());
+  }
+  return map;
 }
 
 export function sourceArchiveUrl(repo: string, commit: string): string {
@@ -137,6 +219,7 @@ export function sourceVersion(ref: string, commit: string): string {
 export function parseSourceRevision(
   json: unknown,
   source: CoreSource = DEFAULT_CORE_SOURCE,
+  binary: ReleaseBinary | null = null,
 ): SourceRevision {
   if (typeof json !== "object" || json === null) {
     throw new Error("malformed GitHub commit response");
@@ -152,5 +235,6 @@ export function parseSourceRevision(
     commit: normalizedCommit,
     version: sourceVersion(source.ref, normalizedCommit),
     archiveUrl: sourceArchiveUrl(source.repo, normalizedCommit),
+    binary,
   };
 }

--- a/plugins/agent-proxy/skills/agent-proxy/SKILL.md
+++ b/plugins/agent-proxy/skills/agent-proxy/SKILL.md
@@ -43,7 +43,7 @@ Auth: pass the local API key as the bearer token / `x-api-key`.
 bb agent-proxy status                 # core state, versions, endpoints
 bb agent-proxy start|stop|restart     # lifecycle
 bb agent-proxy endpoints              # URLs + local API key
-bb agent-proxy install [ref]          # build/install configured source; ref temporarily overrides branch
+bb agent-proxy install [ref]          # install configured source (release archive, else source build); ref temporarily overrides branch
 bb agent-proxy oauth <claude|codex>   # browser OAuth flow (prints URL, waits)
 bb agent-proxy providers              # configured credentials + auth files
 bb agent-proxy usage                  # recent request buckets (JSON)

--- a/plugins/agent-proxy/test/core-install.test.ts
+++ b/plugins/agent-proxy/test/core-install.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
@@ -49,6 +50,7 @@ function makeFixture() {
     commit: COMMIT,
     version: `${RELEASE_TAG}@${COMMIT.slice(0, 12)}`,
     archiveUrl: `https://example.com/${COMMIT}.tar.gz`,
+    binary: null,
   };
 
   const fetchImpl: typeof fetch = (input) =>
@@ -65,6 +67,48 @@ function makeFixture() {
   return { dir, paths, revision, archiveBytes, fetchImpl, buildSource };
 }
 
+/** A published-release install: one root executable in the archive, verified
+    against the release's checksums.txt. */
+function makeBinaryFixture(corrupt = false) {
+  const dir = mkdtempSync(join(tmpdir(), "agent-proxy-binary-"));
+  const paths = buildPaths(join(dir, "data"));
+  mkdirSync(paths.coreDir, { recursive: true });
+
+  const assetName = `CLIProxyAPI_7.2.127_${process.platform}_aarch64.tar.gz`;
+  const archiveSrc = join(dir, "asset");
+  mkdirSync(archiveSrc, { recursive: true });
+  const executable = basename(paths.binPath);
+  writeFileSync(join(archiveSrc, executable), `#!/bin/sh\necho published CLIProxyAPI\n`);
+  const archivePath = join(dir, assetName);
+  execFileSync("tar", ["-czf", archivePath, "-C", archiveSrc, executable]);
+  const archiveBytes = readFileSync(archivePath);
+  const digest = createHash("sha256").update(archiveBytes).digest("hex");
+  const checksums = `${corrupt ? "b".repeat(64) : digest}  ${assetName}\n`;
+
+  const binary = {
+    assetName,
+    assetUrl: "https://example.invalid/asset.tar.gz",
+    checksumsUrl: "https://example.invalid/checksums.txt",
+  };
+  const revision: SourceRevision = {
+    repo: CORE_REPO,
+    ref: RELEASE_TAG,
+    commit: COMMIT,
+    version: `${RELEASE_TAG}@${COMMIT.slice(0, 12)}`,
+    archiveUrl: `https://example.com/${COMMIT}.tar.gz`,
+    binary,
+  };
+
+  const fetchImpl: typeof fetch = (input) => {
+    const url = String(input);
+    if (url === binary.assetUrl) return Promise.resolve(new Response(new Uint8Array(archiveBytes)));
+    if (url === binary.checksumsUrl) return Promise.resolve(new Response(checksums));
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  return { paths, revision, fetchImpl };
+}
+
 function seedInstalled(
   paths: ReturnType<typeof buildPaths>,
   version: string,
@@ -78,49 +122,107 @@ function seedInstalled(
   symlinkSync(releaseDir, paths.currentLink, "dir");
 }
 
-test("fetchSourceRevision resolves the configured ref to an immutable commit", async () => {
-  let requested = "";
+function releaseFetch(assets: { name: string; browser_download_url: string }[]): {
+  fetchImpl: typeof fetch;
+  requested: string[];
+} {
+  const requested: string[] = [];
   const fetchImpl: typeof fetch = (input) => {
-    requested = String(input);
+    const url = String(input);
+    requested.push(url);
+    const body = url.includes("/releases/")
+      ? JSON.stringify({ tag_name: RELEASE_TAG, assets })
+      : JSON.stringify({ sha: COMMIT });
+    return Promise.resolve(new Response(body, { headers: { "content-type": "application/json" } }));
+  };
+  return { fetchImpl, requested };
+}
+
+test("fetchSourceRevision resolves the latest sentinel to a release archive", async () => {
+  const assetName = `CLIProxyAPI_7.2.127_${process.platform}_${process.arch === "arm64" ? "aarch64" : "amd64"}.tar.gz`;
+  const { fetchImpl, requested } = releaseFetch([
+    { name: assetName, browser_download_url: "https://example.invalid/asset" },
+    { name: "checksums.txt", browser_download_url: "https://example.invalid/checksums" },
+  ]);
+  const revision = await fetchSourceRevision({ repo: CORE_REPO, ref: CORE_REF }, fetchImpl);
+  assert.deepEqual(requested, [
+    `https://api.github.com/repos/${CORE_REPO}/releases/latest`,
+    `https://api.github.com/repos/${CORE_REPO}/commits/${RELEASE_TAG}`,
+  ]);
+  assert.equal(revision.ref, RELEASE_TAG);
+  assert.equal(revision.version, `${RELEASE_TAG}@${COMMIT.slice(0, 12)}`);
+  assert.deepEqual(revision.binary, {
+    assetName,
+    assetUrl: "https://example.invalid/asset",
+    checksumsUrl: "https://example.invalid/checksums",
+  });
+});
+
+test("a release without a usable archive still resolves, for a source build", async () => {
+  const { fetchImpl } = releaseFetch([
+    { name: "checksums.txt", browser_download_url: "https://example.invalid/checksums" },
+  ]);
+  const revision = await fetchSourceRevision({ repo: CORE_REPO, ref: RELEASE_TAG }, fetchImpl);
+  assert.equal(revision.binary, null);
+  assert.equal(revision.commit, COMMIT);
+});
+
+test("a branch ref falls back to source when no release carries that tag", async () => {
+  const requested: string[] = [];
+  const fetchImpl: typeof fetch = (input) => {
+    const url = String(input);
+    requested.push(url);
+    return Promise.resolve(
+      url.includes("/releases/tags/")
+        ? new Response("not found", { status: 404 })
+        : new Response(JSON.stringify({ sha: COMMIT }), {
+            headers: { "content-type": "application/json" },
+          }),
+    );
+  };
+  const revision = await fetchSourceRevision({ repo: CORE_REPO, ref: "main" }, fetchImpl);
+  assert.deepEqual(requested, [
+    `https://api.github.com/repos/${CORE_REPO}/releases/tags/main`,
+    `https://api.github.com/repos/${CORE_REPO}/commits/main`,
+  ]);
+  assert.equal(revision.binary, null);
+});
+
+test("a commit ref skips the release lookup entirely", async () => {
+  const requested: string[] = [];
+  const fetchImpl: typeof fetch = (input) => {
+    requested.push(String(input));
     return Promise.resolve(
       new Response(JSON.stringify({ sha: COMMIT }), {
         headers: { "content-type": "application/json" },
       }),
     );
   };
-  const revision = await fetchSourceRevision({ repo: CORE_REPO, ref: "main" }, fetchImpl);
-  assert.match(requested, /commits\/main$/);
-  assert.equal(revision.commit, COMMIT);
-  assert.equal(revision.version, `main@${COMMIT.slice(0, 12)}`);
+  const revision = await fetchSourceRevision({ repo: CORE_REPO, ref: COMMIT }, fetchImpl);
+  assert.deepEqual(requested, [`https://api.github.com/repos/${CORE_REPO}/commits/${COMMIT}`]);
+  assert.equal(revision.binary, null);
 });
 
-test("fetchSourceRevision resolves the latest sentinel through the release tag", async () => {
-  const requested: string[] = [];
-  const fetchImpl: typeof fetch = (input) => {
-    const url = String(input);
-    requested.push(url);
-    const body = url.endsWith("/releases/latest")
-      ? JSON.stringify({ tag_name: "v7.2.127" })
-      : JSON.stringify({ sha: COMMIT });
-    return Promise.resolve(
-      new Response(body, { headers: { "content-type": "application/json" } }),
-    );
-  };
-  const revision = await fetchSourceRevision({ repo: CORE_REPO, ref: CORE_REF }, fetchImpl);
-  assert.deepEqual(requested, [
-    `https://api.github.com/repos/${CORE_REPO}/releases/latest`,
-    `https://api.github.com/repos/${CORE_REPO}/commits/v7.2.127`,
-  ]);
-  assert.equal(revision.ref, "v7.2.127");
-  assert.equal(revision.version, `v7.2.127@${COMMIT.slice(0, 12)}`);
+test("installCore publishes a verified release archive without building", async () => {
+  const { paths, revision, fetchImpl } = makeBinaryFixture();
+  const stages: string[] = [];
+  const version = await installCore(paths, revision, {
+    fetchImpl,
+    onProgress: (stage) => stages.push(stage),
+    buildSource: async () => assert.fail("a published archive must not trigger a build"),
+  });
+  assert.equal(version, revision.version);
+  assert.equal(installedVersion(paths), revision.version);
+  assert.match(readFileSync(paths.binPath, "utf8"), /published CLIProxyAPI/);
+  assert.deepEqual(stages, ["downloading", "verifying", "extracting", "installing", "done"]);
 });
 
-test("fetchSourceRevision reports a repository with no published release", async () => {
-  const fetchImpl: typeof fetch = () => Promise.resolve(new Response("missing", { status: 404 }));
-  await assert.rejects(
-    fetchSourceRevision({ repo: "owner/repo", ref: "latest" }, fetchImpl),
-    /owner\/repo has no published release/,
-  );
+test("installCore refuses a release archive that fails its checksum", async () => {
+  const { paths, revision, fetchImpl } = makeBinaryFixture(true);
+  seedInstalled(paths, "v7.2.126@000000000000");
+  await assert.rejects(installCore(paths, revision, { fetchImpl }), /checksum mismatch/);
+  assert.equal(installedVersion(paths), "v7.2.126@000000000000");
+  assert.equal(readFileSync(paths.binPath, "utf8"), "old-binary");
 });
 
 test("fetchSourceRevision reports a repository with no published release", async () => {

--- a/plugins/agent-proxy/test/release.test.ts
+++ b/plugins/agent-proxy/test/release.test.ts
@@ -11,8 +11,12 @@ import {
   normalizeCoreRef,
   normalizeCoreRepo,
   normalizeCoreSource,
-  parseLatestReleaseTag,
+  parseChecksums,
+  parseRelease,
   parseSourceRevision,
+  pickReleaseBinary,
+  releaseAssetName,
+  releaseTagApiUrl,
   sourceArchiveUrl,
   sourceVersion,
 } from "../lib/release.ts";
@@ -38,12 +42,55 @@ test("the latest sentinel is recognized whatever the case", () => {
   );
 });
 
-test("parseLatestReleaseTag reads and validates the release tag", () => {
-  assert.equal(parseLatestReleaseTag({ tag_name: " v7.2.127 " }), "v7.2.127");
-  assert.throws(() => parseLatestReleaseTag(null), /malformed/);
-  assert.throws(() => parseLatestReleaseTag({}), /tag_name/);
-  assert.throws(() => parseLatestReleaseTag({ tag_name: "   " }), /tag_name/);
-  assert.throws(() => parseLatestReleaseTag({ tag_name: "bad ref" }), /branch or ref/);
+test("parseRelease reads the tag and the downloadable assets", () => {
+  const release = parseRelease({
+    tag_name: " v7.2.127 ",
+    assets: [
+      { name: "checksums.txt", browser_download_url: "https://example.invalid/checksums.txt" },
+      { name: "ignored", size: 1 },
+      { name: "CLIProxyAPI_7.2.127_darwin_aarch64.tar.gz", browser_download_url: "https://example.invalid/a" },
+    ],
+  });
+  assert.equal(release.tag, "v7.2.127");
+  assert.deepEqual(
+    release.assets.map((asset) => asset.name),
+    ["checksums.txt", "CLIProxyAPI_7.2.127_darwin_aarch64.tar.gz"],
+  );
+  assert.throws(() => parseRelease(null), /malformed/);
+  assert.throws(() => parseRelease({}), /tag_name/);
+  assert.throws(() => parseRelease({ tag_name: "   " }), /tag_name/);
+  assert.throws(() => parseRelease({ tag_name: "bad ref" }), /branch or ref/);
+  assert.equal(
+    releaseTagApiUrl(CORE_REPO, "v7.2.127"),
+    "https://api.github.com/repos/router-for-me/CLIProxyAPI/releases/tags/v7.2.127",
+  );
+});
+
+test("release assets are named per platform, with source as the fallback", () => {
+  assert.equal(releaseAssetName("v7.2.127", "darwin", "arm64"), "CLIProxyAPI_7.2.127_darwin_aarch64.tar.gz");
+  assert.equal(releaseAssetName("7.2.127", "linux", "x64"), "CLIProxyAPI_7.2.127_linux_amd64.tar.gz");
+  assert.equal(releaseAssetName("7.2.127", "win32", "x64"), null);
+  assert.equal(releaseAssetName("7.2.127", "linux", "ppc64"), null);
+
+  const assets = [
+    { name: "CLIProxyAPI_7.2.127_darwin_aarch64.tar.gz", url: "https://example.invalid/a" },
+    { name: "checksums.txt", url: "https://example.invalid/c" },
+  ];
+  assert.deepEqual(pickReleaseBinary({ tag: "v7.2.127", assets }, "darwin", "arm64"), {
+    assetName: "CLIProxyAPI_7.2.127_darwin_aarch64.tar.gz",
+    assetUrl: "https://example.invalid/a",
+    checksumsUrl: "https://example.invalid/c",
+  });
+  // No archive for the platform, and no checksums.txt: both build from source.
+  assert.equal(pickReleaseBinary({ tag: "v7.2.127", assets }, "linux", "x64"), null);
+  assert.equal(pickReleaseBinary({ tag: "v7.2.127", assets: [assets[0]!] }, "darwin", "arm64"), null);
+});
+
+test("parseChecksums reads sha256 lines", () => {
+  const sha = "a".repeat(64);
+  const map = parseChecksums(`${sha}  CLIProxyAPI_7.2.127_darwin_aarch64.tar.gz\nnonsense\n`);
+  assert.equal(map.get("CLIProxyAPI_7.2.127_darwin_aarch64.tar.gz"), sha);
+  assert.equal(map.size, 1);
 });
 
 test("commitApiUrl safely encodes branch names", () => {
@@ -94,6 +141,7 @@ test("source revision is pinned to the resolved commit", () => {
     commit: COMMIT,
     version: "v7.2.127@9e593b74486a",
     archiveUrl: `https://codeload.github.com/${CORE_REPO}/tar.gz/${COMMIT}`,
+    binary: null,
   });
   assert.equal(sourceVersion("v7.2.127", COMMIT), "v7.2.127@9e593b74486a");
   assert.equal(sourceArchiveUrl(CORE_REPO, COMMIT), revision.archiveUrl);


### PR DESCRIPTION
Building every install from source existed only to carry the fork branch,
which no longer is the default. A ref that names a published release now
installs that release's archive for the platform and verifies its sha256
against the release's own checksums.txt; anything else (branch, commit,
fork, or a release without an archive for this platform) still builds the
resolved commit with Go.

Both paths share the atomic pointer swap, so a failed install still leaves
the running binary untouched. Go is now required only for source builds.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>