### PR TITLE
fix(gtd-sidebar): activate rows on pointer down

### DIFF
--- a/plugins/gtd-sidebar/components/inbox/thread-card.tsx
+++ b/plugins/gtd-sidebar/components/inbox/thread-card.tsx
@@ -75,7 +75,8 @@ export function ThreadCard({
             href="#"
             aria-label={threadDisplayTitle(thread)}
             {...splitProps}
-            onClick={(event) => {
+            onPointerDown={(event) => {
+              if (event.button !== 0) return;
               event.preventDefault();
               actions.open(thread.id, {
                 split: event.metaKey || event.ctrlKey,
@@ -213,7 +214,7 @@ function ParkButton({
     <button
       type="button"
       aria-label={label}
-      onClick={(event) => {
+      onPointerDown={(event) => {
         event.preventDefault();
         event.stopPropagation();
         onActivate();


### PR DESCRIPTION
Use pointer-down for thread navigation and hover actions so the UI responds at press time. Preserve right-click context menus.

Checks: targeted typecheck, 138 tests, targeted lint, root typecheck, root tests, root build, and pinned-dev browser verification. Root lint remains blocked by unrelated .audit/arena errors.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/smsunarto/bb-plugins/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->