### PR TITLE
fix(gh-stack): handle a fully merged stack in Magic Stack

### DIFF
--- a/plugins/gh-stack/README.md
+++ b/plugins/gh-stack/README.md
@@ -75,11 +75,12 @@ branches and pull requests via the GitHub CLI.
   thread's own agent (whatever harness the session uses) to analyze the
   workspace, design layers, and submit draft PRs — automatic splitting, where
   the composer takes one layer at a time. The prompt adapts to the workspace:
-  `gh stack init` when there is no stack, `gh stack top` + `add` on top of an
-  existing one. It also carries the split protocol — stash unrelated work,
-  lint before splitting, snapshot the finished state and byte-verify the top
-  against it, cherry-pick per-concern commits when they exist, and prefer a
-  manifest-driven splitter (`scripts/split-layers.ts` here) over hand edits.
+  `gh stack init` when there is no stack or every layer of the last one merged,
+  `gh stack top` + `add` while a stack still has a layer to build on. It also
+  carries the split protocol — stash unrelated work, lint before splitting,
+  snapshot the finished state and byte-verify the top against it, cherry-pick
+  per-concern commits when they exist, and prefer a manifest-driven splitter
+  (`scripts/split-layers.ts` here) over hand edits.
 - **Automatic Sync recovery** keeps ordinary updates deterministic with native
   `gh stack sync`. Rebase conflicts, unfinished rebases, local/remote
   divergence, and known stack-topology conflicts are sent directly to the

--- a/plugins/gh-stack/lib/stack-layers.ts
+++ b/plugins/gh-stack/lib/stack-layers.ts
@@ -1,3 +1,15 @@
+/**
+ * A stack whose every layer is merged cannot be extended: `gh stack top` has
+ * no branch to check out, because merged layer branches are normally pruned
+ * locally and on the remote. Only the layers that survive make a stack
+ * extendable; without one, new work starts a stack of its own.
+ */
+export function hasExtendableLayers<
+  T extends { isMerged: boolean; pr?: { state: string } | null },
+>(branches: readonly T[]): boolean {
+  return branches.some((branch) => !branch.isMerged && branch.pr?.state !== "MERGED");
+}
+
 export type StackLayerCheckout = {
   mergedBranch: string;
   target:

--- a/plugins/gh-stack/server.ts
+++ b/plugins/gh-stack/server.ts
@@ -26,6 +26,7 @@ import {
   requiresAgentSyncRecovery,
 } from "./lib/gh-stack-output";
 import {
+  hasExtendableLayers,
   projectStackLayers,
   type StackLayerCheckout,
 } from "./lib/stack-layers";
@@ -881,7 +882,8 @@ function magicExtendPrompt(settings: Settings, detectedPrefix: string | null): s
     "This workspace already has a stack. Split the work that is not yet in it into more layers on top, with `gh stack` (follow the gh-stack skill).",
     "1. Inspect the state: `gh stack view --json`, plus uncommitted changes and commits not yet in a layer.",
     "2. Design the new layers bottom-to-top — one dependent concern per layer (read references/stack-design.md if unsure).",
-    "3. Run `gh stack top`, then `gh stack add <branch>` per layer, moving each concern into its owning layer. Do not run `gh stack init`; it would start a second stack.",
+    "3. Run `gh stack top`, then `gh stack add <branch>` per layer, moving each concern into its owning layer. Do not run `gh stack init` while the stack still has a branch to build on; it would start a second stack.",
+    "If `gh stack top` fails because the layer branches no longer exist (every layer merged, branches pruned locally and on the remote), there is nothing to extend: build the layers on the trunk instead, then adopt them with `gh stack init --base <trunk> <branch>...`, which reuses those branches rather than creating a competing stack.",
     "4. Push and open draft PRs with `gh stack submit --auto`, then confirm with `gh stack view --json` and share the PR links.",
     ...splitProtocolLines(),
     ...conventionsLines(settings, detectedPrefix),
@@ -2604,12 +2606,15 @@ export default async function plugin(bb: BbPluginApi) {
       if (workspace.error) {
         return { ok: false, message: workspace.error.message, detail: null };
       }
-      // An existing stack must be extended, not re-initialized.
+      // A stack with layers left to build on must be extended, not
+      // re-initialized. One whose layers are all merged is finished: its
+      // branches are gone, so there is nothing to stack onto and the agent
+      // needs the create prompt instead.
       const view = await readStackView(workspace.cwd);
       if (view.error && view.error.kind !== "not-a-stack") {
         return { ok: false, message: view.error.message, detail: null };
       }
-      const hasStack = view.stack !== null;
+      const hasStack = view.stack !== null && hasExtendableLayers(view.stack.branches);
       // Hand the agent the same naming rules the composer follows.
       const settings = await loadSettings();
       const detectedPrefix =

--- a/plugins/gh-stack/test/stack-layers.test.ts
+++ b/plugins/gh-stack/test/stack-layers.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { projectStackLayers } from "../lib/stack-layers.ts";
+import { hasExtendableLayers, projectStackLayers } from "../lib/stack-layers.ts";
 
 type Layer = { name: string; isMerged: boolean; marker: number };
 
@@ -79,4 +79,21 @@ test("hiding other merged layers does not move an active or unknown current bran
 
   assert.equal(projectStackLayers(branches, "main", null).checkout, null);
   assert.equal(projectStackLayers(branches, "main", "other").checkout, null);
+});
+
+test("a stack is extendable only while some layer is unmerged", () => {
+  const merged = { isMerged: true, pr: { state: "MERGED" } };
+  const open = { isMerged: false, pr: { state: "OPEN" } };
+
+  assert.equal(hasExtendableLayers([merged, open]), true);
+  assert.equal(hasExtendableLayers([merged, merged]), false);
+  assert.equal(hasExtendableLayers([]), false);
+});
+
+test("a layer whose PR merged behind gh-stack's back is not extendable", () => {
+  // gh stack view can report isMerged: false while the PR already says MERGED.
+  assert.equal(hasExtendableLayers([{ isMerged: false, pr: { state: "MERGED" } }]), false);
+  // A layer with no PR yet is still somewhere to stack onto.
+  assert.equal(hasExtendableLayers([{ isMerged: false, pr: null }]), true);
+  assert.equal(hasExtendableLayers([{ isMerged: false }]), true);
 });


### PR DESCRIPTION
Magic Stack treated any stack record as extendable, so a stack whose
layers had all merged still got the extend prompt. Those branches are
pruned once they merge, leaving `gh stack top` nothing to check out, and
the prompt's own rule forbade the one recovery that works.

Count only the layers that survive, and tell the extend prompt what to do
when the branches are gone: build on the trunk, then adopt with
`gh stack init --base <trunk>`, which reuses branches rather than starting
a competing stack.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>