### PR TITLE
Release Agent Proxy 0.2.3

### DIFF
--- a/.changeset/systemd-unit-unquoted-paths.md
+++ b/.changeset/systemd-unit-unquoted-paths.md
@@ -1,5 +1,0 @@
----
-"@smsunarto/bb-plugin-agent-proxy": patch
----
-
-Emit `WorkingDirectory=`, `StandardOutput=`, and `StandardError=` unquoted in the generated systemd user unit. systemd rejects a quoted `WorkingDirectory=` as a fatal unit error, so the core service never loaded on Linux, and quoted output directives silently sent core logs to the journal instead of `core.log`.

--- a/plugins/agent-proxy/CHANGELOG.md
+++ b/plugins/agent-proxy/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @smsunarto/bb-plugin-agent-proxy
 
+## 0.2.3
+
+### Patch Changes
+
+- ca25205: Emit `WorkingDirectory=`, `StandardOutput=`, and `StandardError=` unquoted in the generated systemd user unit. systemd rejects a quoted `WorkingDirectory=` as a fatal unit error, so the core service never loaded on Linux, and quoted output directives silently sent core logs to the journal instead of `core.log`.
+
 ## 0.2.2
 
 ### Patch Changes

--- a/plugins/agent-proxy/package.json
+++ b/plugins/agent-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smsunarto/bb-plugin-agent-proxy",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Run CLIProxyAPI as a persistent macOS or Linux service with OAuth accounts, providers, usage, and agent wiring.",
   "license": "MIT",
   "author": "Scott Sunarto",


### PR DESCRIPTION
Publishes the Linux systemd path-directive fix as Agent Proxy 0.2.3. Keeps the pending Agentation and GTD Sidebar changesets out of this release.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/smsunarto/bb-plugins/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->