### PR TITLE
ci(release): create one version PR per package

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -6,9 +6,10 @@ Add one changeset for every user-visible package change:
 bun run changeset
 ```
 
-On `main`, the release workflow keeps one version PR up to date. Merging that
-PR publishes each changed scoped package and its unscoped mirror, then creates
-GitHub Releases with tags in the form `<plugin-id>/v<version>`.
+Each changeset must target one package. On `main`, the release workflow keeps
+one version PR per changed package. Merging one PR publishes only that scoped
+package and its unscoped mirror. The workflow also creates a GitHub Release
+with a `<plugin-id>/v<version>` tag.
 
 `dotfiles` and `pr-walkthrough` are private and are never versioned or
 published by Changesets.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,8 @@ jobs:
       packages: ${{ steps.plan.outputs.packages }}
     steps:
       - uses: namespacelabs/nscloud-checkout-action@v9
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
         with:
           bb-cli: "false"
@@ -43,6 +45,8 @@ jobs:
         package: ${{ fromJSON(needs.plan.outputs.packages) }}
     steps:
       - uses: namespacelabs/nscloud-checkout-action@v9
+        with:
+          persist-credentials: true
       - uses: ./.github/actions/setup
         with:
           bb-cli: "false"
@@ -133,9 +137,12 @@ jobs:
         id: changesets
         uses: changesets/action/publish@v2
         with:
+          github-token: ${{ github.token }}
           script: bun run release
           create-github-releases: true
           push-git-tags: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       # `scripts/publish.ts` rewrites each manifest for the unscoped mirror and
       # must restore the original bytes, including after a failed publish.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,15 +9,98 @@ permissions:
   id-token: write
   pull-requests: write
 
-# A second main push should update the release PR, but it must not interrupt a
-# publish that can be between a scoped package and its unscoped mirror.
+# A second main push can update version PRs. It must not interrupt an npm
+# publish between a scoped package and its unscoped mirror.
 concurrency:
   group: release-npm
   cancel-in-progress: false
 
 jobs:
-  release:
-    name: Version or publish packages
+  plan:
+    name: Plan (Packages)
+    runs-on: namespace-profile-linux-8vcpu-16gb-cached
+    outputs:
+      packages: ${{ steps.plan.outputs.packages }}
+    steps:
+      - uses: namespacelabs/nscloud-checkout-action@v9
+      - uses: ./.github/actions/setup
+        with:
+          bb-cli: "false"
+
+      - name: Find packages with pending changesets
+        id: plan
+        run: bun scripts/package-release.ts plan
+
+  version:
+    name: Version (${{ matrix.package.id }})
+    needs: plan
+    if: needs.plan.outputs.packages != '[]'
+    runs-on: namespace-profile-linux-8vcpu-16gb-cached
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.plan.outputs.packages) }}
+    steps:
+      - uses: namespacelabs/nscloud-checkout-action@v9
+      - uses: ./.github/actions/setup
+        with:
+          bb-cli: "false"
+
+      - name: Version only this package
+        id: version
+        env:
+          PACKAGE_NAME: ${{ matrix.package.name }}
+        run: bun scripts/package-release.ts version "$PACKAGE_NAME"
+
+      - name: Push the package release branch
+        env:
+          BRANCH: ${{ steps.version.outputs.branch }}
+          COMMIT_MESSAGE: ${{ steps.version.outputs.commit_message }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add --all
+          if git diff --cached --quiet; then
+            echo "The package version command produced no changes." >&2
+            exit 1
+          fi
+          git commit -m "$COMMIT_MESSAGE"
+          git push --force origin "HEAD:refs/heads/$BRANCH"
+
+      - name: Create or update the package release PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ steps.version.outputs.branch }}
+          PACKAGE_NAME: ${{ steps.version.outputs.package_name }}
+          PACKAGE_VERSION: ${{ steps.version.outputs.package_version }}
+          PR_TITLE: ${{ steps.version.outputs.pr_title }}
+        run: |
+          release_pr_body="This PR releases \`${PACKAGE_NAME}@${PACKAGE_VERSION}\`. It consumes only this package's changesets. Merging it publishes the scoped package and its unscoped mirror, then creates the package GitHub Release."
+          release_pr="$(gh pr list --base main --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$release_pr" ]; then
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/pulls/${release_pr}" -f title="$PR_TITLE" -f body="$release_pr_body" >/dev/null
+          else
+            gh pr create --base main --head "$BRANCH" --title "$PR_TITLE" --body "$release_pr_body"
+          fi
+
+  migrate:
+    name: Migrate (Legacy PR)
+    needs: [plan, version]
+    if: always() && needs.plan.result == 'success' && (needs.version.result == 'success' || needs.version.result == 'skipped')
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Close the legacy combined release PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          legacy_pr="$(gh pr list --repo "$GITHUB_REPOSITORY" --base main --head changeset-release/main --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$legacy_pr" ]; then
+            gh pr close --repo "$GITHUB_REPOSITORY" "$legacy_pr" --delete-branch --comment "Replaced by one release PR per package."
+          fi
+
+  publish:
+    name: Publish (Packages)
     # npm trusted publishing accepts OIDC identities from GitHub-hosted runners,
     # not self-hosted Namespace runners.
     runs-on: ubuntu-24.04
@@ -46,21 +129,16 @@ jobs:
           bun install --frozen-lockfile
           bun install --global "bb-app@$(node -p "require('./package.json').config.bbVersion")"
 
-      - name: Create release PR or publish packages
+      - name: Publish unpublished package versions
         id: changesets
-        uses: changesets/action@v2
+        uses: changesets/action/publish@v2
         with:
-          publish-script: bun run release
-          version-script: bun run version-packages
+          script: bun run release
           create-github-releases: true
           push-git-tags: true
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
 
-      # `scripts/publish.ts` rewrites every manifest to publish the unscoped
-      # mirror and must put it back. Only the publish path does that: the
-      # version path rewrites the same files on purpose, so guarding it there
-      # fails every release PR run.
+      # `scripts/publish.ts` rewrites each manifest for the unscoped mirror and
+      # must restore the original bytes, including after a failed publish.
       - name: Verify manifests were restored
-        if: always() && steps.changesets.outputs.published == 'true'
+        if: always()
         run: git diff --exit-code -- 'plugins/*/package.json'

--- a/scripts/package-release.test.ts
+++ b/scripts/package-release.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  independentPackageReleases,
+  withOnlyPackageChangesets,
+  type ChangesetStatus,
+} from "./package-release";
+import type { WorkspacePlugin } from "./plugin-package";
+
+function plugin(id: string, version: string): WorkspacePlugin {
+  return {
+    directory: id,
+    dir: `/repo/plugins/${id}`,
+    id,
+    name: `@smsunarto/bb-plugin-${id}`,
+    manifest: {
+      name: `@smsunarto/bb-plugin-${id}`,
+      version,
+      bb: { name: id.toUpperCase() },
+    },
+  };
+}
+
+const status: ChangesetStatus = {
+  changesets: [
+    {
+      id: "beta-fix",
+      summary: "Fix beta.",
+      releases: [{ name: "@smsunarto/bb-plugin-beta", type: "minor" }],
+    },
+    {
+      id: "alpha-fix",
+      summary: "Fix alpha.",
+      releases: [{ name: "@smsunarto/bb-plugin-alpha", type: "patch" }],
+    },
+  ],
+  releases: [
+    {
+      name: "@smsunarto/bb-plugin-beta",
+      type: "minor",
+      oldVersion: "2.0.0",
+      newVersion: "2.1.0",
+      changesets: ["beta-fix"],
+    },
+    {
+      name: "@smsunarto/bb-plugin-alpha",
+      type: "patch",
+      oldVersion: "1.0.0",
+      newVersion: "1.0.1",
+      changesets: ["alpha-fix"],
+    },
+  ],
+};
+
+describe("independent package release planning", () => {
+  test("returns one sorted release unit per package", () => {
+    expect(
+      independentPackageReleases(status, [plugin("alpha", "1.0.0"), plugin("beta", "2.0.0")]),
+    ).toEqual([
+      {
+        id: "alpha",
+        name: "@smsunarto/bb-plugin-alpha",
+        displayName: "ALPHA",
+        oldVersion: "1.0.0",
+        newVersion: "1.0.1",
+        changesets: ["alpha-fix"],
+      },
+      {
+        id: "beta",
+        name: "@smsunarto/bb-plugin-beta",
+        displayName: "BETA",
+        oldVersion: "2.0.0",
+        newVersion: "2.1.0",
+        changesets: ["beta-fix"],
+      },
+    ]);
+  });
+
+  test("rejects a changeset that targets several packages", () => {
+    const shared: ChangesetStatus = {
+      changesets: [
+        {
+          id: "shared",
+          summary: "Shared change.",
+          releases: [
+            { name: "@smsunarto/bb-plugin-alpha", type: "patch" },
+            { name: "@smsunarto/bb-plugin-beta", type: "patch" },
+          ],
+        },
+      ],
+      releases: [],
+    };
+    expect(() =>
+      independentPackageReleases(shared, [plugin("alpha", "1.0.0"), plugin("beta", "2.0.0")]),
+    ).toThrow("Each changeset must target exactly one package");
+  });
+
+  test("rejects dependent bumps without a direct package changeset", () => {
+    const dependent: ChangesetStatus = structuredClone(status);
+    dependent.releases.push({
+      name: "@smsunarto/bb-plugin-gamma",
+      type: "patch",
+      oldVersion: "3.0.0",
+      newVersion: "3.0.1",
+      changesets: [],
+    });
+    expect(() =>
+      independentPackageReleases(dependent, [
+        plugin("alpha", "1.0.0"),
+        plugin("beta", "2.0.0"),
+        plugin("gamma", "3.0.0"),
+      ]),
+    ).toThrow("Dependent package bumps cannot use independent release PRs");
+  });
+});
+
+test("changeset isolation restores every other package changeset", () => {
+  const root = mkdtempSync(join(tmpdir(), "bb-package-release-test-"));
+  const directory = join(root, ".changeset");
+  mkdirSync(directory);
+  writeFileSync(join(directory, "alpha-fix.md"), "alpha\n");
+  writeFileSync(join(directory, "beta-fix.md"), "beta\n");
+
+  try {
+    withOnlyPackageChangesets(root, status, new Set(["alpha-fix"]), () => {
+      expect(existsSync(join(directory, "alpha-fix.md"))).toBe(true);
+      expect(existsSync(join(directory, "beta-fix.md"))).toBe(false);
+      writeFileSync(join(directory, "alpha-fix.md"), "consumed\n");
+    });
+    expect(readFileSync(join(directory, "alpha-fix.md"), "utf8")).toBe("consumed\n");
+    expect(readFileSync(join(directory, "beta-fix.md"), "utf8")).toBe("beta\n");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("changeset isolation restores other changesets after a failure", () => {
+  const root = mkdtempSync(join(tmpdir(), "bb-package-release-test-"));
+  const directory = join(root, ".changeset");
+  mkdirSync(directory);
+  writeFileSync(join(directory, "alpha-fix.md"), "alpha\n");
+  writeFileSync(join(directory, "beta-fix.md"), "beta\n");
+
+  try {
+    expect(() =>
+      withOnlyPackageChangesets(root, status, new Set(["alpha-fix"]), () => {
+        throw new Error("version failed");
+      }),
+    ).toThrow("version failed");
+    expect(readFileSync(join(directory, "beta-fix.md"), "utf8")).toBe("beta\n");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/package-release.ts
+++ b/scripts/package-release.ts
@@ -1,0 +1,241 @@
+#!/usr/bin/env bun
+import { execFileSync } from "node:child_process";
+import {
+  appendFileSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { WorkspacePlugin } from "./plugin-package";
+import { publishableWorkspacePlugins } from "./publish";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+export interface ChangesetStatus {
+  changesets: {
+    id: string;
+    summary: string;
+    releases: { name: string; type: string }[];
+  }[];
+  releases: {
+    name: string;
+    type: string;
+    oldVersion: string;
+    newVersion: string;
+    changesets: string[];
+  }[];
+}
+
+export interface PackageRelease {
+  id: string;
+  name: string;
+  displayName: string;
+  oldVersion: string;
+  newVersion: string;
+  changesets: string[];
+}
+
+function sameMembers(left: readonly string[], right: readonly string[]): boolean {
+  const sortedLeft = [...left].sort();
+  const sortedRight = [...right].sort();
+  return (
+    sortedLeft.length === sortedRight.length &&
+    sortedLeft.every((value, index) => value === sortedRight[index])
+  );
+}
+
+/** Build one independent release unit for each package in the Changesets plan. */
+export function independentPackageReleases(
+  status: ChangesetStatus,
+  plugins: readonly WorkspacePlugin[],
+): PackageRelease[] {
+  const pluginsByName = new Map(plugins.map((plugin) => [plugin.name, plugin]));
+  const changesetsByPackage = new Map<string, string[]>();
+
+  for (const changeset of status.changesets) {
+    if (changeset.releases.length !== 1) {
+      throw new Error(
+        `changeset ${changeset.id} targets ${changeset.releases.length} packages. Each changeset must target exactly one package`,
+      );
+    }
+    const packageName = changeset.releases[0].name;
+    if (!pluginsByName.has(packageName)) {
+      throw new Error(`changeset ${changeset.id} targets non-publishable package ${packageName}`);
+    }
+    const packageChangesets = changesetsByPackage.get(packageName) ?? [];
+    packageChangesets.push(changeset.id);
+    changesetsByPackage.set(packageName, packageChangesets);
+  }
+
+  const releases = status.releases.map((release): PackageRelease => {
+    const plugin = pluginsByName.get(release.name);
+    if (!plugin) {
+      throw new Error(`release plan contains non-publishable package ${release.name}`);
+    }
+    const directChangesets = changesetsByPackage.get(release.name) ?? [];
+    if (directChangesets.length === 0) {
+      throw new Error(
+        `release plan updates ${release.name} without a direct changeset. Dependent package bumps cannot use independent release PRs`,
+      );
+    }
+    if (!sameMembers(directChangesets, release.changesets)) {
+      throw new Error(`release plan has inconsistent changesets for ${release.name}`);
+    }
+    if (plugin.manifest.version !== release.oldVersion) {
+      throw new Error(
+        `${release.name} manifest is ${plugin.manifest.version}, but the release plan starts at ${release.oldVersion}`,
+      );
+    }
+    return {
+      id: plugin.id,
+      name: plugin.name,
+      displayName: plugin.manifest.bb?.name ?? plugin.id,
+      oldVersion: release.oldVersion,
+      newVersion: release.newVersion,
+      changesets: [...release.changesets].sort(),
+    };
+  });
+
+  if (releases.length !== changesetsByPackage.size) {
+    throw new Error("the Changesets plan does not contain one release for each changed package");
+  }
+  return releases.sort((left, right) => left.id.localeCompare(right.id));
+}
+
+export function withOnlyPackageChangesets<T>(
+  root: string,
+  status: ChangesetStatus,
+  keptChangesets: ReadonlySet<string>,
+  operation: () => T,
+): T {
+  const removed = new Map<string, Buffer>();
+  for (const changeset of status.changesets) {
+    if (keptChangesets.has(changeset.id)) continue;
+    const path = join(root, ".changeset", `${changeset.id}.md`);
+    removed.set(path, readFileSync(path));
+    unlinkSync(path);
+  }
+
+  try {
+    return operation();
+  } finally {
+    for (const [path, contents] of removed) writeFileSync(path, contents);
+  }
+}
+
+function readChangesetStatus(root: string): ChangesetStatus {
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), "bb-package-release-"));
+  const output = join(temporaryDirectory, "status.json");
+  try {
+    execFileSync("bun", ["run", "changeset", "status", `--output=${output}`], {
+      cwd: root,
+      stdio: ["ignore", "ignore", "inherit"],
+    });
+    return JSON.parse(readFileSync(output, "utf8")) as ChangesetStatus;
+  } finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+function validateOutputValue(label: string, value: string): string {
+  if (value.includes("\n") || value.includes("\r")) {
+    throw new Error(`${label} must fit on one line`);
+  }
+  return value;
+}
+
+function writeOutputs(outputs: Record<string, string>): void {
+  const githubOutput = process.env.GITHUB_OUTPUT;
+  if (!githubOutput) {
+    console.log(JSON.stringify(outputs));
+    return;
+  }
+  for (const [name, rawValue] of Object.entries(outputs)) {
+    const value = validateOutputValue(name, rawValue);
+    appendFileSync(githubOutput, `${name}=${value}\n`);
+  }
+}
+
+function changedPaths(root: string): string[] {
+  const output = execFileSync("git", ["status", "--porcelain=v1", "-z", "--untracked-files=all"], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  return output
+    .split("\0")
+    .map((entry) => entry.slice(3))
+    .filter(Boolean)
+    .sort();
+}
+
+function assertPackageVersionDiff(root: string, release: PackageRelease): void {
+  const allowed = new Set([
+    ...release.changesets.map((id) => `.changeset/${id}.md`),
+    `plugins/${release.id}/CHANGELOG.md`,
+    `plugins/${release.id}/package.json`,
+  ]);
+  const unexpected = changedPaths(root).filter((path) => !allowed.has(path));
+  if (unexpected.length > 0) {
+    throw new Error(
+      `versioning ${release.name} also changed ${unexpected.join(", ")}. One package release PR cannot contain those paths`,
+    );
+  }
+}
+
+function preparePackageRelease(root: string, packageName: string): PackageRelease {
+  const status = readChangesetStatus(root);
+  const releases = independentPackageReleases(status, publishableWorkspacePlugins(root));
+  const release = releases.find((candidate) => candidate.name === packageName);
+  if (!release) throw new Error(`${packageName} has no pending release`);
+
+  withOnlyPackageChangesets(root, status, new Set(release.changesets), () => {
+    execFileSync("bun", ["run", "changeset", "version"], { cwd: root, stdio: "inherit" });
+  });
+
+  const manifestPath = join(root, "plugins", release.id, "package.json");
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as { version?: unknown };
+  if (manifest.version !== release.newVersion) {
+    throw new Error(
+      `${release.name} version is ${String(manifest.version)}, expected ${release.newVersion}`,
+    );
+  }
+  for (const changeset of release.changesets) {
+    const path = join(root, ".changeset", `${changeset}.md`);
+    if (existsSync(path)) throw new Error(`${relative(root, path)} was not consumed`);
+  }
+  assertPackageVersionDiff(root, release);
+  return release;
+}
+
+function main(): void {
+  const [command, argument, ...extra] = process.argv.slice(2);
+  if (extra.length > 0 || (command !== "plan" && command !== "version")) {
+    throw new Error("usage: package-release.ts plan | version <package-name>");
+  }
+
+  if (command === "plan") {
+    if (argument !== undefined) throw new Error("plan takes no package name");
+    const status = readChangesetStatus(ROOT);
+    const releases = independentPackageReleases(status, publishableWorkspacePlugins(ROOT));
+    writeOutputs({ packages: JSON.stringify(releases) });
+    return;
+  }
+
+  if (!argument) throw new Error("version requires a package name");
+  const release = preparePackageRelease(ROOT, argument);
+  writeOutputs({
+    branch: `changeset-release/${release.id}`,
+    commit_message: `chore(${release.id}): version package`,
+    package_name: release.name,
+    package_version: release.newVersion,
+    pr_title: `Release ${release.displayName} ${release.newVersion}`,
+  });
+}
+
+if (import.meta.main) main();


### PR DESCRIPTION
Create an independent Changesets version PR and branch for each publishable package.

Keep npm OIDC publishing on GitHub-hosted runners. Reject changesets that target several packages.

Checks: typecheck, test, lint, build, formatting, and actionlint.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/smsunarto/bb-plugins/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->