### PR TITLE
chore(agentation): drop cross-realm Response workaround

### DIFF
--- a/plugins/agentation/server.ts
+++ b/plugins/agentation/server.ts
@@ -277,10 +277,7 @@ export default async function plugin(bb: BbPluginApi) {
     streams.delete(controller);
   }
 
-  // Responses are built through the Hono context rather than `new Response`:
-  // the host checks `instanceof Response` against its own realm, and only the
-  // context's constructor is guaranteed to be the same one.
-  bb.http.route("GET", "/events", (c) => {
+  bb.http.route("GET", "/events", () => {
     let self: ReadableStreamDefaultController<Uint8Array> | null = null;
     const stream = new ReadableStream<Uint8Array>({
       start(controller) {
@@ -308,7 +305,7 @@ export default async function plugin(bb: BbPluginApi) {
       },
     });
 
-    return c.newResponse(stream, {
+    return new Response(stream, {
       headers: {
         "content-type": "text/event-stream",
         "cache-control": "no-cache, no-transform",


### PR DESCRIPTION
bb 0.39 accepts a cross-realm Response from plugin HTTP routes, and this repo's engines now require bb >=0.39.0. The GET /events SSE route returns `new Response(stream, { headers })` directly, and the realm-workaround comment is gone. SSE headers are unchanged. The /health route keeps `c.json` as ordinary Hono ergonomics.

Verified: tsc clean, 71/71 agentation tests pass, and a live curl against the pinned dev bb instance returned 200 with `text/event-stream` and streamed the hello frame.