### PR TITLE
feat(gh-stack): verify every split layer, not just the top

### DIFF
--- a/plugins/gh-stack/README.md
+++ b/plugins/gh-stack/README.md
@@ -78,9 +78,9 @@ branches and pull requests via the GitHub CLI.
   `gh stack init` when there is no stack or every layer of the last one merged,
   `gh stack top` + `add` while a stack still has a layer to build on. It also
   carries the split protocol — stash unrelated work, lint before splitting,
-  snapshot the finished state and byte-verify the top against it, cherry-pick
-  per-concern commits when they exist, and prefer a manifest-driven splitter
-  (`scripts/split-layers.ts` here) over hand edits.
+  snapshot the finished state and byte-verify the top against it, verify each
+  layer on its own, cherry-pick per-concern commits when they exist, and prefer
+  a manifest-driven splitter (`scripts/split-layers.ts` here) over hand edits.
 - **Automatic Sync recovery** keeps ordinary updates deterministic with native
   `gh stack sync`. Rebase conflicts, unfinished rebases, local/remote
   divergence, and known stack-topology conflicts are sent directly to the

--- a/plugins/gh-stack/server.ts
+++ b/plugins/gh-stack/server.ts
@@ -859,6 +859,7 @@ function splitProtocolLines(): string[] {
     "Before restructuring: `git stash push` any workspace changes that are not part of this work; run the repository's lint and typecheck so you split a clean tree; copy every file you will move to a temporary snapshot directory, and when the stack is built byte-compare the top against that snapshot.",
     "If the work already exists as per-concern commits, build each layer by cherry-picking them — never re-edit files a commit already captures.",
     "When splitting a mixed tree, assign whole files to the single layer that owns them, and for a file two layers share write out its full intermediate state per layer — byte-exact copies, not patches or anchored string edits, which drift and cannot safely re-run. If the repository has a splitter tool (for example `bun scripts/split-layers.ts <manifest>`), drive it with a manifest instead of editing by hand.",
+    "Prove every layer stands alone, not just the top one: give the splitter a `verify` command that runs the repository's typecheck and tests, or run them yourself before each commit. A layer that only compiles once the layer above lands is not reviewable.",
   ];
 }
 


### PR DESCRIPTION
The split protocol proved the top of the stack against the snapshot and
left the layers below unchecked, so a split could land a layer that only
compiles once the layer above it does — unreviewable on its own.

Ask for a splitter `verify` command, or the same checks by hand before
each commit.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>