### PR TITLE
feat(gtd-sidebar): GitHub PR status on thread cards

### DIFF
--- a/.changeset/gtd-sidebar-github-webhooks.md
+++ b/.changeset/gtd-sidebar-github-webhooks.md
@@ -1,0 +1,5 @@
+---
+"@smsunarto/bb-plugin-gtd-sidebar": minor
+---
+
+Accept signed GitHub webhooks to update PR badge colours in realtime. A **GitHub webhooks via Cloudflare** setting checks for `cloudflared` and opens a trycloudflare tunnel to a webhook-only local port (not the bb API). Hydrate on mount, reconcile every 10 minutes, and skip hook registration on session-gated bb connect URLs. The hourly snooze watch stays as a backup.

--- a/.changeset/gtd-sidebar-listed-pr-merge-state.md
+++ b/.changeset/gtd-sidebar-listed-pr-merge-state.md
@@ -1,0 +1,20 @@
+---
+"@smsunarto/bb-plugin-gtd-sidebar": patch
+---
+
+Stop painting every listed PR green. `/repos/:owner/:repo/pulls` omits
+`mergeable_state` — GitHub computes it lazily and serves it only from the
+numbered GET — so every PR matched off the open list parsed as `"unknown"`,
+collapsed to attention `"none"`, and fell through to the open-PR green.
+Conflicts, failing checks and branch protection were all invisible; only the
+PRs that missed the list and took the numbered fallback ever turned red.
+
+A listed open PR whose state the list cannot decide now buys it with a
+numbered GET, deduped per PR and bounded by the existing per-tick cap. Draft,
+auto-merge, merged and closed stay decidable from the list and spend nothing.
+The webhook path had the same hole — `pull_request_review` and `issue_comment`
+embed a shortened pull with no `mergeable_state`, and that value was published
+straight to the sidebar — so it refetches too.
+
+Conflicting PRs are now struck through as well as red, separating the one
+state that needs a local rebase from the reds that need a re-run or a review.

--- a/.changeset/gtd-sidebar-merged-pr-color.md
+++ b/.changeset/gtd-sidebar-merged-pr-color.md
@@ -1,0 +1,5 @@
+---
+"@smsunarto/bb-plugin-gtd-sidebar": patch
+---
+
+Colour merged PRs purple again. After a PR leaves GitHub's open list, look it up by number instead of treating the title as still open.

--- a/.changeset/gtd-sidebar-merged-pr-list.md
+++ b/.changeset/gtd-sidebar-merged-pr-list.md
@@ -1,0 +1,5 @@
+---
+"@smsunarto/bb-plugin-gtd-sidebar": patch
+---
+
+Fix merged PR colours: list recently closed PRs, prefer the cached number over a parent `#123` in the title, and stop reusing a stale "open" cache after the PR leaves the open list.

--- a/.changeset/gtd-sidebar-open-pr-green.md
+++ b/.changeset/gtd-sidebar-open-pr-green.md
@@ -1,0 +1,5 @@
+---
+"@smsunarto/bb-plugin-gtd-sidebar": patch
+---
+
+Paint open PRs green (`text-success`), matching bb's own open-PR token, and map GitHub mergeable_state so ready, failing, blocked, and queued PRs get the right colour.

--- a/.changeset/gtd-sidebar-pr-in-app-browser.md
+++ b/.changeset/gtd-sidebar-pr-in-app-browser.md
@@ -1,0 +1,5 @@
+---
+"@smsunarto/bb-plugin-gtd-sidebar": patch
+---
+
+Open a sidebar PR number in bb's in-app thread browser. Hold any modifier key to fall back to the system browser.

--- a/.changeset/gtd-sidebar-pr-rest-index.md
+++ b/.changeset/gtd-sidebar-pr-rest-index.md
@@ -1,0 +1,5 @@
+---
+"@smsunarto/bb-plugin-gtd-sidebar": patch
+---
+
+Resolve sidebar PR numbers with one REST list per repository, a local cache, and title fallbacks. Stop calling bb's per-card GraphQL PR lookup, which burned the rate limit and blanked every badge.

--- a/.changeset/gtd-sidebar-pr-watch.md
+++ b/.changeset/gtd-sidebar-pr-watch.md
@@ -1,0 +1,5 @@
+---
+"@smsunarto/bb-plugin-gtd-sidebar": minor
+---
+
+Colour draft PRs grey and merge-queue PRs amber on the thread card. Once an hour, watch snoozed threads' GitHub PRs with one GraphQL query and unsnooze plus ping the agent when comments, reviews, checks, or deployments change, backing off when GitHub's rate limit is low.

--- a/plugins/gtd-sidebar/README.md
+++ b/plugins/gtd-sidebar/README.md
@@ -96,6 +96,16 @@ thread needs — failed, waiting on you, working, or finished while you were awa
 and its age (`now`, `7m`, `3d`) when it needs nothing. Hovering swaps that slot for
 the two park buttons.
 
+The PR number uses the same colours bb uses elsewhere: muted grey for an open
+PR, a paler grey for a **draft**, amber for a PR in the **merge queue**, purple
+for merged, red for closed or failing. Badges come from one open REST list per
+repository (not per-card GraphQL). A PR that has merged or closed drops off that
+list, so the next tick looks it up by number (from the title or the last cache)
+instead of treating the title as still open. Title text and the local cache are
+the fallback when GitHub is rate-limited. Click a number to open the PR in bb's
+in-app browser on that thread. Hold any modifier key (or click when the in-app
+browser is unavailable) to open it in the system browser instead.
+
 ### A working thread can never be parked
 
 Workflows, background agents, background commands, plan mode, and goals all count as
@@ -105,6 +115,17 @@ never hidden.
 ### Snoozing
 
 The hover button snoozes until **09:00 tomorrow**.
+
+Once an hour the plugin asks GitHub about every snoozed thread that has a pull
+request — one GraphQL query, not one call per PR. If comments, reviews, checks,
+or deployments moved, it unsnoozes the thread and sends the agent a turn naming
+what changed. The first observation is only a baseline, so a PR that already had
+comments does not wake the moment you snooze it.
+
+The watch uses the GitHub CLI (`gh auth login`) on the bb server. It skips the
+hour when GitHub's GraphQL budget is too low and waits for GitHub's own reset
+instead of retrying. Threads snoozed without a known PR are resolved a few at a
+time so a cold shelf cannot burst the REST rate limit.
 
 ### Child threads
 
@@ -142,7 +163,11 @@ hours. Older work is still settled and still archived — look for it in bb's ar
 view.
 
 **A snoozed thread came back early.** That is the design: a snoozed thread wakes when
-it starts working or asks you a question.
+it starts working, asks you a question, or its GitHub pull request changed.
+
+**Snoozed PRs never wake on GitHub activity.** The watch needs the GitHub CLI
+logged in on the machine that runs bb (`gh auth status`). It also skips an hour
+when GitHub reports too few GraphQL points remaining.
 
 **Un-settling did not bring the thread back.** Archive and unarchive run on the
 thread's host, which can be offline. When an unarchive fails, bb keeps the thread

--- a/plugins/gtd-sidebar/README.md
+++ b/plugins/gtd-sidebar/README.md
@@ -96,13 +96,16 @@ thread needs — failed, waiting on you, working, or finished while you were awa
 and its age (`now`, `7m`, `3d`) when it needs nothing. Hovering swaps that slot for
 the two park buttons.
 
-The PR number uses the same colours bb uses elsewhere: muted grey for an open
-PR, a paler grey for a **draft**, amber for a PR in the **merge queue**, purple
-for merged, red for closed or failing. Badges come from one open REST list per
-repository (not per-card GraphQL). A PR that has merged or closed drops off that
-list, so the next tick looks it up by number (from the title or the last cache)
-instead of treating the title as still open. Title text and the local cache are
-the fallback when GitHub is rate-limited. Click a number to open the PR in bb's
+The PR number uses the same colours bb uses elsewhere: green for an open
+PR, muted grey for a **draft**, amber for a PR in the **merge queue**, purple
+for merged, red for closed or failing. Badges hydrate with one REST list per
+repository when the inbox mounts (not per-card GraphQL). After that, GitHub
+webhooks update the cache and the sidebar over realtime when GitHub can reach
+this machine. Turn on **GitHub webhooks via Cloudflare** (requires
+`cloudflared` on PATH) to open a trycloudflare tunnel to a webhook-only local
+port — not the bb API, and not a bb connect URL, which GitHub cannot sign in
+to. The inbox still hydrates on mount and reconciles every 10 minutes. A PR that has merged or closed is matched from the recent
+closed list or looked up by number. Click a number to open the PR in bb's
 in-app browser on that thread. Hold any modifier key (or click when the in-app
 browser is unavailable) to open it in the system browser instead.
 
@@ -143,11 +146,18 @@ a child, a chip that names the parent and opens it.
 
 ## Configuration
 
-One setting, in **Settings → Plugins → GTD Sidebar**:
+Settings live in **Settings → Plugins → GTD Sidebar**:
 
 - **Show the agent icon on each card** — on. Turn it off to drop the trailing agent
   glyph and give the branch that space back. Every card follows it together, so the
   meta line keeps a straight right edge either way.
+- **GitHub webhooks via Cloudflare** — off. When on, the plugin checks for
+  `cloudflared` (`brew install cloudflared`) and opens a trycloudflare HTTPS
+  tunnel to a listener that only accepts signed GitHub webhook POSTs. The public
+  address changes whenever bb restarts, and GitHub hooks are updated to match.
+- **GitHub webhook public URL** — optional override if you already have an
+  unauthenticated HTTPS origin that forwards to this bb. Leave empty to use the
+  Cloudflare tunnel. `*.getbb.app` URLs cannot receive GitHub POSTs.
 
 The snooze presets assume a 09:00 morning, an 18:00 evening, and a week starting
 Monday, in your local timezone. The settled shelf reaches back 24 hours. None of
@@ -167,7 +177,8 @@ it starts working, asks you a question, or its GitHub pull request changed.
 
 **Snoozed PRs never wake on GitHub activity.** The watch needs the GitHub CLI
 logged in on the machine that runs bb (`gh auth status`). It also skips an hour
-when GitHub reports too few GraphQL points remaining.
+when GitHub reports too few GraphQL points remaining. For realtime badge updates,
+turn on **GitHub webhooks via Cloudflare** and keep `cloudflared` installed.
 
 **Un-settling did not bring the thread back.** Archive and unarchive run on the
 thread's host, which can be offline. When an unarchive fails, bb keeps the thread

--- a/plugins/gtd-sidebar/app.tsx
+++ b/plugins/gtd-sidebar/app.tsx
@@ -7,6 +7,7 @@ import { definePluginApp } from "@get-bb/plugin-sdk/app";
 import { ThreadInbox } from "@/components/inbox/thread-inbox";
 import { ParentChip } from "@/components/inbox/parent-chip";
 import { SubagentsChip } from "@/components/inbox/subagents-chip";
+import { GithubWebhookSettings } from "@/components/github-webhook-settings";
 
 export default definePluginApp((app) => {
   app.slots.experimental_threadList({
@@ -33,5 +34,12 @@ export default definePluginApp((app) => {
     id: "children",
     title: "Child threads",
     component: SubagentsChip,
+  });
+
+  app.slots.settingsSection({
+    id: "github-webhooks",
+    title: "GitHub webhooks",
+    description: "Realtime PR badges through a webhook-only Cloudflare tunnel.",
+    component: GithubWebhookSettings,
   });
 });

--- a/plugins/gtd-sidebar/components/github-webhook-settings.tsx
+++ b/plugins/gtd-sidebar/components/github-webhook-settings.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+import {
+  useRealtime,
+  useRealtimeConnectionState,
+  useRpc,
+  useSettings,
+} from "@get-bb/plugin-sdk/app";
+import type { gtdSidebarRpcContract } from "@/server";
+import { WEBHOOK_TUNNEL_CHANNEL } from "@/lib/channels";
+import {
+  WEBHOOK_TUNNEL_STATUS_OFF,
+  type WebhookTunnelStatus,
+} from "@/lib/webhook-tunnel-status";
+
+function asStatus(value: unknown): WebhookTunnelStatus | null {
+  if (typeof value !== "object" || value === null) return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.enabled !== "boolean" || typeof record.state !== "string") return null;
+  return {
+    enabled: record.enabled,
+    state: record.state as WebhookTunnelStatus["state"],
+    url: typeof record.url === "string" ? record.url : null,
+    origin: typeof record.origin === "string" ? record.origin : null,
+    error: typeof record.error === "string" ? record.error : null,
+  };
+}
+
+function statusCopy(status: WebhookTunnelStatus, enabled: boolean): string {
+  if (!enabled) {
+    return "Turn this on to check for cloudflared and open a trycloudflare HTTPS tunnel to a webhook-only local port. GitHub cannot use bb connect URLs, and the bb API port is never exposed.";
+  }
+  switch (status.state) {
+    case "checking":
+    case "starting":
+      return "Looking for cloudflared and opening a trycloudflare tunnel…";
+    case "missing-cloudflared":
+      return "cloudflared was not found. Install it with brew install cloudflared, then toggle this setting off and on.";
+    case "live":
+      return status.url === null
+        ? "The trycloudflare tunnel is up. GitHub hooks are registered against it; the address changes when bb restarts."
+        : `GitHub can reach this bb at ${status.url}. The address changes when bb restarts.`;
+    case "error":
+      return status.error ?? "The Cloudflare tunnel failed. Toggle the setting off and on to retry.";
+    default:
+      return "GitHub webhooks via Cloudflare is on. Waiting for the tunnel to start.";
+  }
+}
+
+export function GithubWebhookSettings() {
+  const { values } = useSettings();
+  const rpc = useRpc<typeof gtdSidebarRpcContract>();
+  const connection = useRealtimeConnectionState();
+  const enabled = values?.githubWebhooksViaCloudflare === true;
+  const [status, setStatus] = useState<WebhookTunnelStatus>(WEBHOOK_TUNNEL_STATUS_OFF);
+
+  useEffect(() => {
+    let cancelled = false;
+    void rpc
+      .call("githubWebhookTunnelStatus", {})
+      .then((next) => {
+        if (!cancelled) setStatus(next);
+      })
+      .catch(() => {
+        // The host-rendered toggle still works if status rpc is down.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [rpc, connection, enabled]);
+
+  useRealtime(WEBHOOK_TUNNEL_CHANNEL, (payload) => {
+    const next = asStatus(payload);
+    if (next !== null) setStatus(next);
+  });
+
+  return (
+    <div className="space-y-2 text-sm text-muted-foreground">
+      <p>{statusCopy(status, enabled)}</p>
+      {enabled && status.state === "live" && status.url !== null ? (
+        <p>
+          <code className="text-foreground">{status.url}</code>
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/plugins/gtd-sidebar/components/inbox/thread-card.tsx
+++ b/plugins/gtd-sidebar/components/inbox/thread-card.tsx
@@ -1,7 +1,7 @@
 import {
-  experimental_useSidebarThreadPullRequest as useSidebarThreadPullRequest,
   experimental_useSidebarThreadSplit as useSidebarThreadSplit,
   experimental_useSidebarThreadActions as useSidebarThreadActions,
+  useRpc,
   type PluginSidebarThread,
 } from "@get-bb/plugin-sdk/app";
 import { Icon, type IconName } from "@/components/ui/icon";
@@ -11,6 +11,15 @@ import { ProviderGlyph, type ProviderGlyphInfo } from "@/components/inbox/provid
 import { STATUS_SLOT_CLASS, StatusOrTime } from "@/components/inbox/status-slot";
 import { threadDisplayTitle } from "@/lib/inbox";
 import { resolveSnoozePresets } from "@/lib/lifecycle";
+import {
+  createInAppBrowserTab,
+  isDesktopInAppBrowserAvailable,
+  revealInAppBrowserTab,
+  shouldDeferToSystemBrowser,
+} from "@/lib/open-in-app-browser";
+import { prNumberClassName, prNumberLabel } from "@/lib/pr-status";
+import type { SidebarPullRequest } from "@/lib/pr-index";
+import type { gtdSidebarRpcContract } from "@/server";
 
 /**
  * One thread as a two-line card: title and status, then project, branch and
@@ -33,6 +42,8 @@ export function ThreadCard({
   onSettle,
   onSnooze,
   now,
+  debugPullRequests,
+  pullRequest,
 }: {
   thread: PluginSidebarThread;
   provider?: ProviderGlyphInfo;
@@ -46,15 +57,15 @@ export function ThreadCard({
   showProviderIcon: boolean;
   onNavigate: () => void;
   onSettle: () => void;
-  onSnooze: (snoozedUntil: number) => void;
+  onSnooze: (snoozedUntil: number, pullRequestUrl: string | null) => void;
   /** Quantized clock, so every card in one render agrees on "now". */
   now: number;
+  debugPullRequests: boolean;
+  pullRequest: SidebarPullRequest | null;
 }) {
   const actions = useSidebarThreadActions();
+  const rpc = useRpc<typeof gtdSidebarRpcContract>();
   const { splitProps, layout } = useSidebarThreadSplit(thread.id);
-  // Opt-in per row: this costs a git-host lookup, and threads sharing a
-  // worktree share one.
-  const { pullRequest } = useSidebarThreadPullRequest(thread.id);
 
   return (
     <RowContextMenu thread={thread}>
@@ -114,7 +125,7 @@ export function ThreadCard({
                     // pick silently becomes "Next week" every afternoon.
                     const presets = resolveSnoozePresets(new Date());
                     const tomorrow = presets.find((p) => p.id === "tomorrow");
-                    if (tomorrow) onSnooze(tomorrow.snoozedUntil);
+                    if (tomorrow) onSnooze(tomorrow.snoozedUntil, pullRequest?.url ?? null);
                   }}
                 />
                 <ParkButton label="Settle thread" icon="Check" onActivate={onSettle} />
@@ -175,21 +186,44 @@ export function ThreadCard({
                 href={pullRequest.url}
                 target="_blank"
                 rel="noreferrer"
-                onClick={(event) => event.stopPropagation()}
-                title={pullRequest.title}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  if (
+                    shouldDeferToSystemBrowser(event) ||
+                    !isDesktopInAppBrowserAvailable()
+                  ) {
+                    return;
+                  }
+                  event.preventDefault();
+                  const tab = createInAppBrowserTab({
+                    environmentId: thread.environment?.id ?? null,
+                    title: pullRequest.title,
+                    url: pullRequest.url,
+                  });
+                  revealInAppBrowserTab({ tab, threadId: thread.id });
+                  void rpc
+                    .call("openThreadBrowserTab", { tab, threadId: thread.id })
+                    .then((result) => {
+                      if (result.tab.id !== tab.id) {
+                        revealInAppBrowserTab({ tab: result.tab, threadId: thread.id });
+                      }
+                    })
+                    .catch(() => {
+                      // The local reveal still stands. A failed persist must
+                      // not bounce the click out to the system browser.
+                    });
+                  actions.open(thread.id);
+                }}
+                title={`${prNumberLabel(pullRequest)}: ${pullRequest.title}`}
                 className={cn(
-                  "relative shrink-0 font-mono hover:underline",
-                  pullRequest.state === "merged"
-                    ? "text-[color:var(--pr-merged)]"
-                    : pullRequest.attention === "checks_failed" ||
-                        pullRequest.attention === "conflicts"
-                      ? "text-destructive-text"
-                      : pullRequest.attention === "ready_to_merge"
-                        ? "text-success-foreground"
-                        : "text-muted-foreground",
+                  "pointer-events-auto relative shrink-0 font-mono hover:underline",
+                  prNumberClassName(pullRequest),
                 )}
               >
                 #{pullRequest.number}
+                {debugPullRequests ? (
+                  <span className="text-muted-foreground/70">·{pullRequest.source}</span>
+                ) : null}
               </a>
             ) : null}
             {/* Drawn for every card or for none, never per thread, so the line

--- a/plugins/gtd-sidebar/components/inbox/thread-inbox.tsx
+++ b/plugins/gtd-sidebar/components/inbox/thread-inbox.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/lib/inbox";
 import { readWarmStartProviders, writeWarmStartProviders } from "@/lib/warm-start";
 import { resolveSidebarBranchLabel } from "@/lib/gitbutler";
+import { useThreadPullRequests } from "@/hooks/use-thread-pull-requests";
 
 const ALL_PROJECTS = "__all__";
 const EMPTY_STATE_CLASS = "px-2 py-6 text-center text-xs text-muted-foreground";
@@ -83,6 +84,7 @@ export function ThreadInbox({ activeThreadId, onNavigate, searchQuery }: PluginT
   // the glyph. That way the common case never flashes it on and off.
   const { values: settingValues } = useSettings();
   const showProviderIcon = settingValues?.showProviderIcon !== false;
+  const debugPullRequests = settingValues?.debugPullRequests === true;
 
   const gitButlerEnvironmentIds = useMemo(
     () =>
@@ -159,6 +161,8 @@ export function ThreadInbox({ activeThreadId, onNavigate, searchQuery }: PluginT
   }, [rpc]);
   const [showSnoozed, setShowSnoozed] = useState(false);
   const [showSettled, setShowSettled] = useState(false);
+
+  const pullRequestByThreadId = useThreadPullRequests(threads, gitButlerLabels);
 
   const projectNameById = useMemo(
     () => new Map(projects.map((project) => [project.id, project.name])),
@@ -333,6 +337,8 @@ export function ThreadInbox({ activeThreadId, onNavigate, searchQuery }: PluginT
                     thread={thread}
                     provider={providerInfoById.get(thread.providerId)}
                     showProviderIcon={showProviderIcon}
+                    debugPullRequests={debugPullRequests}
+                    pullRequest={pullRequestByThreadId.get(thread.id) ?? null}
                     projectName={projectNameById.get(thread.projectId) ?? null}
                     branchName={resolveSidebarBranchLabel(
                       thread.environment?.branchName ?? null,
@@ -343,7 +349,9 @@ export function ThreadInbox({ activeThreadId, onNavigate, searchQuery }: PluginT
                     canPark={lifecycle.canPark(thread)}
                     onNavigate={onNavigate}
                     onSettle={() => lifecycle.settle(thread.id)}
-                    onSnooze={(until) => lifecycle.snooze(thread.id, until)}
+                    onSnooze={(until, pullRequestUrl) =>
+                      lifecycle.snooze(thread.id, until, pullRequestUrl)
+                    }
                     now={now}
                   />
                 ))}
@@ -357,6 +365,8 @@ export function ThreadInbox({ activeThreadId, onNavigate, searchQuery }: PluginT
                     thread={thread}
                     provider={providerInfoById.get(thread.providerId)}
                     showProviderIcon={showProviderIcon}
+                    debugPullRequests={debugPullRequests}
+                    pullRequest={pullRequestByThreadId.get(thread.id) ?? null}
                     projectName={projectNameById.get(thread.projectId) ?? null}
                     branchName={resolveSidebarBranchLabel(
                       thread.environment?.branchName ?? null,
@@ -367,7 +377,9 @@ export function ThreadInbox({ activeThreadId, onNavigate, searchQuery }: PluginT
                     canPark={lifecycle.canPark(thread)}
                     onNavigate={onNavigate}
                     onSettle={() => lifecycle.settle(thread.id)}
-                    onSnooze={(until) => lifecycle.snooze(thread.id, until)}
+                    onSnooze={(until, pullRequestUrl) =>
+                      lifecycle.snooze(thread.id, until, pullRequestUrl)
+                    }
                     now={now}
                   />
                 ))}
@@ -381,6 +393,8 @@ export function ThreadInbox({ activeThreadId, onNavigate, searchQuery }: PluginT
                     thread={thread}
                     provider={providerInfoById.get(thread.providerId)}
                     showProviderIcon={showProviderIcon}
+                    debugPullRequests={debugPullRequests}
+                    pullRequest={pullRequestByThreadId.get(thread.id) ?? null}
                     projectName={projectNameById.get(thread.projectId) ?? null}
                     branchName={resolveSidebarBranchLabel(
                       thread.environment?.branchName ?? null,
@@ -391,7 +405,9 @@ export function ThreadInbox({ activeThreadId, onNavigate, searchQuery }: PluginT
                     canPark={lifecycle.canPark(thread)}
                     onNavigate={onNavigate}
                     onSettle={() => lifecycle.settle(thread.id)}
-                    onSnooze={(until) => lifecycle.snooze(thread.id, until)}
+                    onSnooze={(until, pullRequestUrl) =>
+                      lifecycle.snooze(thread.id, until, pullRequestUrl)
+                    }
                     now={now}
                   />
                 ))}

--- a/plugins/gtd-sidebar/hooks/use-lifecycle.ts
+++ b/plugins/gtd-sidebar/hooks/use-lifecycle.ts
@@ -57,7 +57,7 @@ export interface LifecycleApi {
   wakeAtFor(thread: PluginSidebarThread): number | null;
   settle(threadId: string): void;
   unsettle(threadId: string): void;
-  snooze(threadId: string, snoozedUntil: number): void;
+  snooze(threadId: string, snoozedUntil: number, pullRequestUrl?: string | null): void;
   unsnooze(threadId: string): void;
 }
 
@@ -250,8 +250,12 @@ export function useLifecycle(threads: readonly PluginSidebarThread[]): Lifecycle
       settle: (threadId) => void mutate("settle", threadId),
       unsettle: (threadId) => void mutate("unsettle", threadId),
       unsnooze: (threadId) => void mutate("unsnooze", threadId),
-      snooze: (threadId, snoozedUntil) => {
-        void rpc.call("snooze", { threadId, snoozedUntil });
+      snooze: (threadId, snoozedUntil, pullRequestUrl) => {
+        void rpc.call("snooze", {
+          threadId,
+          snoozedUntil,
+          ...(pullRequestUrl ? { pullRequestUrl } : {}),
+        });
       },
     };
   }, [now, parkedThreadIds, rows, rpc, shelvesReady]);

--- a/plugins/gtd-sidebar/hooks/use-thread-pull-requests.ts
+++ b/plugins/gtd-sidebar/hooks/use-thread-pull-requests.ts
@@ -1,0 +1,90 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useRpc } from "@get-bb/plugin-sdk/app";
+import type { PluginSidebarThread } from "@get-bb/plugin-sdk";
+import type { gtdSidebarRpcContract } from "@/server";
+import { threadDisplayTitle } from "@/lib/inbox";
+import { resolveSidebarBranchLabel } from "@/lib/gitbutler";
+import type { SidebarPullRequest } from "@/lib/pr-index";
+
+const PR_INDEX_REFRESH_MS = 2 * 60_000;
+
+export function useThreadPullRequests(
+  threads: readonly PluginSidebarThread[],
+  gitButlerLabels: ReadonlyMap<string, string>,
+): ReadonlyMap<string, SidebarPullRequest> {
+  const rpc = useRpc<typeof gtdSidebarRpcContract>();
+  const [byThreadId, setByThreadId] = useState<ReadonlyMap<string, SidebarPullRequest>>(
+    () => new Map(),
+  );
+
+  const payload = useMemo(
+    () =>
+      threads.slice(0, 100).map((thread) => ({
+        threadId: thread.id,
+        environmentId: thread.environment?.id ?? null,
+        branchName: resolveSidebarBranchLabel(
+          thread.environment?.branchName ?? null,
+          thread.environment?.id ?? null,
+          gitButlerLabels,
+        ),
+        title: threadDisplayTitle(thread),
+      })),
+    [gitButlerLabels, threads],
+  );
+  const payloadKey = useMemo(
+    () =>
+      payload
+        .map(
+          (row) =>
+            `${row.threadId}:${row.environmentId ?? ""}:${row.branchName ?? ""}:${row.title}`,
+        )
+        .join("\n"),
+    [payload],
+  );
+
+  const payloadRef = useRef(payload);
+  payloadRef.current = payload;
+
+  useEffect(() => {
+    const current = payloadRef.current;
+    if (current.length === 0) {
+      setByThreadId(new Map());
+      return;
+    }
+    let cancelled = false;
+    const refresh = async () => {
+      try {
+        const result = await rpc.call("listThreadPullRequests", {
+          threads: payloadRef.current,
+        });
+        if (cancelled) return;
+        setByThreadId(
+          new Map(
+            result.pullRequests.map((row) => [
+              row.threadId,
+              {
+                number: row.number,
+                title: row.title,
+                url: row.url,
+                state: row.state as SidebarPullRequest["state"],
+                attention: row.attention,
+                source: row.source,
+              },
+            ]),
+          ),
+        );
+      } catch {
+        // Keep the last index. A failed tick must not blank badges that were
+        // already on screen.
+      }
+    };
+    void refresh();
+    const timer = setInterval(() => void refresh(), PR_INDEX_REFRESH_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [payloadKey, rpc]);
+
+  return byThreadId;
+}

--- a/plugins/gtd-sidebar/hooks/use-thread-pull-requests.ts
+++ b/plugins/gtd-sidebar/hooks/use-thread-pull-requests.ts
@@ -1,12 +1,58 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useRpc } from "@get-bb/plugin-sdk/app";
+import {
+  useRealtime,
+  useRealtimeConnectionState,
+  useRpc,
+} from "@get-bb/plugin-sdk/app";
 import type { PluginSidebarThread } from "@get-bb/plugin-sdk";
 import type { gtdSidebarRpcContract } from "@/server";
+import { PR_INDEX_CHANNEL } from "@/lib/channels";
 import { threadDisplayTitle } from "@/lib/inbox";
 import { resolveSidebarBranchLabel } from "@/lib/gitbutler";
 import type { SidebarPullRequest } from "@/lib/pr-index";
 
-const PR_INDEX_REFRESH_MS = 2 * 60_000;
+function branchNamesFor(
+  thread: PluginSidebarThread,
+  gitButlerLabels: ReadonlyMap<string, string>,
+): string[] {
+  const raw = thread.environment?.branchName?.trim() ?? "";
+  const label =
+    resolveSidebarBranchLabel(
+      thread.environment?.branchName ?? null,
+      thread.environment?.id ?? null,
+      gitButlerLabels,
+    )?.trim() ?? "";
+  const names: string[] = [];
+  if (raw.length > 0) names.push(raw);
+  if (label.length > 0 && label !== raw) names.push(label);
+  return names;
+}
+
+interface IndexRow {
+  environmentId: string;
+  number: number;
+  title: string;
+  url: string;
+  state: string;
+  attention: string;
+}
+
+function asIndexRow(value: unknown): IndexRow | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.environmentId !== "string") return null;
+  if (typeof record.number !== "number" || typeof record.title !== "string") return null;
+  if (typeof record.url !== "string" || typeof record.state !== "string") return null;
+  if (typeof record.attention !== "string") return null;
+  return {
+    environmentId: record.environmentId,
+    number: record.number,
+    title: record.title,
+    url: record.url,
+    state: record.state,
+    attention: record.attention,
+  };
+}
 
 export function useThreadPullRequests(
   threads: readonly PluginSidebarThread[],
@@ -22,11 +68,8 @@ export function useThreadPullRequests(
       threads.slice(0, 100).map((thread) => ({
         threadId: thread.id,
         environmentId: thread.environment?.id ?? null,
-        branchName: resolveSidebarBranchLabel(
-          thread.environment?.branchName ?? null,
-          thread.environment?.id ?? null,
-          gitButlerLabels,
-        ),
+        branchName: thread.environment?.branchName ?? null,
+        branchNames: branchNamesFor(thread, gitButlerLabels),
         title: threadDisplayTitle(thread),
       })),
     [gitButlerLabels, threads],
@@ -36,7 +79,7 @@ export function useThreadPullRequests(
       payload
         .map(
           (row) =>
-            `${row.threadId}:${row.environmentId ?? ""}:${row.branchName ?? ""}:${row.title}`,
+            `${row.threadId}:${row.environmentId ?? ""}:${row.branchName ?? ""}:${row.branchNames.join(",")}:${row.title}`,
         )
         .join("\n"),
     [payload],
@@ -45,46 +88,100 @@ export function useThreadPullRequests(
   const payloadRef = useRef(payload);
   payloadRef.current = payload;
 
-  useEffect(() => {
+  const refresh = useRef<() => Promise<void>>(async () => {});
+  refresh.current = async () => {
     const current = payloadRef.current;
     if (current.length === 0) {
       setByThreadId(new Map());
       return;
     }
+    try {
+      const result = await rpc.call("listThreadPullRequests", {
+        threads: current,
+      });
+      setByThreadId(
+        new Map(
+          result.pullRequests.map((row) => [
+            row.threadId,
+            {
+              number: row.number,
+              title: row.title,
+              url: row.url,
+              state: row.state as SidebarPullRequest["state"],
+              attention: row.attention,
+              source: row.source,
+            },
+          ]),
+        ),
+      );
+    } catch {
+      // Keep the last index. A failed hydrate must not blank badges.
+    }
+  };
+
+  useEffect(() => {
     let cancelled = false;
-    const refresh = async () => {
-      try {
-        const result = await rpc.call("listThreadPullRequests", {
-          threads: payloadRef.current,
-        });
-        if (cancelled) return;
-        setByThreadId(
-          new Map(
-            result.pullRequests.map((row) => [
-              row.threadId,
-              {
-                number: row.number,
-                title: row.title,
-                url: row.url,
-                state: row.state as SidebarPullRequest["state"],
-                attention: row.attention,
-                source: row.source,
-              },
-            ]),
-          ),
-        );
-      } catch {
-        // Keep the last index. A failed tick must not blank badges that were
-        // already on screen.
-      }
-    };
-    void refresh();
-    const timer = setInterval(() => void refresh(), PR_INDEX_REFRESH_MS);
+    void refresh.current();
+    // Reconcile rarely: GitHub webhooks drive live colour, but delivery can
+    // miss (bb connect is session-gated, so hooks may not be registered).
+    const timer = setInterval(() => {
+      if (!cancelled) void refresh.current();
+    }, 10 * 60_000);
     return () => {
       cancelled = true;
       clearInterval(timer);
     };
   }, [payloadKey, rpc]);
+
+  useRealtime(PR_INDEX_CHANNEL, (payloadValue) => {
+    if (typeof payloadValue !== "object" || payloadValue === null || Array.isArray(payloadValue)) {
+      void refresh.current();
+      return;
+    }
+    const record = payloadValue as Record<string, unknown>;
+    if (record.refresh === true) {
+      void refresh.current();
+      return;
+    }
+    if (!Array.isArray(record.rows)) {
+      void refresh.current();
+      return;
+    }
+    const rows = record.rows.flatMap((entry) => {
+      const row = asIndexRow(entry);
+      return row === null ? [] : [row];
+    });
+    if (rows.length === 0) return;
+    const byEnv = new Map(rows.map((row) => [row.environmentId, row]));
+    setByThreadId((prev) => {
+      const next = new Map(prev);
+      for (const thread of payloadRef.current) {
+        if (thread.environmentId === null) continue;
+        const row = byEnv.get(thread.environmentId);
+        if (row === undefined) continue;
+        next.set(thread.threadId, {
+          number: row.number,
+          title: row.title,
+          url: row.url,
+          state: row.state as SidebarPullRequest["state"],
+          attention: row.attention,
+          source: "rest",
+        });
+      }
+      return next;
+    });
+  });
+
+  const connectionState = useRealtimeConnectionState();
+  const seenConnected = useRef(false);
+  useEffect(() => {
+    if (connectionState !== "connected") return;
+    if (!seenConnected.current) {
+      seenConnected.current = true;
+      return;
+    }
+    void refresh.current();
+  }, [connectionState]);
 
   return byThreadId;
 }

--- a/plugins/gtd-sidebar/hooks/use-thread-pull-requests.ts
+++ b/plugins/gtd-sidebar/hooks/use-thread-pull-requests.ts
@@ -87,18 +87,21 @@ export function useThreadPullRequests(
 
   const payloadRef = useRef(payload);
   payloadRef.current = payload;
+  const refreshGeneration = useRef(0);
 
   const refresh = useRef<() => Promise<void>>(async () => {});
   refresh.current = async () => {
     const current = payloadRef.current;
+    const generation = ++refreshGeneration.current;
     if (current.length === 0) {
-      setByThreadId(new Map());
+      if (generation === refreshGeneration.current) setByThreadId(new Map());
       return;
     }
     try {
       const result = await rpc.call("listThreadPullRequests", {
         threads: current,
       });
+      if (generation !== refreshGeneration.current) return;
       setByThreadId(
         new Map(
           result.pullRequests.map((row) => [

--- a/plugins/gtd-sidebar/host.ts
+++ b/plugins/gtd-sidebar/host.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { experimental_defineHostEntry } from "@get-bb/plugin-sdk/host";
 import { gitButlerHostContract, parseGitButlerBranchSummary } from "./lib/gitbutler.ts";
+import { parseGithubRemote } from "./lib/github-repo.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -22,6 +23,21 @@ export default experimental_defineHostEntry({
         // A regular repository, a host without `but`, and a stopped GitButler
         // project all keep bb's own branch label. This probe is an enhancement.
         return { label: null };
+      }
+    },
+    async githubRepoContext({ cwd }, context) {
+      try {
+        const { stdout } = await execFileAsync("git", ["remote", "get-url", "origin"], {
+          cwd,
+          encoding: "utf8",
+          maxBuffer: 64 * 1024,
+          signal: context.signal,
+          timeout: 5_000,
+        });
+        const parsed = parseGithubRemote(stdout.trim());
+        return { owner: parsed?.owner ?? null, repo: parsed?.repo ?? null };
+      } catch {
+        return { owner: null, repo: null };
       }
     },
   },

--- a/plugins/gtd-sidebar/lib/channels.ts
+++ b/plugins/gtd-sidebar/lib/channels.ts
@@ -1,0 +1,6 @@
+/** Channel the frontend re-reads lifecycle rows on. */
+export const LIFECYCLE_CHANNEL = "lifecycle";
+/** Channel the inbox re-reads PR badges on. */
+export const PR_INDEX_CHANNEL = "pr-index";
+/** Channel the settings page re-reads the Cloudflare webhook tunnel on. */
+export const WEBHOOK_TUNNEL_CHANNEL = "webhook-tunnel";

--- a/plugins/gtd-sidebar/lib/cloudflared.ts
+++ b/plugins/gtd-sidebar/lib/cloudflared.ts
@@ -1,0 +1,171 @@
+import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export const CLOUDFLARED_CANDIDATES = [
+  "cloudflared",
+  "/opt/homebrew/bin/cloudflared",
+  "/usr/local/bin/cloudflared",
+  "/usr/bin/cloudflared",
+] as const;
+
+const TRYCLOUDFLARE_URL = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/i;
+
+export function parseTrycloudflareOrigin(text: string): string | null {
+  const match = text.match(TRYCLOUDFLARE_URL);
+  if (match === null || match[0] === undefined) return null;
+  try {
+    return new URL(match[0]).origin;
+  } catch {
+    return null;
+  }
+}
+
+type ExecResult = { stdout: string; stderr: string; exitCode: number };
+
+function exec(
+  file: string,
+  args: readonly string[],
+  timeoutMs: number,
+  signal: AbortSignal,
+): Promise<ExecResult> {
+  return new Promise((resolve) => {
+    execFile(
+      file,
+      [...args],
+      { timeout: timeoutMs, maxBuffer: 256 * 1024, signal },
+      (error, stdout, stderr) => {
+        const exitCode =
+          error && "code" in error && typeof error.code === "number" ? error.code : error ? 1 : 0;
+        resolve({
+          stdout: typeof stdout === "string" ? stdout : "",
+          stderr: typeof stderr === "string" ? stderr : "",
+          exitCode: error && (error as NodeJS.ErrnoException).code === "ABORT_ERR" ? 1 : exitCode,
+        });
+      },
+    );
+  });
+}
+
+export async function resolveCloudflaredPath(
+  signal: AbortSignal,
+  run: (
+    file: string,
+    args: readonly string[],
+    timeoutMs: number,
+    signal: AbortSignal,
+  ) => Promise<Pick<ExecResult, "exitCode">> = exec,
+): Promise<string | null> {
+  for (const candidate of CLOUDFLARED_CANDIDATES) {
+    const result = await run(candidate, ["--version"], 5_000, signal);
+    if (result.exitCode === 0) return candidate;
+  }
+  return null;
+}
+
+function stopChild(child: ChildProcess): void {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill("SIGTERM");
+  const killer = setTimeout(() => {
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+  }, 2_000);
+  killer.unref();
+}
+
+export interface TrycloudflareTunnel {
+  origin: string;
+  wait: Promise<number>;
+  stop: () => void;
+}
+
+export async function startTrycloudflareTunnel(args: {
+  bin: string;
+  localOrigin: string;
+  signal: AbortSignal;
+  timeoutMs?: number;
+  spawnImpl?: typeof spawn;
+}): Promise<TrycloudflareTunnel> {
+  if (args.signal.aborted) throw new Error("aborted");
+  const spawnFn = args.spawnImpl ?? spawn;
+  // ~/.cloudflared/config.yml is for named tunnels and often ends in a
+  // catch-all 404. Quick tunnels must not inherit it.
+  const configDir = await mkdtemp(join(tmpdir(), "gtd-cloudflared-"));
+  const configPath = join(configDir, "config.yml");
+  await writeFile(configPath, "# gtd-sidebar webhook quick tunnel\n", "utf8");
+  const child = spawnFn(
+    args.bin,
+    ["tunnel", "--no-autoupdate", "--config", configPath, "--url", args.localOrigin],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+
+  const wait = new Promise<number>((resolve) => {
+    child.once("exit", (code, signal) => {
+      void rm(configDir, { recursive: true, force: true });
+      if (typeof code === "number") resolve(code);
+      else resolve(signal === "SIGTERM" || signal === "SIGINT" ? 0 : 1);
+    });
+    child.once("error", () => {
+      void rm(configDir, { recursive: true, force: true });
+      resolve(1);
+    });
+  });
+
+  const stop = () => stopChild(child);
+  args.signal.addEventListener("abort", stop, { once: true });
+
+  let origin: string | null = null;
+  let log = "";
+  const take = (chunk: string) => {
+    log += chunk;
+    if (log.length > 32_768) log = log.slice(-16_384);
+    if (origin === null) origin = parseTrycloudflareOrigin(chunk);
+  };
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+
+  const timeoutMs = args.timeoutMs ?? 45_000;
+  const found = await new Promise<string>((resolve, reject) => {
+    let settled = false;
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      args.signal.removeEventListener("abort", onAbort);
+      child.off("exit", onExit);
+      fn();
+    };
+    const onAbort = () =>
+      finish(() => {
+        stop();
+        reject(new Error("aborted"));
+      });
+    const onExit = (code: number | null) =>
+      finish(() => {
+        reject(
+          new Error(
+            `cloudflared exited ${code ?? 1} before publishing a URL${log.trim().length > 0 ? `: ${log.trim()}` : ""}`,
+          ),
+        );
+      });
+    const timer = setTimeout(() => {
+      finish(() => {
+        stop();
+        reject(new Error(`cloudflared did not print a trycloudflare URL within ${timeoutMs}ms`));
+      });
+    }, timeoutMs);
+    const onData = (chunk: string) => {
+      take(chunk);
+      const foundOrigin = origin;
+      if (foundOrigin !== null) finish(() => resolve(foundOrigin));
+    };
+    child.stdout?.on("data", onData);
+    child.stderr?.on("data", onData);
+    child.once("exit", onExit);
+    args.signal.addEventListener("abort", onAbort, { once: true });
+    const already = origin;
+    if (already !== null) finish(() => resolve(already));
+  });
+
+  return { origin: found, wait, stop };
+}

--- a/plugins/gtd-sidebar/lib/gh-cli.ts
+++ b/plugins/gtd-sidebar/lib/gh-cli.ts
@@ -1,0 +1,92 @@
+import { execFile } from "node:child_process";
+
+const GH_CANDIDATES = ["gh", "/opt/homebrew/bin/gh", "/usr/local/bin/gh"];
+
+export interface GhCommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface GhRunner {
+  run(args: readonly string[], timeoutMs?: number): Promise<GhCommandResult>;
+}
+
+function exec(
+  file: string,
+  args: readonly string[],
+  timeoutMs: number,
+  signal: AbortSignal,
+): Promise<GhCommandResult> {
+  return new Promise((resolve) => {
+    execFile(
+      file,
+      [...args],
+      { timeout: timeoutMs, maxBuffer: 8 * 1024 * 1024, signal },
+      (error, stdout, stderr) => {
+        const exitCode =
+          error && "code" in error && typeof error.code === "number" ? error.code : error ? 1 : 0;
+        resolve({
+          stdout: typeof stdout === "string" ? stdout : "",
+          stderr: typeof stderr === "string" ? stderr : "",
+          exitCode: error && (error as NodeJS.ErrnoException).code === "ABORT_ERR" ? 1 : exitCode,
+        });
+      },
+    );
+  });
+}
+
+export async function resolveGhPath(signal: AbortSignal): Promise<string | null> {
+  for (const candidate of GH_CANDIDATES) {
+    const result = await exec(candidate, ["--version"], 5_000, signal);
+    if (result.exitCode === 0) return candidate;
+  }
+  return null;
+}
+
+export function createGhRunner(signal: AbortSignal, path: string): GhRunner {
+  return {
+    run(args, timeoutMs = 30_000) {
+      return exec(path, args, timeoutMs, signal);
+    },
+  };
+}
+
+export async function githubRestJson(
+  gh: GhRunner,
+  path: string,
+  timeoutMs = 20_000,
+): Promise<{ raw: unknown; stdout: string; stderr: string; exitCode: number }> {
+  const result = await gh.run(["api", "--hostname", "github.com", path], timeoutMs);
+  let raw: unknown = null;
+  const trimmed = result.stdout.trim();
+  if (trimmed.length > 0) {
+    try {
+      raw = JSON.parse(trimmed);
+    } catch {
+      raw = null;
+    }
+  }
+  return { raw, stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode };
+}
+
+export async function githubGraphql(
+  gh: GhRunner,
+  query: string,
+  timeoutMs = 30_000,
+): Promise<{ raw: unknown; stdout: string; stderr: string; exitCode: number }> {
+  const result = await gh.run(
+    ["api", "graphql", "--hostname", "github.com", "-f", `query=${query}`],
+    timeoutMs,
+  );
+  let raw: unknown = null;
+  const trimmed = result.stdout.trim();
+  if (trimmed.length > 0) {
+    try {
+      raw = JSON.parse(trimmed);
+    } catch {
+      raw = null;
+    }
+  }
+  return { raw, stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode };
+}

--- a/plugins/gtd-sidebar/lib/gh-cli.ts
+++ b/plugins/gtd-sidebar/lib/gh-cli.ts
@@ -1,4 +1,8 @@
 import { execFile } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const GH_CANDIDATES = ["gh", "/opt/homebrew/bin/gh", "/usr/local/bin/gh"];
 
@@ -56,18 +60,34 @@ export async function githubRestJson(
   gh: GhRunner,
   path: string,
   timeoutMs = 20_000,
+  init?: { method?: string; body?: unknown },
 ): Promise<{ raw: unknown; stdout: string; stderr: string; exitCode: number }> {
-  const result = await gh.run(["api", "--hostname", "github.com", path], timeoutMs);
-  let raw: unknown = null;
-  const trimmed = result.stdout.trim();
-  if (trimmed.length > 0) {
-    try {
-      raw = JSON.parse(trimmed);
-    } catch {
-      raw = null;
-    }
+  const args = ["api", "--hostname", "github.com"];
+  if (init?.method !== undefined && init.method !== "GET") {
+    args.push("--method", init.method);
   }
-  return { raw, stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode };
+  let inputPath: string | null = null;
+  if (init?.body !== undefined) {
+    inputPath = join(tmpdir(), `gtd-gh-${randomBytes(8).toString("hex")}.json`);
+    await writeFile(inputPath, JSON.stringify(init.body), "utf8");
+    args.push("--input", inputPath);
+  }
+  args.push(path);
+  try {
+    const result = await gh.run(args, timeoutMs);
+    let raw: unknown = null;
+    const trimmed = result.stdout.trim();
+    if (trimmed.length > 0) {
+      try {
+        raw = JSON.parse(trimmed);
+      } catch {
+        raw = null;
+      }
+    }
+    return { raw, stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode };
+  } finally {
+    if (inputPath !== null) await unlink(inputPath).catch(() => undefined);
+  }
 }
 
 export async function githubGraphql(

--- a/plugins/gtd-sidebar/lib/gitbutler.ts
+++ b/plugins/gtd-sidebar/lib/gitbutler.ts
@@ -8,6 +8,15 @@ export const gitButlerHostContract = defineRpcContract({
       label: z.string().nullable(),
     }),
   },
+  githubRepoContext: {
+    input: z.object({ cwd: z.string().trim().min(1) }).strict(),
+    output: z
+      .object({
+        owner: z.string().nullable(),
+        repo: z.string().nullable(),
+      })
+      .strict(),
+  },
 });
 
 export interface GitButlerBranchSummary {

--- a/plugins/gtd-sidebar/lib/github-hooks.ts
+++ b/plugins/gtd-sidebar/lib/github-hooks.ts
@@ -35,19 +35,16 @@ export async function ensureGithubRepoHook(
   }
   const needsUrl = existing.url !== url;
   const needsEvents = !eventsMatch(existing.events, GITHUB_WEBHOOK_EVENTS);
-  if (!needsUrl && !needsEvents) return "unchanged";
+  // GitHub never echoes the secret, so an uninstall that minted a new KV
+  // secret would otherwise leave deliveries failing HMAC while we report
+  // unchanged. Always PATCH config (url + secret) when we already own the hook.
   const patched = await githubRestJson(
     gh,
     `repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.repo)}/hooks/${existing.id}`,
     15_000,
-    {
-      method: "PATCH",
-      body: needsUrl
-        ? createBody
-        : { events: [...GITHUB_WEBHOOK_EVENTS], active: true },
-    },
+    { method: "PATCH", body: createBody },
   );
   if (patched.exitCode === 403) return "denied";
   if (patched.exitCode !== 0) return "error";
-  return "updated";
+  return needsUrl || needsEvents ? "updated" : "unchanged";
 }

--- a/plugins/gtd-sidebar/lib/github-hooks.ts
+++ b/plugins/gtd-sidebar/lib/github-hooks.ts
@@ -1,0 +1,53 @@
+import type { GithubRepo } from "./github-repo.ts";
+import {
+  eventsMatch,
+  GITHUB_WEBHOOK_EVENTS,
+  matchingManagedGithubHook,
+  webhookHookBody,
+} from "./github-webhook.ts";
+import { githubRestJson, type GhRunner } from "./gh-cli.ts";
+
+export type EnsureHookResult = "created" | "updated" | "unchanged" | "denied" | "error";
+
+export async function ensureGithubRepoHook(
+  gh: GhRunner,
+  repo: GithubRepo,
+  url: string,
+  secret: string,
+  previousUrl?: string | null,
+): Promise<EnsureHookResult> {
+  const listPath = `repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.repo)}/hooks?per_page=100`;
+  const listed = await githubRestJson(gh, listPath, 15_000);
+  if (listed.exitCode === 403) return "denied";
+  if (listed.exitCode !== 0) return "error";
+  const existing = matchingManagedGithubHook(listed.raw, url, previousUrl);
+  const createBody = webhookHookBody(url, secret);
+  if (existing === null) {
+    const created = await githubRestJson(
+      gh,
+      `repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.repo)}/hooks`,
+      15_000,
+      { method: "POST", body: createBody },
+    );
+    if (created.exitCode === 403) return "denied";
+    if (created.exitCode !== 0) return "error";
+    return "created";
+  }
+  const needsUrl = existing.url !== url;
+  const needsEvents = !eventsMatch(existing.events, GITHUB_WEBHOOK_EVENTS);
+  if (!needsUrl && !needsEvents) return "unchanged";
+  const patched = await githubRestJson(
+    gh,
+    `repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.repo)}/hooks/${existing.id}`,
+    15_000,
+    {
+      method: "PATCH",
+      body: needsUrl
+        ? createBody
+        : { events: [...GITHUB_WEBHOOK_EVENTS], active: true },
+    },
+  );
+  if (patched.exitCode === 403) return "denied";
+  if (patched.exitCode !== 0) return "error";
+  return "updated";
+}

--- a/plugins/gtd-sidebar/lib/github-repo.ts
+++ b/plugins/gtd-sidebar/lib/github-repo.ts
@@ -1,0 +1,46 @@
+/**
+ * GitHub identity that can be read without the GitHub API: a git remote, or a
+ * `owner/repo#123` / `#123` mention in a thread title.
+ */
+
+export interface GithubRepo {
+  owner: string;
+  repo: string;
+}
+
+export interface ParsedPrRef {
+  owner: string | null;
+  repo: string | null;
+  number: number;
+}
+
+const GITHUB_REMOTE = /(?:github\.com[:/]|git@github\.com:)([^/\s]+)\/([^/\s]+?)(?:\.git)?\/?$/i;
+const TITLE_OWNER_REPO_PR = /\b([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)#(\d+)\b/;
+const TITLE_BARE_PR = /(?:\bPR\s*|#)(\d+)\b/i;
+
+export function parseGithubRemote(url: string): GithubRepo | null {
+  const match = url.trim().match(GITHUB_REMOTE);
+  if (match === null) return null;
+  const owner = match[1];
+  const repo = match[2]?.replace(/\.git$/i, "");
+  if (!owner || !repo) return null;
+  return { owner, repo };
+}
+
+export function parsePrRefFromTitle(title: string): ParsedPrRef | null {
+  const named = title.match(TITLE_OWNER_REPO_PR);
+  if (named !== null) {
+    const number = Number(named[3]);
+    if (!Number.isInteger(number) || number < 1) return null;
+    return { owner: named[1] ?? null, repo: named[2] ?? null, number };
+  }
+  const bare = title.match(TITLE_BARE_PR);
+  if (bare === null) return null;
+  const number = Number(bare[1]);
+  if (!Number.isInteger(number) || number < 1) return null;
+  return { owner: null, repo: null, number };
+}
+
+export function githubPullUrl(owner: string, repo: string, number: number): string {
+  return `https://github.com/${owner}/${repo}/pull/${number}`;
+}

--- a/plugins/gtd-sidebar/lib/github-webhook-tunnel.ts
+++ b/plugins/gtd-sidebar/lib/github-webhook-tunnel.ts
@@ -163,7 +163,26 @@ export async function maintainCloudflareWebhookTunnel(args: {
           error: null,
         });
         args.log.info(`github webhooks: trycloudflare ${url}`);
-        await Promise.race([tunnel.wait, waitUntilAborted(run.signal)]);
+        const stopped = await Promise.race([
+          tunnel.wait.then((code) => ({ kind: "exit" as const, code })),
+          waitUntilAborted(run.signal).then(() => ({ kind: "abort" as const })),
+        ]);
+        if (
+          stopped.kind === "exit" &&
+          !run.signal.aborted &&
+          !args.signal.aborted
+        ) {
+          const message = `cloudflared exited ${stopped.code}`;
+          args.log.warn(`github webhook tunnel: ${message}`);
+          args.onStatus({
+            enabled: true,
+            state: "error",
+            url: null,
+            origin: null,
+            error: message,
+          });
+          await sleep(retryDelayMs, args.signal);
+        }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         if (!run.signal.aborted && !args.signal.aborted) {

--- a/plugins/gtd-sidebar/lib/github-webhook-tunnel.ts
+++ b/plugins/gtd-sidebar/lib/github-webhook-tunnel.ts
@@ -1,0 +1,197 @@
+import {
+  dedicatedGithubWebhookUrl,
+  shouldStartCloudflareTunnel,
+} from "./github-webhook.ts";
+import {
+  resolveCloudflaredPath,
+  startTrycloudflareTunnel,
+  type TrycloudflareTunnel,
+} from "./cloudflared.ts";
+import {
+  startWebhookListener,
+  type WebhookRequestHandler,
+} from "./webhook-listener.ts";
+import type { WebhookTunnelStatus } from "./webhook-tunnel-status.ts";
+
+export type { WebhookTunnelStatus, WebhookTunnelState } from "./webhook-tunnel-status.ts";
+export { WEBHOOK_TUNNEL_STATUS_OFF } from "./webhook-tunnel-status.ts";
+
+export function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function waitUntilAborted(signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    signal.addEventListener("abort", () => resolve(), { once: true });
+  });
+}
+
+export async function maintainCloudflareWebhookTunnel(args: {
+  signal: AbortSignal;
+  readSettings: () => Promise<{ enabled: boolean; configuredOrigin: string }>;
+  onSettingsChange: (listener: () => void) => () => void;
+  handle: WebhookRequestHandler;
+  onLive: (info: { origin: string; url: string }) => void;
+  onStopped: () => void;
+  onStatus: (status: WebhookTunnelStatus) => void;
+  log: { info(message: string): void; warn(message: string): void };
+  resolveBin?: typeof resolveCloudflaredPath;
+  startListener?: typeof startWebhookListener;
+  startTunnel?: typeof startTrycloudflareTunnel;
+  retryDelayMs?: number;
+}): Promise<void> {
+  const resolveBin = args.resolveBin ?? resolveCloudflaredPath;
+  const startListener = args.startListener ?? startWebhookListener;
+  const startTunnel = args.startTunnel ?? startTrycloudflareTunnel;
+  const retryDelayMs = args.retryDelayMs ?? 5_000;
+
+  let settingsWaiters: Array<() => void> = [];
+  let activeRun: AbortController | null = null;
+  const unsubscribe = args.onSettingsChange(() => {
+    const waiters = settingsWaiters;
+    settingsWaiters = [];
+    for (const wake of waiters) wake();
+    void args.readSettings().then((next) => {
+      if (!shouldStartCloudflareTunnel(next.enabled, next.configuredOrigin)) {
+        activeRun?.abort();
+      }
+    });
+  });
+  const waitForSettings = () =>
+    new Promise<void>((resolve) => {
+      if (args.signal.aborted) {
+        resolve();
+        return;
+      }
+      const onAbort = () => {
+        args.signal.removeEventListener("abort", onAbort);
+        resolve();
+      };
+      args.signal.addEventListener("abort", onAbort, { once: true });
+      settingsWaiters.push(() => {
+        args.signal.removeEventListener("abort", onAbort);
+        resolve();
+      });
+    });
+
+  try {
+    while (!args.signal.aborted) {
+      const settings = await args.readSettings();
+      if (!shouldStartCloudflareTunnel(settings.enabled, settings.configuredOrigin)) {
+        args.onStopped();
+        args.onStatus({
+          enabled: settings.enabled,
+          state: "off",
+          url: null,
+          origin: null,
+          error: null,
+        });
+        await waitForSettings();
+        continue;
+      }
+
+      args.onStatus({
+        enabled: true,
+        state: "checking",
+        url: null,
+        origin: null,
+        error: null,
+      });
+      const bin = await resolveBin(args.signal);
+      if (args.signal.aborted) return;
+      if (bin === null) {
+        args.log.warn(
+          "github webhooks: cloudflared not found. Install it with `brew install cloudflared`, then toggle the setting off and on.",
+        );
+        args.onStatus({
+          enabled: true,
+          state: "missing-cloudflared",
+          url: null,
+          origin: null,
+          error: "cloudflared not found on PATH",
+        });
+        await waitForSettings();
+        continue;
+      }
+
+      const run = new AbortController();
+      activeRun = run;
+      const stopRun = () => run.abort();
+      args.signal.addEventListener("abort", stopRun);
+
+      let listener: { port: number; close: () => Promise<void> } | null = null;
+      let tunnel: TrycloudflareTunnel | null = null;
+      try {
+        args.onStatus({
+          enabled: true,
+          state: "starting",
+          url: null,
+          origin: null,
+          error: null,
+        });
+        listener = await startListener({ handle: args.handle, signal: run.signal });
+        tunnel = await startTunnel({
+          bin,
+          localOrigin: `http://127.0.0.1:${listener.port}`,
+          signal: run.signal,
+        });
+        const url = dedicatedGithubWebhookUrl(tunnel.origin);
+        args.onLive({ origin: tunnel.origin, url });
+        args.onStatus({
+          enabled: true,
+          state: "live",
+          url,
+          origin: tunnel.origin,
+          error: null,
+        });
+        args.log.info(`github webhooks: trycloudflare ${url}`);
+        await Promise.race([tunnel.wait, waitUntilAborted(run.signal)]);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!run.signal.aborted && !args.signal.aborted) {
+          args.log.warn(`github webhook tunnel: ${message}`);
+          args.onStatus({
+            enabled: true,
+            state: "error",
+            url: null,
+            origin: null,
+            error: message,
+          });
+          await sleep(retryDelayMs, args.signal);
+        }
+      } finally {
+        args.signal.removeEventListener("abort", stopRun);
+        if (activeRun === run) activeRun = null;
+        args.onStopped();
+        tunnel?.stop();
+        if (listener !== null) {
+          try {
+            await listener.close();
+          } catch {
+            // Listener already closed on abort.
+          }
+        }
+      }
+    }
+  } finally {
+    unsubscribe();
+  }
+}

--- a/plugins/gtd-sidebar/lib/github-webhook.ts
+++ b/plugins/gtd-sidebar/lib/github-webhook.ts
@@ -1,0 +1,280 @@
+/**
+ * GitHub webhook signature, URL, and payload helpers.
+ *
+ * Plugin HTTP `auth: "none"` is only for signature-verified webhooks. The
+ * secret lives in plugin KV. A dedicated trycloudflare listener serves
+ * `/github-webhook`; a manual public origin that forwards to bb uses
+ * `/api/v1/plugins/<id>/http/github-webhook`.
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { parseRestPull, sidebarPrFromRest, type RestPull } from "./pr-index.ts";
+import type { GithubRepo } from "./github-repo.ts";
+
+export const GITHUB_WEBHOOK_EVENTS = [
+  "pull_request",
+  "pull_request_review",
+  "pull_request_review_comment",
+  "issue_comment",
+  "check_suite",
+  "deployment_status",
+] as const;
+
+export const SNOOZE_WAKE_EVENTS = new Set<string>([
+  "issue_comment",
+  "pull_request_review",
+  "pull_request_review_comment",
+  "check_suite",
+  "deployment_status",
+]);
+
+export function githubWebhookPath(): string {
+  return "/github-webhook";
+}
+
+export function githubWebhookUrl(baseUrl: string, pluginId: string): string {
+  const origin = baseUrl.trim().replace(/\/+$/u, "");
+  return `${origin}/api/v1/plugins/${pluginId}/http/github-webhook`;
+}
+
+/** Public URL for the dedicated webhook-only listener (not the bb API). */
+export function dedicatedGithubWebhookUrl(origin: string): string {
+  return `${origin.trim().replace(/\/+$/u, "")}${githubWebhookPath()}`;
+}
+
+/**
+ * Prefer a user-supplied unauthenticated origin that forwards to bb. Session-
+ * gated getbb.app URLs are skipped so a live trycloudflare tunnel can win.
+ */
+export function resolveWebhookDeliveryUrl(args: {
+  configuredOrigin: string;
+  tunnelOrigin: string | null;
+  pluginId: string;
+}): string | null {
+  const configured = args.configuredOrigin.trim();
+  if (configured.length > 0 && !isSessionGatedWebhookOrigin(configured)) {
+    return githubWebhookUrl(configured, args.pluginId);
+  }
+  if (args.tunnelOrigin !== null && args.tunnelOrigin.length > 0) {
+    return dedicatedGithubWebhookUrl(args.tunnelOrigin);
+  }
+  return null;
+}
+
+/** Start a trycloudflare tunnel only when the setting is on and no usable manual origin exists. */
+export function shouldStartCloudflareTunnel(
+  enabled: boolean,
+  configuredOrigin: string,
+): boolean {
+  if (!enabled) return false;
+  const configured = configuredOrigin.trim();
+  if (configured.length === 0) return true;
+  return isSessionGatedWebhookOrigin(configured);
+}
+
+export function isTrycloudflareWebhookUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.hostname.toLowerCase().endsWith(".trycloudflare.com") &&
+      parsed.pathname === githubWebhookPath()
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * bb connect (`*.getbb.app`) requires an owner session before the request
+ * reaches the plugin. GitHub's webhook delivery cannot sign in, so those
+ * origins must not be registered as hook targets.
+ */
+export function isSessionGatedWebhookOrigin(baseUrl: string): boolean {
+  try {
+    const hostname = new URL(baseUrl.trim()).hostname.toLowerCase();
+    return hostname === "getbb.app" || hostname.endsWith(".getbb.app");
+  } catch {
+    return false;
+  }
+}
+
+export function verifyGithubSignature(
+  secret: string,
+  rawBody: string,
+  header: string | undefined,
+): boolean {
+  if (header === undefined || !header.startsWith("sha256=")) return false;
+  const expected = createHmac("sha256", secret).update(rawBody).digest("hex");
+  const got = header.slice("sha256=".length);
+  if (got.length !== expected.length) return false;
+  return timingSafeEqual(Buffer.from(expected, "utf8"), Buffer.from(got, "utf8"));
+}
+
+export interface WebhookPullRef {
+  owner: string;
+  repo: string;
+  pull: RestPull;
+}
+
+export function parseRepoFromPayload(payload: unknown): GithubRepo | null {
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) return null;
+  const repository = (payload as Record<string, unknown>).repository;
+  if (typeof repository !== "object" || repository === null || Array.isArray(repository)) {
+    return null;
+  }
+  const record = repository as Record<string, unknown>;
+  const name = record.name;
+  const ownerValue = record.owner;
+  const ownerLogin =
+    typeof ownerValue === "object" && ownerValue !== null && !Array.isArray(ownerValue)
+      ? (ownerValue as Record<string, unknown>).login
+      : null;
+  if (typeof name !== "string" || typeof ownerLogin !== "string") return null;
+  if (name.trim().length === 0 || ownerLogin.trim().length === 0) return null;
+  return { owner: ownerLogin, repo: name };
+}
+
+export function parseWebhookPull(payload: unknown): WebhookPullRef | null {
+  const repo = parseRepoFromPayload(payload);
+  if (repo === null) return null;
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) return null;
+  const pull = parseRestPull((payload as Record<string, unknown>).pull_request);
+  if (pull === null) return null;
+  return { owner: repo.owner, repo: repo.repo, pull };
+}
+
+export function webhookPrNumbers(event: string, payload: unknown): number[] {
+  const fromPull = parseWebhookPull(payload);
+  if (fromPull !== null) return [fromPull.pull.number];
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) return [];
+  const record = payload as Record<string, unknown>;
+  if (event === "issue_comment") {
+    const issue = record.issue;
+    if (typeof issue === "object" && issue !== null && !Array.isArray(issue)) {
+      const issueRecord = issue as Record<string, unknown>;
+      if (issueRecord.pull_request != null && typeof issueRecord.number === "number") {
+        return [issueRecord.number];
+      }
+    }
+  }
+  if (event === "check_suite") {
+    const suite = record.check_suite;
+    if (typeof suite === "object" && suite !== null && !Array.isArray(suite)) {
+      const pulls = (suite as Record<string, unknown>).pull_requests;
+      if (Array.isArray(pulls)) {
+        return pulls.flatMap((entry) => {
+          if (typeof entry !== "object" || entry === null || Array.isArray(entry)) return [];
+          const number = (entry as Record<string, unknown>).number;
+          return typeof number === "number" && Number.isInteger(number) && number > 0
+            ? [number]
+            : [];
+        });
+      }
+    }
+  }
+  if (event === "deployment_status") {
+    const deployment = record.deployment;
+    if (typeof deployment === "object" && deployment !== null && !Array.isArray(deployment)) {
+      const sha = (deployment as Record<string, unknown>).sha;
+      if (typeof sha === "string") {
+        // Number is not on the deployment; callers GET by repo list or skip.
+        return [];
+      }
+    }
+  }
+  return [];
+}
+
+export function webhookHookBody(url: string, secret: string): unknown {
+  return {
+    name: "web",
+    active: true,
+    events: [...GITHUB_WEBHOOK_EVENTS],
+    config: {
+      url,
+      content_type: "json",
+      secret,
+      insecure_ssl: "0",
+    },
+  };
+}
+
+export function matchingGithubHook(
+  hooks: unknown,
+  url: string,
+): { id: number; events: string[]; url: string } | null {
+  if (!Array.isArray(hooks)) return null;
+  for (const entry of hooks) {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) continue;
+    const record = entry as Record<string, unknown>;
+    const id = record.id;
+    const config = record.config;
+    if (typeof id !== "number" || typeof config !== "object" || config === null) continue;
+    const hookUrl = (config as Record<string, unknown>).url;
+    if (hookUrl !== url) continue;
+    const events = Array.isArray(record.events)
+      ? record.events.filter((event): event is string => typeof event === "string")
+      : [];
+    return { id, events, url };
+  }
+  return null;
+}
+
+/**
+ * Find the hook we manage: exact URL, then the previous trycloudflare URL,
+ * then any trycloudflare `/github-webhook` left behind after a restart.
+ */
+export function matchingManagedGithubHook(
+  hooks: unknown,
+  url: string,
+  previousUrl?: string | null,
+): { id: number; events: string[]; url: string } | null {
+  const exact = matchingGithubHook(hooks, url);
+  if (exact !== null) return exact;
+  if (typeof previousUrl === "string" && previousUrl.length > 0 && previousUrl !== url) {
+    const previous = matchingGithubHook(hooks, previousUrl);
+    if (previous !== null) return previous;
+  }
+  if (!Array.isArray(hooks)) return null;
+  for (const entry of hooks) {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) continue;
+    const record = entry as Record<string, unknown>;
+    const id = record.id;
+    const config = record.config;
+    if (typeof id !== "number" || typeof config !== "object" || config === null) continue;
+    const hookUrl = (config as Record<string, unknown>).url;
+    if (typeof hookUrl !== "string" || !isTrycloudflareWebhookUrl(hookUrl)) continue;
+    const events = Array.isArray(record.events)
+      ? record.events.filter((event): event is string => typeof event === "string")
+      : [];
+    return { id, events, url: hookUrl };
+  }
+  return null;
+}
+
+export function eventsMatch(have: readonly string[], want: readonly string[]): boolean {
+  if (have.length !== want.length) return false;
+  const set = new Set(have);
+  return want.every((event) => set.has(event));
+}
+
+export function indexedRowFromPull(
+  environmentId: string,
+  owner: string,
+  repo: string,
+  pull: RestPull,
+  now: number,
+) {
+  const sidebar = sidebarPrFromRest(pull);
+  return {
+    environmentId,
+    owner,
+    repo,
+    number: sidebar.number,
+    title: sidebar.title,
+    url: sidebar.url,
+    state: sidebar.state,
+    attention: sidebar.attention,
+    fetchedAt: now,
+  };
+}

--- a/plugins/gtd-sidebar/lib/github-webhook.ts
+++ b/plugins/gtd-sidebar/lib/github-webhook.ts
@@ -221,8 +221,8 @@ export function matchingGithubHook(
 }
 
 /**
- * Find the hook we manage: exact URL, then the previous trycloudflare URL,
- * then any trycloudflare `/github-webhook` left behind after a restart.
+ * Find the hook we manage: the current URL, or the previous URL this plugin
+ * persisted. Do not claim some other integration's trycloudflare hook.
  */
 export function matchingManagedGithubHook(
   hooks: unknown,
@@ -232,22 +232,7 @@ export function matchingManagedGithubHook(
   const exact = matchingGithubHook(hooks, url);
   if (exact !== null) return exact;
   if (typeof previousUrl === "string" && previousUrl.length > 0 && previousUrl !== url) {
-    const previous = matchingGithubHook(hooks, previousUrl);
-    if (previous !== null) return previous;
-  }
-  if (!Array.isArray(hooks)) return null;
-  for (const entry of hooks) {
-    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) continue;
-    const record = entry as Record<string, unknown>;
-    const id = record.id;
-    const config = record.config;
-    if (typeof id !== "number" || typeof config !== "object" || config === null) continue;
-    const hookUrl = (config as Record<string, unknown>).url;
-    if (typeof hookUrl !== "string" || !isTrycloudflareWebhookUrl(hookUrl)) continue;
-    const events = Array.isArray(record.events)
-      ? record.events.filter((event): event is string => typeof event === "string")
-      : [];
-    return { id, events, url: hookUrl };
+    return matchingGithubHook(hooks, previousUrl);
   }
   return null;
 }

--- a/plugins/gtd-sidebar/lib/open-in-app-browser.ts
+++ b/plugins/gtd-sidebar/lib/open-in-app-browser.ts
@@ -1,0 +1,223 @@
+/**
+ * Open a URL in bb's thread-side in-app browser from a plugin that cannot
+ * call the host's `openTab({ kind: "browser" })`.
+ *
+ * The plugin SDK has no browser opener, and `UrlOpenRoutingProvider` does not
+ * wrap the left sidebar. A click with `target="_blank"` is sent to the OS
+ * browser by Electron. This module writes the same localStorage blob the host
+ * hydrates on panel mount (`atomWithStorage` re-reads on mount, and a
+ * synthetic `storage` event covers an already-mounted thread) and persists
+ * the tab through `threads.tabs` so the host's server reconcile does not
+ * wipe it.
+ */
+
+export const FIXED_PANEL_TABS_STATE_STORAGE_PREFIX = "bb.thread.fixedPanelTabsState";
+export const FIXED_PANEL_TABS_STATE_STORAGE_VERSION = 1;
+export const IN_APP_BROWSER_MAX_URL_LENGTH = 4096;
+export const IN_APP_BROWSER_MAX_TITLE_LENGTH = 1024;
+
+export interface InAppBrowserTab {
+  environmentId: string | null;
+  id: string;
+  kind: "browser";
+  title: string | null;
+  url: string;
+}
+
+export interface FixedPanelTabsState {
+  lastUsedAt: number;
+  secondary: {
+    activeTabId: string | null;
+    isOpen: boolean;
+    tabs: unknown[];
+  };
+  version: typeof FIXED_PANEL_TABS_STATE_STORAGE_VERSION;
+}
+
+export interface ModifierKeyEvent {
+  altKey: boolean;
+  button?: number;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+}
+
+export function hasAnyModifierKey(event: ModifierKeyEvent): boolean {
+  return event.altKey || event.ctrlKey || event.metaKey || event.shiftKey;
+}
+
+/** Left-click with no modifier goes in-app; anything else keeps the OS browser. */
+export function shouldDeferToSystemBrowser(event: ModifierKeyEvent): boolean {
+  return (event.button !== undefined && event.button !== 0) || hasAnyModifierKey(event);
+}
+
+export function isDesktopInAppBrowserAvailable(): boolean {
+  if (typeof window === "undefined") return false;
+  const desktop = (window as Window & { bbDesktop?: { browser?: unknown } }).bbDesktop;
+  return desktop?.browser != null;
+}
+
+export function panelStorageKey(threadId: string): string {
+  return `${FIXED_PANEL_TABS_STATE_STORAGE_PREFIX}-${encodeURIComponent(threadId.trim())}-${FIXED_PANEL_TABS_STATE_STORAGE_VERSION}`;
+}
+
+export function clipInAppBrowserText(value: string, max: number): string {
+  return value.length <= max ? value : value.slice(0, max);
+}
+
+export function createInAppBrowserTab({
+  environmentId,
+  instanceId = crypto.randomUUID(),
+  title,
+  url,
+}: {
+  environmentId: string | null;
+  instanceId?: string;
+  title: string;
+  url: string;
+}): InAppBrowserTab {
+  const clippedTitle = clipInAppBrowserText(title.trim(), IN_APP_BROWSER_MAX_TITLE_LENGTH);
+  return {
+    environmentId,
+    id: [
+      "browser",
+      encodeURIComponent(instanceId),
+      encodeURIComponent(environmentId ?? "none"),
+    ].join(":"),
+    kind: "browser",
+    title: clippedTitle.length > 0 ? clippedTitle : "Pull request",
+    url: clipInAppBrowserText(url, IN_APP_BROWSER_MAX_URL_LENGTH),
+  };
+}
+
+export function upsertBrowserTab<T extends { id: string; kind: string; url?: string }>(
+  tabs: readonly T[],
+  tab: InAppBrowserTab,
+): { tab: T | InAppBrowserTab; tabs: Array<T | InAppBrowserTab> } {
+  const existing = tabs.find(
+    (candidate) => candidate.kind === "browser" && candidate.url === tab.url,
+  );
+  if (existing !== undefined) {
+    return { tab: existing, tabs: [...tabs] };
+  }
+  return { tab, tabs: [...tabs, tab] };
+}
+
+export function parsePanelState(storedValue: string | null): FixedPanelTabsState | null {
+  if (storedValue === null) return null;
+  try {
+    const parsed: unknown = JSON.parse(storedValue);
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const record = parsed as Record<string, unknown>;
+    if (record.version !== FIXED_PANEL_TABS_STATE_STORAGE_VERSION) return null;
+    if (typeof record.secondary !== "object" || record.secondary === null) return null;
+    const secondary = record.secondary as Record<string, unknown>;
+    if (!Array.isArray(secondary.tabs) || typeof secondary.isOpen !== "boolean") return null;
+    const activeTabId = secondary.activeTabId;
+    if (activeTabId !== null && typeof activeTabId !== "string") return null;
+    const lastUsedAt = record.lastUsedAt;
+    if (typeof lastUsedAt !== "number" || !Number.isInteger(lastUsedAt) || lastUsedAt < 0) {
+      return null;
+    }
+    return {
+      lastUsedAt,
+      secondary: {
+        activeTabId,
+        isOpen: secondary.isOpen,
+        tabs: secondary.tabs,
+      },
+      version: FIXED_PANEL_TABS_STATE_STORAGE_VERSION,
+    };
+  } catch {
+    return null;
+  }
+}
+
+type BrowserTabCandidate = {
+  environmentId?: unknown;
+  id: string;
+  kind: string;
+  title?: unknown;
+  url?: string;
+};
+
+function asInAppBrowserTab(candidate: BrowserTabCandidate, fallback: InAppBrowserTab): InAppBrowserTab {
+  if (candidate.kind !== "browser" || typeof candidate.url !== "string") return fallback;
+  const title = candidate.title;
+  const environmentId = candidate.environmentId;
+  return {
+    environmentId:
+      typeof environmentId === "string" || environmentId === null
+        ? environmentId
+        : fallback.environmentId,
+    id: candidate.id,
+    kind: "browser",
+    title: typeof title === "string" && title.length > 0 ? title : fallback.title,
+    url: candidate.url,
+  };
+}
+
+export function openBrowserTabInPanelState(
+  state: FixedPanelTabsState | null,
+  tab: InAppBrowserTab,
+  now: number,
+): { state: FixedPanelTabsState; tab: InAppBrowserTab } {
+  const currentTabs = (state?.secondary.tabs ?? []) as BrowserTabCandidate[];
+  const next = upsertBrowserTab(currentTabs, tab);
+  const opened = asInAppBrowserTab(next.tab, tab);
+  return {
+    tab: opened,
+    state: {
+      lastUsedAt: now,
+      secondary: {
+        activeTabId: opened.id,
+        isOpen: true,
+        tabs: next.tabs,
+      },
+      version: FIXED_PANEL_TABS_STATE_STORAGE_VERSION,
+    },
+  };
+}
+
+export function serializePanelState(state: FixedPanelTabsState): string {
+  return JSON.stringify(state);
+}
+
+const REVEAL_RETRY_DELAYS_MS = [50, 250] as const;
+
+/**
+ * Write the host's per-thread panel blob and poke jotai. Retries cover the
+ * window where `threads.tabs` realtime reconcile can briefly replace the
+ * strip before the PUT is visible to the query cache.
+ */
+export function revealInAppBrowserTab({
+  tab,
+  threadId,
+}: {
+  tab: InAppBrowserTab;
+  threadId: string;
+}): void {
+  const apply = (): void => {
+    if (typeof window === "undefined") return;
+    const key = panelStorageKey(threadId);
+    const current = parsePanelState(window.localStorage.getItem(key));
+    const { state } = openBrowserTabInPanelState(current, tab, Date.now());
+    const serialized = serializePanelState(state);
+    window.localStorage.setItem(key, serialized);
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key,
+        newValue: serialized,
+        storageArea: window.localStorage,
+      }),
+    );
+  };
+
+  apply();
+  if (typeof requestAnimationFrame === "function") {
+    requestAnimationFrame(apply);
+  }
+  for (const delay of REVEAL_RETRY_DELAYS_MS) {
+    window.setTimeout(apply, delay);
+  }
+}

--- a/plugins/gtd-sidebar/lib/pr-index-run.ts
+++ b/plugins/gtd-sidebar/lib/pr-index-run.ts
@@ -57,8 +57,13 @@ function numberedHint(
   stale: CachedPullRow | undefined,
 ): { number: number; repo: GithubRepo } | null {
   const fromTitle = parsePrRefFromTitle(query.title);
-  const owner = repo?.owner ?? stale?.owner ?? fromTitle?.owner ?? null;
-  const name = repo?.repo ?? stale?.repo ?? fromTitle?.repo ?? null;
+  // An explicit `owner/repo#N` names that repository, even when this thread's
+  // checkout is somewhere else. Cache-number precedence is only for a bare `#N`.
+  if (fromTitle !== null && fromTitle.owner !== null && fromTitle.repo !== null) {
+    return { number: fromTitle.number, repo: { owner: fromTitle.owner, repo: fromTitle.repo } };
+  }
+  const owner = repo?.owner ?? stale?.owner ?? null;
+  const name = repo?.repo ?? stale?.repo ?? null;
   // Cache number first: titles often cite a parent PR (`outside the #2255 sweep`)
   // while this thread's own PR is already known.
   const number = stale?.number ?? fromTitle?.number ?? null;

--- a/plugins/gtd-sidebar/lib/pr-index-run.ts
+++ b/plugins/gtd-sidebar/lib/pr-index-run.ts
@@ -1,0 +1,205 @@
+import { parsePrRefFromTitle, type GithubRepo } from "./github-repo.ts";
+import {
+  isCacheFresh,
+  matchPullForBranch,
+  MAX_CLOSED_HEAD_LOOKUPS_PER_TICK,
+  MAX_PR_LOOKUPS_PER_TICK,
+  MAX_REPOS_PER_TICK,
+  MIN_REST_REMAINING,
+  sidebarPrFromCache,
+  sidebarPrFromRest,
+  sidebarPrFromTitle,
+  type CachedPullRow,
+  type RestPull,
+  type SidebarPullRequest,
+} from "./pr-index.ts";
+
+export interface ThreadPrQuery {
+  threadId: string;
+  environmentId: string | null;
+  branchName: string | null;
+  title: string;
+}
+
+export interface PrIndexDeps {
+  now: number;
+  restRemaining: number | null;
+  getCache(environmentId: string): CachedPullRow | undefined;
+  putCache(row: CachedPullRow): void;
+  getRepo(environmentId: string): Promise<GithubRepo | null>;
+  listOpenPulls(repo: GithubRepo): Promise<RestPull[]>;
+  getPull(repo: GithubRepo, number: number): Promise<RestPull | null>;
+  listClosedPullsByHead(repo: GithubRepo, branchName: string): Promise<RestPull[]>;
+  log: { info(message: string): void; warn(message: string): void };
+}
+
+function cacheableChoice(chosen: SidebarPullRequest | null): boolean {
+  return chosen === null || chosen.source === "rest";
+}
+
+function numberedHint(
+  query: ThreadPrQuery,
+  repo: GithubRepo | null,
+  stale: CachedPullRow | undefined,
+): { number: number; repo: GithubRepo } | null {
+  const fromTitle = parsePrRefFromTitle(query.title);
+  const owner = fromTitle?.owner ?? repo?.owner ?? stale?.owner ?? null;
+  const name = fromTitle?.repo ?? repo?.repo ?? stale?.repo ?? null;
+  const number = fromTitle?.number ?? stale?.number ?? null;
+  if (owner === null || name === null || number === null) return null;
+  return { number, repo: { owner, repo: name } };
+}
+
+export async function resolveThreadPullRequests(
+  queries: readonly ThreadPrQuery[],
+  deps: PrIndexDeps,
+): Promise<ReadonlyMap<string, SidebarPullRequest>> {
+  const result = new Map<string, SidebarPullRequest>();
+  const pending: ThreadPrQuery[] = [];
+
+  for (const query of queries) {
+    const fromTitle = sidebarPrFromTitle(query.title, null);
+    if (query.environmentId === null) {
+      if (fromTitle !== null) pending.push(query);
+      continue;
+    }
+    const cached = deps.getCache(query.environmentId);
+    if (cached !== undefined && isCacheFresh(cached, deps.now)) {
+      const pr = sidebarPrFromCache(cached);
+      if (pr !== null) result.set(query.threadId, pr);
+      continue;
+    }
+    pending.push(query);
+  }
+
+  const repoByEnvironment = new Map<string, GithubRepo | null>();
+  const uniqueEnvIds = [
+    ...new Set(
+      pending.map((query) => query.environmentId).filter((id): id is string => id !== null),
+    ),
+  ];
+  await Promise.all(
+    uniqueEnvIds.map(async (environmentId) => {
+      try {
+        repoByEnvironment.set(environmentId, await deps.getRepo(environmentId));
+      } catch (error) {
+        deps.log.warn(`git remote for ${environmentId} failed: ${String(error)}`);
+        repoByEnvironment.set(environmentId, null);
+      }
+    }),
+  );
+
+  const canSpendRest = deps.restRemaining === null || deps.restRemaining >= MIN_REST_REMAINING;
+  const pullsByRepo = new Map<string, RestPull[]>();
+  if (canSpendRest) {
+    const repos: GithubRepo[] = [];
+    const seen = new Set<string>();
+    for (const environmentId of uniqueEnvIds) {
+      const repo = repoByEnvironment.get(environmentId);
+      if (repo === null || repo === undefined) continue;
+      const key = `${repo.owner}/${repo.repo}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      repos.push(repo);
+      if (repos.length >= MAX_REPOS_PER_TICK) break;
+    }
+    for (const repo of repos) {
+      try {
+        const pulls = await deps.listOpenPulls(repo);
+        pullsByRepo.set(`${repo.owner}/${repo.repo}`, pulls);
+      } catch (error) {
+        deps.log.warn(`REST pulls for ${repo.owner}/${repo.repo} failed: ${String(error)}`);
+      }
+    }
+    deps.log.info(
+      `pr-index listed ${pullsByRepo.size} repos for ${pending.length} threads (REST remaining ${deps.restRemaining ?? "unknown"})`,
+    );
+  } else {
+    deps.log.info(
+      `pr-index skipping REST (${deps.restRemaining} remaining); cache and titles only`,
+    );
+  }
+
+  const pullByNumber = new Map<string, RestPull | null>();
+  let numberedLookups = 0;
+  let closedHeadLookups = 0;
+
+  const lookupNumbered = async (
+    repo: GithubRepo,
+    number: number,
+  ): Promise<RestPull | null> => {
+    const key = `${repo.owner}/${repo.repo}#${number}`;
+    if (pullByNumber.has(key)) return pullByNumber.get(key) ?? null;
+    if (!canSpendRest || numberedLookups >= MAX_PR_LOOKUPS_PER_TICK) return null;
+    numberedLookups += 1;
+    try {
+      const pull = await deps.getPull(repo, number);
+      pullByNumber.set(key, pull);
+      return pull;
+    } catch (error) {
+      deps.log.warn(`REST pull ${key} failed: ${String(error)}`);
+      pullByNumber.set(key, null);
+      return null;
+    }
+  };
+
+  for (const query of pending) {
+    const repo =
+      query.environmentId === null ? null : (repoByEnvironment.get(query.environmentId) ?? null);
+    const pulls = repo === null ? [] : (pullsByRepo.get(`${repo.owner}/${repo.repo}`) ?? []);
+    const matched = matchPullForBranch(pulls, query.branchName);
+    const fromRest = matched === null ? null : sidebarPrFromRest(matched);
+    const stale = query.environmentId === null ? undefined : deps.getCache(query.environmentId);
+    const hint = numberedHint(query, repo, stale);
+
+    let fromLookup: SidebarPullRequest | null = null;
+    if (fromRest === null && hint !== null) {
+      const pulled = await lookupNumbered(hint.repo, hint.number);
+      fromLookup = pulled === null ? null : sidebarPrFromRest(pulled);
+    }
+
+    let fromClosedHead: SidebarPullRequest | null = null;
+    if (
+      fromRest === null &&
+      fromLookup === null &&
+      repo !== null &&
+      query.branchName !== null &&
+      query.branchName.trim().length > 0 &&
+      query.branchName.trim() !== "gitbutler/workspace" &&
+      canSpendRest &&
+      closedHeadLookups < MAX_CLOSED_HEAD_LOOKUPS_PER_TICK
+    ) {
+      closedHeadLookups += 1;
+      try {
+        const closed = await deps.listClosedPullsByHead(repo, query.branchName.trim());
+        const closedMatch = matchPullForBranch(closed, query.branchName);
+        fromClosedHead = closedMatch === null ? null : sidebarPrFromRest(closedMatch);
+      } catch (error) {
+        deps.log.warn(
+          `REST closed pulls for ${repo.owner}/${repo.repo} ${query.branchName} failed: ${String(error)}`,
+        );
+      }
+    }
+
+    const fromTitle = sidebarPrFromTitle(query.title, hint?.repo ?? repo);
+    const fromStale = stale === undefined ? null : sidebarPrFromCache(stale);
+    const chosen = fromRest ?? fromLookup ?? fromClosedHead ?? fromStale ?? fromTitle;
+
+    if (query.environmentId !== null && cacheableChoice(chosen)) {
+      deps.putCache({
+        environmentId: query.environmentId,
+        owner: repo?.owner ?? hint?.repo.owner ?? stale?.owner ?? null,
+        repo: repo?.repo ?? hint?.repo.repo ?? stale?.repo ?? null,
+        number: chosen?.number ?? null,
+        title: chosen?.title ?? null,
+        url: chosen?.url ?? null,
+        state: chosen?.state ?? null,
+        attention: chosen?.attention ?? null,
+        fetchedAt: deps.now,
+      });
+    }
+    if (chosen !== null) result.set(query.threadId, chosen);
+  }
+
+  return result;
+}

--- a/plugins/gtd-sidebar/lib/pr-index-run.ts
+++ b/plugins/gtd-sidebar/lib/pr-index-run.ts
@@ -1,10 +1,11 @@
 import { parsePrRefFromTitle, type GithubRepo } from "./github-repo.ts";
 import {
   isCacheFresh,
-  matchPullForBranch,
-  MAX_CLOSED_HEAD_LOOKUPS_PER_TICK,
+  matchPullForBranches,
+  matchPullForNumber,
   MAX_PR_LOOKUPS_PER_TICK,
   MAX_REPOS_PER_TICK,
+  mergeListedPulls,
   MIN_REST_REMAINING,
   sidebarPrFromCache,
   sidebarPrFromRest,
@@ -18,6 +19,8 @@ export interface ThreadPrQuery {
   threadId: string;
   environmentId: string | null;
   branchName: string | null;
+  /** Extra git refs to try (GitButler virtual branch, bb's own branch). */
+  branchNames?: readonly string[];
   title: string;
 }
 
@@ -28,13 +31,24 @@ export interface PrIndexDeps {
   putCache(row: CachedPullRow): void;
   getRepo(environmentId: string): Promise<GithubRepo | null>;
   listOpenPulls(repo: GithubRepo): Promise<RestPull[]>;
+  listRecentClosedPulls(repo: GithubRepo): Promise<RestPull[]>;
   getPull(repo: GithubRepo, number: number): Promise<RestPull | null>;
-  listClosedPullsByHead(repo: GithubRepo, branchName: string): Promise<RestPull[]>;
   log: { info(message: string): void; warn(message: string): void };
 }
 
 function cacheableChoice(chosen: SidebarPullRequest | null): boolean {
   return chosen === null || chosen.source === "rest";
+}
+
+function queryBranchNames(query: ThreadPrQuery): string[] {
+  const names: string[] = [];
+  for (const name of [query.branchName, ...(query.branchNames ?? [])]) {
+    if (typeof name !== "string") continue;
+    const trimmed = name.trim();
+    if (trimmed.length === 0) continue;
+    names.push(trimmed);
+  }
+  return [...new Set(names)];
 }
 
 function numberedHint(
@@ -43,11 +57,40 @@ function numberedHint(
   stale: CachedPullRow | undefined,
 ): { number: number; repo: GithubRepo } | null {
   const fromTitle = parsePrRefFromTitle(query.title);
-  const owner = fromTitle?.owner ?? repo?.owner ?? stale?.owner ?? null;
-  const name = fromTitle?.repo ?? repo?.repo ?? stale?.repo ?? null;
-  const number = fromTitle?.number ?? stale?.number ?? null;
+  const owner = repo?.owner ?? stale?.owner ?? fromTitle?.owner ?? null;
+  const name = repo?.repo ?? stale?.repo ?? fromTitle?.repo ?? null;
+  // Cache number first: titles often cite a parent PR (`outside the #2255 sweep`)
+  // while this thread's own PR is already known.
+  const number = stale?.number ?? fromTitle?.number ?? null;
   if (owner === null || name === null || number === null) return null;
   return { number, repo: { owner, repo: name } };
+}
+
+function matchFromListedPulls(
+  pulls: readonly RestPull[],
+  query: ThreadPrQuery,
+  stale: CachedPullRow | undefined,
+): RestPull | null {
+  const byBranch = matchPullForBranches(pulls, queryBranchNames(query));
+  if (byBranch !== null) return byBranch;
+  const byCacheNumber = matchPullForNumber(pulls, stale?.number ?? null);
+  if (byCacheNumber !== null) return byCacheNumber;
+  if (stale?.number != null) return null;
+  const fromTitle = parsePrRefFromTitle(query.title);
+  return matchPullForNumber(pulls, fromTitle?.number ?? null);
+}
+
+function usableStaleCache(
+  stale: CachedPullRow | undefined,
+  listedThisTick: boolean,
+): SidebarPullRequest | null {
+  const pr = stale === undefined ? null : sidebarPrFromCache(stale);
+  if (pr === null) return null;
+  if (!listedThisTick) return pr;
+  if (pr.state === "merged" || pr.state === "closed") return pr;
+  // An open/draft row that is not on this tick's open+closed lists is a lie:
+  // #2450 stayed grey after merge because the pre-merge cache was reused.
+  return null;
 }
 
 export async function resolveThreadPullRequests(
@@ -104,12 +147,20 @@ export async function resolveThreadPullRequests(
       if (repos.length >= MAX_REPOS_PER_TICK) break;
     }
     for (const repo of repos) {
+      const key = `${repo.owner}/${repo.repo}`;
+      let open: RestPull[] = [];
+      let closed: RestPull[] = [];
       try {
-        const pulls = await deps.listOpenPulls(repo);
-        pullsByRepo.set(`${repo.owner}/${repo.repo}`, pulls);
+        open = await deps.listOpenPulls(repo);
       } catch (error) {
-        deps.log.warn(`REST pulls for ${repo.owner}/${repo.repo} failed: ${String(error)}`);
+        deps.log.warn(`REST open pulls for ${key} failed: ${String(error)}`);
       }
+      try {
+        closed = await deps.listRecentClosedPulls(repo);
+      } catch (error) {
+        deps.log.warn(`REST closed pulls for ${key} failed: ${String(error)}`);
+      }
+      pullsByRepo.set(key, mergeListedPulls(open, closed));
     }
     deps.log.info(
       `pr-index listed ${pullsByRepo.size} repos for ${pending.length} threads (REST remaining ${deps.restRemaining ?? "unknown"})`,
@@ -122,7 +173,6 @@ export async function resolveThreadPullRequests(
 
   const pullByNumber = new Map<string, RestPull | null>();
   let numberedLookups = 0;
-  let closedHeadLookups = 0;
 
   const lookupNumbered = async (
     repo: GithubRepo,
@@ -146,44 +196,25 @@ export async function resolveThreadPullRequests(
   for (const query of pending) {
     const repo =
       query.environmentId === null ? null : (repoByEnvironment.get(query.environmentId) ?? null);
-    const pulls = repo === null ? [] : (pullsByRepo.get(`${repo.owner}/${repo.repo}`) ?? []);
-    const matched = matchPullForBranch(pulls, query.branchName);
-    const fromRest = matched === null ? null : sidebarPrFromRest(matched);
+    const repoKey = repo === null ? null : `${repo.owner}/${repo.repo}`;
+    const listedThisTick = repoKey !== null && pullsByRepo.has(repoKey);
+    const pulls = repoKey === null ? [] : (pullsByRepo.get(repoKey) ?? []);
     const stale = query.environmentId === null ? undefined : deps.getCache(query.environmentId);
+    const listed = matchFromListedPulls(pulls, query, stale);
+    const fromList = listed === null ? null : sidebarPrFromRest(listed);
     const hint = numberedHint(query, repo, stale);
 
     let fromLookup: SidebarPullRequest | null = null;
-    if (fromRest === null && hint !== null) {
+    if (fromList === null && hint !== null) {
       const pulled = await lookupNumbered(hint.repo, hint.number);
       fromLookup = pulled === null ? null : sidebarPrFromRest(pulled);
     }
 
-    let fromClosedHead: SidebarPullRequest | null = null;
-    if (
-      fromRest === null &&
-      fromLookup === null &&
-      repo !== null &&
-      query.branchName !== null &&
-      query.branchName.trim().length > 0 &&
-      query.branchName.trim() !== "gitbutler/workspace" &&
-      canSpendRest &&
-      closedHeadLookups < MAX_CLOSED_HEAD_LOOKUPS_PER_TICK
-    ) {
-      closedHeadLookups += 1;
-      try {
-        const closed = await deps.listClosedPullsByHead(repo, query.branchName.trim());
-        const closedMatch = matchPullForBranch(closed, query.branchName);
-        fromClosedHead = closedMatch === null ? null : sidebarPrFromRest(closedMatch);
-      } catch (error) {
-        deps.log.warn(
-          `REST closed pulls for ${repo.owner}/${repo.repo} ${query.branchName} failed: ${String(error)}`,
-        );
-      }
-    }
-
-    const fromTitle = sidebarPrFromTitle(query.title, hint?.repo ?? repo);
-    const fromStale = stale === undefined ? null : sidebarPrFromCache(stale);
-    const chosen = fromRest ?? fromLookup ?? fromClosedHead ?? fromStale ?? fromTitle;
+    const fromTitle = listedThisTick
+      ? null
+      : sidebarPrFromTitle(query.title, hint?.repo ?? repo);
+    const fromStale = usableStaleCache(stale, listedThisTick);
+    const chosen = fromList ?? fromLookup ?? fromStale ?? fromTitle;
 
     if (query.environmentId !== null && cacheableChoice(chosen)) {
       deps.putCache({

--- a/plugins/gtd-sidebar/lib/pr-index-run.ts
+++ b/plugins/gtd-sidebar/lib/pr-index-run.ts
@@ -7,6 +7,7 @@ import {
   MAX_REPOS_PER_TICK,
   mergeListedPulls,
   MIN_REST_REMAINING,
+  needsMergeStateLookup,
   sidebarPrFromCache,
   sidebarPrFromRest,
   sidebarPrFromTitle,
@@ -205,7 +206,14 @@ export async function resolveThreadPullRequests(
     const listedThisTick = repoKey !== null && pullsByRepo.has(repoKey);
     const pulls = repoKey === null ? [] : (pullsByRepo.get(repoKey) ?? []);
     const stale = query.environmentId === null ? undefined : deps.getCache(query.environmentId);
-    const listed = matchFromListedPulls(pulls, query, stale);
+    let listed = matchFromListedPulls(pulls, query, stale);
+    // The list route leaves `mergeable_state` out, so a listed open PR carries
+    // no attention at all and paints green. Buy the real state with a numbered
+    // GET; the lookup cache and per-tick cap keep the cost bounded.
+    if (listed !== null && repo !== null && needsMergeStateLookup(listed)) {
+      const detailed = await lookupNumbered(repo, listed.number);
+      if (detailed !== null) listed = detailed;
+    }
     const fromList = listed === null ? null : sidebarPrFromRest(listed);
     const hint = numberedHint(query, repo, stale);
 

--- a/plugins/gtd-sidebar/lib/pr-index.ts
+++ b/plugins/gtd-sidebar/lib/pr-index.ts
@@ -1,0 +1,199 @@
+/**
+ * Sidebar PR badges without per-card `gh pr view`.
+ *
+ * bb's own hook runs GraphQL once per environment on mount. Reloading the
+ * plugin stampedes that path and burns the 5,000-point GraphQL budget, after
+ * which every badge goes blank. This path uses REST (`/repos/.../pulls`, a
+ * separate 5,000/hour budget), one open list per repository, then a numbered
+ * GET when that list misses (merged PRs drop off it), then title-text and a
+ * local cache when REST is too tight to spend.
+ */
+
+import { githubPullUrl, parsePrRefFromTitle, type GithubRepo } from "./github-repo.ts";
+
+export const PR_CACHE_FRESH_MS = 15 * 60 * 1000;
+export const PR_MISS_CACHE_MS = 5 * 60 * 1000;
+export const MIN_REST_REMAINING = 80;
+export const MAX_REPOS_PER_TICK = 12;
+export const MAX_PR_LOOKUPS_PER_TICK = 20;
+export const MAX_CLOSED_HEAD_LOOKUPS_PER_TICK = 8;
+
+export interface SidebarPullRequest {
+  number: number;
+  title: string;
+  url: string;
+  state: "draft" | "open" | "merged" | "closed";
+  attention: string;
+  source: "rest" | "cache" | "title";
+}
+
+export interface RestPull {
+  number: number;
+  title: string;
+  url: string;
+  draft: boolean;
+  state: "open" | "closed";
+  merged: boolean;
+  headRef: string;
+}
+
+export interface CachedPullRow {
+  environmentId: string;
+  owner: string | null;
+  repo: string | null;
+  number: number | null;
+  title: string | null;
+  url: string | null;
+  state: string | null;
+  attention: string | null;
+  fetchedAt: number;
+}
+
+export function isCacheFresh(row: CachedPullRow, now: number): boolean {
+  if (row.number === null) return now - row.fetchedAt < PR_MISS_CACHE_MS;
+  // Open and draft still move (merge, close). Trusting them for 15 minutes
+  // left merged PRs grey until the title fallback recached them as open.
+  if (row.state !== "merged" && row.state !== "closed") return false;
+  return now - row.fetchedAt < PR_CACHE_FRESH_MS;
+}
+
+export function sidebarPrFromCache(row: CachedPullRow): SidebarPullRequest | null {
+  if (
+    row.number === null ||
+    row.title === null ||
+    row.url === null ||
+    row.state === null ||
+    row.attention === null
+  ) {
+    return null;
+  }
+  return {
+    number: row.number,
+    title: row.title,
+    url: row.url,
+    state: asPrState(row.state),
+    attention: row.attention,
+    source: "cache",
+  };
+}
+
+function asPrState(value: string): SidebarPullRequest["state"] {
+  if (value === "draft" || value === "merged" || value === "closed") return value;
+  return "open";
+}
+
+export function parseRestPull(raw: unknown): RestPull | null {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+  const record = raw as Record<string, unknown>;
+  const number = record.number;
+  const title = record.title;
+  const url = record.html_url;
+  const state = record.state;
+  if (typeof number !== "number" || !Number.isInteger(number) || number < 1) return null;
+  if (typeof title !== "string" || typeof url !== "string") return null;
+  if (state !== "open" && state !== "closed") return null;
+  const head = record.head;
+  const headRef =
+    typeof head === "object" && head !== null && !Array.isArray(head)
+      ? (head as Record<string, unknown>).ref
+      : null;
+  return {
+    number,
+    title,
+    url,
+    draft: record.draft === true,
+    state,
+    merged: record.merged === true || (record.merged_at != null && record.merged_at !== ""),
+    headRef: typeof headRef === "string" ? headRef : "",
+  };
+}
+
+export function parseRestPulls(raw: unknown): RestPull[] {
+  if (!Array.isArray(raw)) return [];
+  const pulls: RestPull[] = [];
+  for (const entry of raw) {
+    const parsed = parseRestPull(entry);
+    if (parsed !== null) pulls.push(parsed);
+  }
+  return pulls;
+}
+
+export function matchPullForBranch(
+  pulls: readonly RestPull[],
+  branchName: string | null,
+): RestPull | null {
+  if (branchName === null || branchName.trim().length === 0) return null;
+  const wanted = branchName.trim();
+  if (wanted === "gitbutler/workspace") return null;
+  const matches = pulls.filter((pull) => pull.headRef === wanted);
+  if (matches.length === 0) return null;
+  const open = matches.find((pull) => pull.state === "open");
+  return open ?? matches[0] ?? null;
+}
+
+export function sidebarPrFromRest(pull: RestPull): SidebarPullRequest {
+  const state: SidebarPullRequest["state"] = pull.merged
+    ? "merged"
+    : pull.draft
+      ? "draft"
+      : pull.state === "closed"
+        ? "closed"
+        : "open";
+  const attention =
+    state === "merged"
+      ? "merged"
+      : state === "closed"
+        ? "closed"
+        : state === "draft"
+          ? "draft"
+          : "none";
+  return {
+    number: pull.number,
+    title: pull.title,
+    url: pull.url,
+    state,
+    attention,
+    source: "rest",
+  };
+}
+
+export function sidebarPrFromTitle(
+  title: string,
+  repo: GithubRepo | null,
+): SidebarPullRequest | null {
+  const ref = parsePrRefFromTitle(title);
+  if (ref === null) return null;
+  const owner = ref.owner ?? repo?.owner ?? null;
+  const name = ref.repo ?? repo?.repo ?? null;
+  if (owner === null || name === null) return null;
+  const state = "open";
+  return {
+    number: ref.number,
+    title,
+    url: githubPullUrl(owner, name, ref.number),
+    state,
+    attention: "none",
+    source: "title",
+  };
+}
+
+export function parseRestRateLimit(raw: unknown): {
+  restRemaining: number;
+  graphqlRemaining: number;
+} | null {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+  const resources = (raw as Record<string, unknown>).resources;
+  if (typeof resources !== "object" || resources === null || Array.isArray(resources)) {
+    return null;
+  }
+  const core = (resources as Record<string, unknown>).core;
+  const graphql = (resources as Record<string, unknown>).graphql;
+  const restRemaining =
+    typeof core === "object" && core !== null ? (core as Record<string, unknown>).remaining : null;
+  const graphqlRemaining =
+    typeof graphql === "object" && graphql !== null
+      ? (graphql as Record<string, unknown>).remaining
+      : null;
+  if (typeof restRemaining !== "number" || typeof graphqlRemaining !== "number") return null;
+  return { restRemaining, graphqlRemaining };
+}

--- a/plugins/gtd-sidebar/lib/pr-index.ts
+++ b/plugins/gtd-sidebar/lib/pr-index.ts
@@ -243,3 +243,19 @@ export function parseRestRateLimit(raw: unknown): {
   if (typeof restRemaining !== "number" || typeof graphqlRemaining !== "number") return null;
   return { restRemaining, graphqlRemaining };
 }
+
+/**
+ * True when only a numbered GET can decide this pull's attention.
+ *
+ * `/repos/.../pulls` omits `mergeable_state` — GitHub computes it lazily and
+ * serves it from the single-PR route alone. Everything read off the list
+ * therefore arrived as "unknown", collapsed to attention "none", and painted
+ * green: #377 showed as a healthy open PR while it was blocked with failing
+ * checks. Draft, merged, closed and auto-merge are all decidable from the list
+ * itself, so they never spend the extra call.
+ */
+export function needsMergeStateLookup(pull: RestPull): boolean {
+  if (pull.merged || pull.state === "closed") return false;
+  if (pull.draft || pull.autoMerge) return false;
+  return pull.mergeableState === "unknown";
+}

--- a/plugins/gtd-sidebar/lib/pr-index.ts
+++ b/plugins/gtd-sidebar/lib/pr-index.ts
@@ -15,8 +15,7 @@ export const PR_CACHE_FRESH_MS = 15 * 60 * 1000;
 export const PR_MISS_CACHE_MS = 5 * 60 * 1000;
 export const MIN_REST_REMAINING = 80;
 export const MAX_REPOS_PER_TICK = 12;
-export const MAX_PR_LOOKUPS_PER_TICK = 20;
-export const MAX_CLOSED_HEAD_LOOKUPS_PER_TICK = 8;
+export const MAX_PR_LOOKUPS_PER_TICK = 40;
 
 export interface SidebarPullRequest {
   number: number;
@@ -35,6 +34,9 @@ export interface RestPull {
   state: "open" | "closed";
   merged: boolean;
   headRef: string;
+  /** GitHub `mergeable_state`, or "unknown" when the list omits it. */
+  mergeableState: string;
+  autoMerge: boolean;
 }
 
 export interface CachedPullRow {
@@ -105,6 +107,8 @@ export function parseRestPull(raw: unknown): RestPull | null {
     state,
     merged: record.merged === true || (record.merged_at != null && record.merged_at !== ""),
     headRef: typeof headRef === "string" ? headRef : "",
+    mergeableState: typeof record.mergeable_state === "string" ? record.mergeable_state : "unknown",
+    autoMerge: record.auto_merge != null,
   };
 }
 
@@ -125,10 +129,60 @@ export function matchPullForBranch(
   if (branchName === null || branchName.trim().length === 0) return null;
   const wanted = branchName.trim();
   if (wanted === "gitbutler/workspace") return null;
+  if (/^\d+ GitButler branches$/u.test(wanted)) return null;
   const matches = pulls.filter((pull) => pull.headRef === wanted);
   if (matches.length === 0) return null;
   const open = matches.find((pull) => pull.state === "open");
   return open ?? matches[0] ?? null;
+}
+
+export function matchPullForBranches(
+  pulls: readonly RestPull[],
+  branchNames: readonly string[],
+): RestPull | null {
+  for (const branchName of branchNames) {
+    const matched = matchPullForBranch(pulls, branchName);
+    if (matched !== null) return matched;
+  }
+  return null;
+}
+
+export function matchPullForNumber(
+  pulls: readonly RestPull[],
+  number: number | null | undefined,
+): RestPull | null {
+  if (number === null || number === undefined) return null;
+  return pulls.find((pull) => pull.number === number) ?? null;
+}
+
+/** Closed first, then open, so an open PR with the same number wins. */
+export function mergeListedPulls(
+  open: readonly RestPull[],
+  closed: readonly RestPull[],
+): RestPull[] {
+  const byNumber = new Map<number, RestPull>();
+  for (const pull of closed) byNumber.set(pull.number, pull);
+  for (const pull of open) byNumber.set(pull.number, pull);
+  return [...byNumber.values()];
+}
+
+export function restPullAttention(pull: RestPull): string {
+  if (pull.merged) return "merged";
+  if (pull.state === "closed") return "closed";
+  if (pull.draft || pull.mergeableState === "draft") return "draft";
+  if (pull.autoMerge) return "queued";
+  switch (pull.mergeableState) {
+    case "dirty":
+      return "conflicts";
+    case "unstable":
+      return "checks_failed";
+    case "blocked":
+      return "blocked";
+    case "clean":
+      return "ready_to_merge";
+    default:
+      return "none";
+  }
 }
 
 export function sidebarPrFromRest(pull: RestPull): SidebarPullRequest {
@@ -139,20 +193,12 @@ export function sidebarPrFromRest(pull: RestPull): SidebarPullRequest {
       : pull.state === "closed"
         ? "closed"
         : "open";
-  const attention =
-    state === "merged"
-      ? "merged"
-      : state === "closed"
-        ? "closed"
-        : state === "draft"
-          ? "draft"
-          : "none";
   return {
     number: pull.number,
     title: pull.title,
     url: pull.url,
     state,
-    attention,
+    attention: restPullAttention(pull),
     source: "rest",
   };
 }

--- a/plugins/gtd-sidebar/lib/pr-status.ts
+++ b/plugins/gtd-sidebar/lib/pr-status.ts
@@ -18,6 +18,19 @@ const OPEN = "text-success";
 const DRAFT = "text-muted-foreground";
 const QUEUE = "text-[color:var(--attention)]";
 const DANGER = "text-destructive-text";
+/**
+ * Conflicts are the one red the user has to act on locally — a rebase, not a
+ * re-run or a re-review. Striking the number through separates it from the
+ * other danger states at a glance.
+ *
+ * The card's own `hover:underline` sets the same property and Tailwind emits
+ * it after this rule, so hovering would otherwise trade the strikethrough —
+ * the one thing carrying the conflict — for an underline. `!` is what settles
+ * that: the two utilities are siblings on one element, so neither source order
+ * nor tailwind-merge (different groups, it keeps both) decides it for us.
+ */
+const CONFLICTS =
+  "text-destructive-text line-through hover:[text-decoration-line:underline_line-through]!";
 const PENDING = "text-[color:var(--warning-text)]";
 const READY = "text-success";
 
@@ -25,9 +38,10 @@ export function prNumberClassName(pr: PrNumberAppearance): string {
   switch (pr.attention) {
     case "merged":
       return MERGED;
+    case "conflicts":
+      return CONFLICTS;
     case "closed":
     case "checks_failed":
-    case "conflicts":
     case "changes_requested":
     case "blocked":
     case "review_requested":

--- a/plugins/gtd-sidebar/lib/pr-status.ts
+++ b/plugins/gtd-sidebar/lib/pr-status.ts
@@ -16,7 +16,12 @@ const MERGED = "text-[color:var(--pr-merged)]";
 const OPEN = "text-success";
 /** Draft is muted, matching bb's draft token. */
 const DRAFT = "text-muted-foreground";
-const QUEUE = "text-[color:var(--attention)]";
+/**
+ * Merge-queue is in-flight, not an alarm. `--attention` is the peach
+ * attention-dot and reads too orange; `--warning-text` is the ochre
+ * Full Access uses in bb's permission-mode switcher.
+ */
+const QUEUE = "text-[color:var(--warning-text)]";
 const DANGER = "text-destructive-text";
 /**
  * Conflicts are the one red the user has to act on locally — a rebase, not a

--- a/plugins/gtd-sidebar/lib/pr-status.ts
+++ b/plugins/gtd-sidebar/lib/pr-status.ts
@@ -12,14 +12,14 @@ export interface PrNumberAppearance {
 }
 
 const MERGED = "text-[color:var(--pr-merged)]";
-/** Quiet open PRs stay on the meta line's own grey so they cannot vanish into a theme token. */
-const OPEN = "text-muted-foreground";
-/** Draft is the same grey, washed out, so it stays visible and distinct. */
-const DRAFT = "text-muted-foreground/50";
+/** bb paints open PRs with `text-success`, not the meta line's grey. */
+const OPEN = "text-success";
+/** Draft is muted, matching bb's draft token. */
+const DRAFT = "text-muted-foreground";
 const QUEUE = "text-[color:var(--attention)]";
 const DANGER = "text-destructive-text";
 const PENDING = "text-[color:var(--warning-text)]";
-const READY = "text-success-foreground";
+const READY = "text-success";
 
 export function prNumberClassName(pr: PrNumberAppearance): string {
   switch (pr.attention) {

--- a/plugins/gtd-sidebar/lib/pr-status.ts
+++ b/plugins/gtd-sidebar/lib/pr-status.ts
@@ -1,0 +1,97 @@
+/**
+ * Colour for a sidebar PR number, matching bb's own pull-request tokens.
+ *
+ * Draft and merge-queue used to fall through to the same muted grey as an
+ * ordinary open PR that is not ready, so those two GitHub states were
+ * invisible on the card. Attention is the rolled-up signal and wins; state
+ * covers the cases attention does not distinguish.
+ */
+export interface PrNumberAppearance {
+  state: string;
+  attention: string;
+}
+
+const MERGED = "text-[color:var(--pr-merged)]";
+/** Quiet open PRs stay on the meta line's own grey so they cannot vanish into a theme token. */
+const OPEN = "text-muted-foreground";
+/** Draft is the same grey, washed out, so it stays visible and distinct. */
+const DRAFT = "text-muted-foreground/50";
+const QUEUE = "text-[color:var(--attention)]";
+const DANGER = "text-destructive-text";
+const PENDING = "text-[color:var(--warning-text)]";
+const READY = "text-success-foreground";
+
+export function prNumberClassName(pr: PrNumberAppearance): string {
+  switch (pr.attention) {
+    case "merged":
+      return MERGED;
+    case "closed":
+    case "checks_failed":
+    case "conflicts":
+    case "changes_requested":
+    case "blocked":
+    case "review_requested":
+      return DANGER;
+    case "queued":
+      return QUEUE;
+    case "draft":
+      return DRAFT;
+    case "checks_pending":
+      return PENDING;
+    case "ready_to_merge":
+      return READY;
+    default:
+      break;
+  }
+
+  switch (pr.state) {
+    case "merged":
+      return MERGED;
+    case "closed":
+      return DANGER;
+    case "draft":
+      return DRAFT;
+    default:
+      return OPEN;
+  }
+}
+
+export function prNumberLabel(pr: PrNumberAppearance): string {
+  switch (pr.attention) {
+    case "merged":
+      return "Merged pull request";
+    case "closed":
+      return "Closed pull request";
+    case "queued":
+      return "Pull request in merge queue";
+    case "draft":
+      return "Draft pull request";
+    case "checks_failed":
+      return "Pull request checks failed";
+    case "conflicts":
+      return "Pull request has conflicts";
+    case "changes_requested":
+      return "Pull request has changes requested";
+    case "blocked":
+      return "Pull request is blocked";
+    case "review_requested":
+      return "Pull request review requested";
+    case "checks_pending":
+      return "Pull request checks pending";
+    case "ready_to_merge":
+      return "Pull request ready to merge";
+    default:
+      break;
+  }
+
+  switch (pr.state) {
+    case "merged":
+      return "Merged pull request";
+    case "closed":
+      return "Closed pull request";
+    case "draft":
+      return "Draft pull request";
+    default:
+      return "Open pull request";
+  }
+}

--- a/plugins/gtd-sidebar/lib/pr-watch-run.ts
+++ b/plugins/gtd-sidebar/lib/pr-watch-run.ts
@@ -1,0 +1,217 @@
+import {
+  MAX_PR_BACKFILL_PER_TICK,
+  buildSnoozedPrWatchQuery,
+  canonicalPullRequestUrl,
+  diffSnapshots,
+  fingerprintOf,
+  isGraphqlRateLimited,
+  parseSnoozedPrWatchResponse,
+  parseStoredSnapshot,
+  serializeSnapshot,
+  shouldSkipForRateLimit,
+  skipUntilMsFromResetAt,
+  type PrChange,
+  type PrWatchSnapshot,
+} from "./pr-watch.ts";
+
+export interface SnoozedWatchTarget {
+  threadId: string;
+  snoozedUntil: number;
+}
+
+export interface StoredPrWatch {
+  threadId: string;
+  prUrl: string;
+  snapshotJson: string | null;
+}
+
+export interface PrWatchPollStore {
+  listSnoozed(): SnoozedWatchTarget[];
+  getWatch(threadId: string): StoredPrWatch | undefined;
+  upsertWatch(row: StoredPrWatch & { lastPolledAt: number }): void;
+}
+
+export interface PrWatchPollDeps {
+  now: number;
+  store: PrWatchPollStore;
+  graphql: (query: string) => Promise<{ raw: unknown; stderr: string; exitCode: number }>;
+  resolvePrUrl: (threadId: string) => Promise<string | null>;
+  wakeThread: (
+    threadId: string,
+    snapshot: PrWatchSnapshot,
+    changes: readonly PrChange[],
+  ) => Promise<void>;
+  log: { info(message: string): void; warn(message: string): void };
+  remainingHint: number | null;
+  skipUntilMs: number | null;
+}
+
+export interface PrWatchPollResult {
+  remaining: number | null;
+  skipUntilMs: number | null;
+  queried: number;
+  woken: number;
+  baselined: number;
+}
+
+export async function pollSnoozedPullRequests(deps: PrWatchPollDeps): Promise<PrWatchPollResult> {
+  if (shouldSkipForRateLimit(deps.remainingHint, deps.skipUntilMs, deps.now)) {
+    deps.log.info("skipping snoozed PR watch until the GitHub rate limit resets");
+    return {
+      remaining: deps.remainingHint,
+      skipUntilMs: deps.skipUntilMs,
+      queried: 0,
+      woken: 0,
+      baselined: 0,
+    };
+  }
+
+  const snoozed = deps.store.listSnoozed().filter((row) => row.snoozedUntil > deps.now);
+
+  let backfilled = 0;
+  for (const row of snoozed) {
+    if (deps.store.getWatch(row.threadId) !== undefined) continue;
+    if (backfilled >= MAX_PR_BACKFILL_PER_TICK) break;
+    backfilled += 1;
+    try {
+      const url = await deps.resolvePrUrl(row.threadId);
+      const canonical = url === null ? null : canonicalPullRequestUrl(url);
+      if (canonical === null) continue;
+      deps.store.upsertWatch({
+        threadId: row.threadId,
+        prUrl: canonical,
+        snapshotJson: null,
+        lastPolledAt: 0,
+      });
+    } catch (error) {
+      deps.log.warn(`could not resolve a PR for snoozed thread ${row.threadId}: ${String(error)}`);
+    }
+  }
+
+  const urls: string[] = [];
+  const watchersByUrl = new Map<string, string[]>();
+  for (const row of snoozed) {
+    const watch = deps.store.getWatch(row.threadId);
+    if (watch === undefined) continue;
+    const canonical = canonicalPullRequestUrl(watch.prUrl);
+    if (canonical === null) continue;
+    urls.push(canonical);
+    const watchers = watchersByUrl.get(canonical) ?? [];
+    watchers.push(row.threadId);
+    watchersByUrl.set(canonical, watchers);
+  }
+
+  if (urls.length === 0) {
+    return {
+      remaining: deps.remainingHint,
+      skipUntilMs: null,
+      queried: 0,
+      woken: 0,
+      baselined: 0,
+    };
+  }
+
+  const query = buildSnoozedPrWatchQuery(urls);
+  const result = await deps.graphql(query);
+  const parsed = parseSnoozedPrWatchResponse(result.raw);
+
+  if (
+    isGraphqlRateLimited(result.raw, result.stderr) ||
+    (result.exitCode !== 0 && parsed.snapshots.length === 0)
+  ) {
+    const skipUntilMs =
+      parsed.rateLimit !== null
+        ? skipUntilMsFromResetAt(parsed.rateLimit.resetAt, deps.now)
+        : deps.now + 60 * 60 * 1000;
+    deps.log.warn("GitHub refused the snoozed PR watch; waiting for the rate limit to reset");
+    return {
+      remaining: parsed.rateLimit?.remaining ?? 0,
+      skipUntilMs,
+      queried: 0,
+      woken: 0,
+      baselined: 0,
+    };
+  }
+
+  const remaining = parsed.rateLimit?.remaining ?? deps.remainingHint;
+  const skipUntilMs =
+    parsed.rateLimit !== null && shouldSkipForRateLimit(parsed.rateLimit.remaining, null, deps.now)
+      ? skipUntilMsFromResetAt(parsed.rateLimit.resetAt, deps.now)
+      : null;
+
+  let woken = 0;
+  let baselined = 0;
+  const snapshotsByUrl = new Map(
+    parsed.snapshots.map((snapshot) => [
+      canonicalPullRequestUrl(snapshot.url) ?? snapshot.url,
+      snapshot,
+    ]),
+  );
+
+  for (const [url, threadIds] of watchersByUrl) {
+    const snapshot = snapshotsByUrl.get(url);
+    if (snapshot === undefined) continue;
+    const nextJson = serializeSnapshot(snapshot);
+    const nextFingerprint = fingerprintOf(snapshot);
+
+    for (const threadId of threadIds) {
+      const watch = deps.store.getWatch(threadId);
+      const previous = parseStoredSnapshot(watch?.snapshotJson ?? null);
+      if (previous === null) {
+        deps.store.upsertWatch({
+          threadId,
+          prUrl: url,
+          snapshotJson: nextJson,
+          lastPolledAt: deps.now,
+        });
+        baselined += 1;
+        continue;
+      }
+
+      if (fingerprintOf(previous) === nextFingerprint) {
+        deps.store.upsertWatch({
+          threadId,
+          prUrl: url,
+          snapshotJson: nextJson,
+          lastPolledAt: deps.now,
+        });
+        continue;
+      }
+
+      const changes = diffSnapshots(previous, snapshot);
+      if (changes.length === 0) {
+        deps.store.upsertWatch({
+          threadId,
+          prUrl: url,
+          snapshotJson: nextJson,
+          lastPolledAt: deps.now,
+        });
+        continue;
+      }
+
+      try {
+        await deps.wakeThread(threadId, snapshot, changes);
+        woken += 1;
+      } catch (error) {
+        // Leave the previous snapshot in place so the next hour retries the
+        // same diff. Restoring the new snapshot here would swallow a failed
+        // wake and never ask again.
+        deps.log.warn(`could not wake snoozed thread ${threadId}: ${String(error)}`);
+      }
+    }
+  }
+
+  if (parsed.rateLimit !== null) {
+    deps.log.info(
+      `snoozed PR watch queried ${parsed.snapshots.length} PRs, cost ${parsed.rateLimit.cost}, ${parsed.rateLimit.remaining}/${parsed.rateLimit.limit} remaining`,
+    );
+  }
+
+  return {
+    remaining,
+    skipUntilMs,
+    queried: parsed.snapshots.length,
+    woken,
+    baselined,
+  };
+}

--- a/plugins/gtd-sidebar/lib/pr-watch.ts
+++ b/plugins/gtd-sidebar/lib/pr-watch.ts
@@ -1,0 +1,427 @@
+/**
+ * Hourly GitHub watch for snoozed threads.
+ *
+ * One GraphQL query covers every watched PR. The first observation is a
+ * baseline, not a wake: otherwise the first hour would unsnooze everything
+ * that already had comments. Later ticks compare a fingerprint of comments,
+ * reviews, check rollup, and deployments.
+ *
+ * Rate limit: GitHub GraphQL is 5,000 points per hour. This query's cost
+ * scales with the number of PRs, not with nested page size (each connection
+ * is totalCount or last:1). Skip the tick when remaining points are too low
+ * to pay for another run, and wait until GitHub's own reset rather than
+ * retrying inside the hour.
+ */
+
+export const MAX_WATCHED_PRS = 80;
+export const MAX_PR_BACKFILL_PER_TICK = 8;
+export const MIN_RATE_LIMIT_REMAINING = 200;
+
+export interface PrWatchSnapshot {
+  nodeId: string;
+  url: string;
+  number: number;
+  title: string;
+  updatedAt: string;
+  commentCount: number;
+  reviewCount: number;
+  reviewThreadCount: number;
+  latestReviewState: string | null;
+  latestReviewAuthor: string | null;
+  checkRollup: string | null;
+  latestDeployment: {
+    createdAt: string;
+    state: string;
+    environment: string | null;
+  } | null;
+}
+
+export interface PrWatchRateLimit {
+  cost: number;
+  remaining: number;
+  resetAt: string;
+  limit: number;
+}
+
+export interface PrChange {
+  kind: "comments" | "reviews" | "review-threads" | "checks" | "deployments" | "updated";
+  text: string;
+}
+
+const GITHUB_PULL_URL =
+  /^https:\/\/github\.com\/([^/?#]+)\/([^/?#]+)\/pull\/(\d+)(?:\/.*)?(?:\?.*)?$/i;
+
+export function canonicalPullRequestUrl(url: string): string | null {
+  const match = url.trim().match(GITHUB_PULL_URL);
+  if (match === null) return null;
+  const owner = match[1];
+  const repo = match[2]?.replace(/\.git$/i, "");
+  const number = match[3];
+  if (!owner || !repo || !number) return null;
+  return `https://github.com/${owner}/${repo}/pull/${number}`;
+}
+
+export function fingerprintOf(snapshot: PrWatchSnapshot): string {
+  return JSON.stringify({
+    updatedAt: snapshot.updatedAt,
+    commentCount: snapshot.commentCount,
+    reviewCount: snapshot.reviewCount,
+    reviewThreadCount: snapshot.reviewThreadCount,
+    latestReviewState: snapshot.latestReviewState,
+    checkRollup: snapshot.checkRollup,
+    latestDeployment: snapshot.latestDeployment,
+  });
+}
+
+export function diffSnapshots(previous: PrWatchSnapshot, next: PrWatchSnapshot): PrChange[] {
+  const changes: PrChange[] = [];
+
+  if (next.commentCount > previous.commentCount) {
+    const added = next.commentCount - previous.commentCount;
+    changes.push({
+      kind: "comments",
+      text: `${added} new comment${added === 1 ? "" : "s"}`,
+    });
+  }
+
+  if (
+    next.reviewCount > previous.reviewCount ||
+    (next.latestReviewState !== null && next.latestReviewState !== previous.latestReviewState)
+  ) {
+    const who = next.latestReviewAuthor ? ` from ${next.latestReviewAuthor}` : "";
+    const state = next.latestReviewState ?? "submitted";
+    changes.push({
+      kind: "reviews",
+      text: `new review${who} (${state})`,
+    });
+  }
+
+  if (next.reviewThreadCount > previous.reviewThreadCount) {
+    const added = next.reviewThreadCount - previous.reviewThreadCount;
+    changes.push({
+      kind: "review-threads",
+      text: `${added} new inline comment thread${added === 1 ? "" : "s"}`,
+    });
+  }
+
+  if (next.checkRollup !== previous.checkRollup && next.checkRollup !== null) {
+    const from = previous.checkRollup ?? "unknown";
+    changes.push({
+      kind: "checks",
+      text: `checks ${from} → ${next.checkRollup}`,
+    });
+  }
+
+  const prevDeploy = previous.latestDeployment;
+  const nextDeploy = next.latestDeployment;
+  if (
+    nextDeploy !== null &&
+    (prevDeploy === null ||
+      nextDeploy.createdAt > prevDeploy.createdAt ||
+      nextDeploy.state !== prevDeploy.state)
+  ) {
+    const env = nextDeploy.environment ? ` to ${nextDeploy.environment}` : "";
+    changes.push({
+      kind: "deployments",
+      text: `deployment${env}: ${nextDeploy.state}`,
+    });
+  }
+
+  if (changes.length === 0 && next.updatedAt !== previous.updatedAt) {
+    changes.push({ kind: "updated", text: "PR updated on GitHub" });
+  }
+
+  return changes;
+}
+
+export function formatAgentWakeMessage(
+  snapshot: PrWatchSnapshot,
+  changes: readonly PrChange[],
+): string {
+  const lines = changes.map((change) => `- ${change.text}`);
+  return [
+    `GitHub pull request #${snapshot.number} changed while this thread was snoozed.`,
+    snapshot.title.trim().length > 0 ? snapshot.title.trim() : null,
+    snapshot.url,
+    "",
+    "What changed:",
+    ...lines,
+    "",
+    "Please inspect the pull request and continue any work this update unblocks.",
+  ]
+    .filter((line) => line !== null)
+    .join("\n");
+}
+
+export function shouldSkipForRateLimit(
+  remaining: number | null,
+  skipUntilMs: number | null,
+  now: number,
+): boolean {
+  if (skipUntilMs !== null && now < skipUntilMs) return true;
+  if (remaining === null) return false;
+  return remaining < MIN_RATE_LIMIT_REMAINING;
+}
+
+export function skipUntilMsFromResetAt(resetAt: string, now: number): number {
+  const reset = Date.parse(resetAt);
+  if (!Number.isFinite(reset) || reset <= now) return now + 60 * 60 * 1000;
+  return reset;
+}
+
+function escapeGraphQlString(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+const PR_WATCH_FRAGMENT = `fragment PrWatchFields on PullRequest {
+  id
+  url
+  number
+  title
+  updatedAt
+  comments(first: 1) { totalCount }
+  reviews(first: 1) { totalCount }
+  reviewThreads(first: 1) { totalCount }
+  latestReviews: reviews(last: 1) {
+    nodes { state author { login } }
+  }
+  commits(last: 1) {
+    nodes {
+      commit {
+        statusCheckRollup { state }
+        deployments(last: 3) {
+          nodes { createdAt state environment }
+        }
+      }
+    }
+  }
+}`;
+
+/**
+ * One query, one round trip. Aliased `resource(url:)` lookups so the first
+ * poll does not need GraphQL node ids. GitHub caps a query's size well above
+ * {@link MAX_WATCHED_PRS} of these aliases.
+ */
+export function buildSnoozedPrWatchQuery(urls: readonly string[]): string {
+  const unique: string[] = [];
+  const seen = new Set<string>();
+  for (const url of urls) {
+    const canonical = canonicalPullRequestUrl(url);
+    if (canonical === null || seen.has(canonical)) continue;
+    seen.add(canonical);
+    unique.push(canonical);
+    if (unique.length >= MAX_WATCHED_PRS) break;
+  }
+
+  const aliases = unique.map((url, index) => {
+    return `  p${index}: resource(url: "${escapeGraphQlString(url)}") { ...PrWatchFields }`;
+  });
+
+  return [
+    "query GtdSnoozedPrWatch {",
+    "  rateLimit { cost remaining resetAt limit }",
+    ...aliases,
+    "}",
+    PR_WATCH_FRAGMENT,
+  ].join("\n");
+}
+
+export function watchedUrlsForQuery(urls: readonly string[]): string[] {
+  const unique: string[] = [];
+  const seen = new Set<string>();
+  for (const url of urls) {
+    const canonical = canonicalPullRequestUrl(url);
+    if (canonical === null || seen.has(canonical)) continue;
+    seen.add(canonical);
+    unique.push(canonical);
+    if (unique.length >= MAX_WATCHED_PRS) break;
+  }
+  return unique;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function totalCount(value: unknown): number {
+  const record = asRecord(value);
+  const count = record === null ? null : asNumber(record.totalCount);
+  return count === null || count < 0 ? 0 : count;
+}
+
+function parseDeployment(nodes: unknown): PrWatchSnapshot["latestDeployment"] {
+  if (!Array.isArray(nodes)) return null;
+  let latest: PrWatchSnapshot["latestDeployment"] = null;
+  for (const node of nodes) {
+    const record = asRecord(node);
+    if (record === null) continue;
+    const createdAt = asString(record.createdAt);
+    const state = asString(record.state);
+    if (createdAt === null || state === null) continue;
+    const environment = asString(record.environment);
+    if (latest === null || createdAt > latest.createdAt) {
+      latest = { createdAt, state, environment };
+    }
+  }
+  return latest;
+}
+
+export function parsePullRequestNode(value: unknown): PrWatchSnapshot | null {
+  const record = asRecord(value);
+  if (record === null) return null;
+  const nodeId = asString(record.id);
+  const url = asString(record.url);
+  const number = asNumber(record.number);
+  const title = asString(record.title) ?? "";
+  const updatedAt = asString(record.updatedAt);
+  if (nodeId === null || url === null || number === null || updatedAt === null) {
+    return null;
+  }
+  if (!Number.isInteger(number) || number < 1) return null;
+
+  const latestReviews = asRecord(record.latestReviews);
+  const reviewNodes = Array.isArray(latestReviews?.nodes) ? latestReviews.nodes : [];
+  const latestReview = asRecord(reviewNodes[0] ?? null);
+  const latestReviewAuthor = asRecord(latestReview?.author ?? null);
+
+  const commits = asRecord(record.commits);
+  const commitNodes = Array.isArray(commits?.nodes) ? commits.nodes : [];
+  const commitWrap = asRecord(commitNodes[0] ?? null);
+  const commit = asRecord(commitWrap?.commit ?? null);
+  const rollup = asRecord(commit?.statusCheckRollup ?? null);
+  const deployments = asRecord(commit?.deployments ?? null);
+
+  return {
+    nodeId,
+    url,
+    number,
+    title,
+    updatedAt,
+    commentCount: totalCount(record.comments),
+    reviewCount: totalCount(record.reviews),
+    reviewThreadCount: totalCount(record.reviewThreads),
+    latestReviewState: asString(latestReview?.state ?? null),
+    latestReviewAuthor: asString(latestReviewAuthor?.login ?? null),
+    checkRollup: asString(rollup?.state ?? null),
+    latestDeployment: parseDeployment(deployments?.nodes ?? null),
+  };
+}
+
+export function parseRateLimit(value: unknown): PrWatchRateLimit | null {
+  const record = asRecord(value);
+  if (record === null) return null;
+  const cost = asNumber(record.cost);
+  const remaining = asNumber(record.remaining);
+  const limit = asNumber(record.limit);
+  const resetAt = asString(record.resetAt);
+  if (cost === null || remaining === null || limit === null || resetAt === null) {
+    return null;
+  }
+  return { cost, remaining, resetAt, limit };
+}
+
+export function parseSnoozedPrWatchResponse(raw: unknown): {
+  snapshots: PrWatchSnapshot[];
+  rateLimit: PrWatchRateLimit | null;
+} {
+  const root = asRecord(raw);
+  const data = asRecord(root?.data ?? root);
+  if (data === null) return { snapshots: [], rateLimit: null };
+
+  const snapshots: PrWatchSnapshot[] = [];
+  for (const [key, value] of Object.entries(data)) {
+    if (key === "rateLimit" || !key.startsWith("p")) continue;
+    const snapshot = parsePullRequestNode(value);
+    if (snapshot !== null) snapshots.push(snapshot);
+  }
+
+  return { snapshots, rateLimit: parseRateLimit(data.rateLimit) };
+}
+
+export function isGraphqlRateLimited(raw: unknown, stderr: string): boolean {
+  const blob = `${JSON.stringify(raw)} ${stderr}`.toLowerCase();
+  return (
+    blob.includes("rate limit") ||
+    blob.includes("rate_limited") ||
+    blob.includes("ratelimited") ||
+    blob.includes("secondaryrate") ||
+    blob.includes("you have exceeded a secondary rate limit")
+  );
+}
+
+export function parseStoredSnapshot(raw: string | null): PrWatchSnapshot | null {
+  if (raw === null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const record = asRecord(parsed);
+  if (record === null) return null;
+  const nodeId = asString(record.nodeId);
+  const url = asString(record.url);
+  const number = asNumber(record.number);
+  const title = asString(record.title) ?? "";
+  const updatedAt = asString(record.updatedAt);
+  const commentCount = asNumber(record.commentCount);
+  const reviewCount = asNumber(record.reviewCount);
+  const reviewThreadCount = asNumber(record.reviewThreadCount);
+  if (
+    nodeId === null ||
+    url === null ||
+    number === null ||
+    updatedAt === null ||
+    commentCount === null ||
+    reviewCount === null ||
+    reviewThreadCount === null
+  ) {
+    return null;
+  }
+  if (!Number.isInteger(number) || number < 1) return null;
+
+  const latestDeploymentRecord = asRecord(record.latestDeployment);
+  const latestDeployment =
+    latestDeploymentRecord === null
+      ? null
+      : (() => {
+          const createdAt = asString(latestDeploymentRecord.createdAt);
+          const state = asString(latestDeploymentRecord.state);
+          if (createdAt === null || state === null) return null;
+          return {
+            createdAt,
+            state,
+            environment: asString(latestDeploymentRecord.environment),
+          };
+        })();
+
+  return {
+    nodeId,
+    url,
+    number,
+    title,
+    updatedAt,
+    commentCount,
+    reviewCount,
+    reviewThreadCount,
+    latestReviewState: asString(record.latestReviewState),
+    latestReviewAuthor: asString(record.latestReviewAuthor),
+    checkRollup: asString(record.checkRollup),
+    latestDeployment,
+  };
+}
+
+export function serializeSnapshot(snapshot: PrWatchSnapshot): string {
+  return JSON.stringify(snapshot);
+}

--- a/plugins/gtd-sidebar/lib/webhook-listener.ts
+++ b/plugins/gtd-sidebar/lib/webhook-listener.ts
@@ -1,0 +1,127 @@
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import { githubWebhookPath } from "./github-webhook.ts";
+
+export interface WebhookHttpResult {
+  status: number;
+  body: unknown;
+}
+
+export type WebhookRequestHandler = (input: {
+  raw: string;
+  event: string;
+  signature: string | undefined;
+}) => Promise<WebhookHttpResult>;
+
+const MAX_BODY_BYTES = 5 * 1024 * 1024;
+
+function header(req: IncomingMessage, name: string): string | undefined {
+  const value = req.headers[name];
+  if (typeof value === "string") return value;
+  if (Array.isArray(value) && typeof value[0] === "string") return value[0];
+  return undefined;
+}
+
+function readBody(req: IncomingMessage, limit: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    req.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > limit) {
+        req.destroy();
+        reject(new Error("payload too large"));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      resolve(Buffer.concat(chunks).toString("utf8"));
+    });
+    req.on("error", reject);
+  });
+}
+
+function sendJson(res: import("node:http").ServerResponse, status: number, body: unknown): void {
+  const json = JSON.stringify(body);
+  res.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    "content-length": Buffer.byteLength(json),
+  });
+  res.end(json);
+}
+
+export async function startWebhookListener(args: {
+  handle: WebhookRequestHandler;
+  signal?: AbortSignal;
+}): Promise<{ port: number; close: () => Promise<void> }> {
+  const path = githubWebhookPath();
+  const server: Server = createServer((req, res) => {
+    void (async () => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (url.pathname !== path) {
+        sendJson(res, 404, { ok: false, error: "not found" });
+        return;
+      }
+      if (req.method === "GET") {
+        sendJson(res, 200, { ok: true });
+        return;
+      }
+      if (req.method !== "POST") {
+        sendJson(res, 405, { ok: false, error: "method not allowed" });
+        return;
+      }
+      let raw: string;
+      try {
+        raw = await readBody(req, MAX_BODY_BYTES);
+      } catch {
+        sendJson(res, 413, { ok: false, error: "payload too large" });
+        return;
+      }
+      const result = await args.handle({
+        raw,
+        event: header(req, "x-github-event") ?? "",
+        signature: header(req, "x-hub-signature-256"),
+      });
+      sendJson(res, result.status, result.body);
+    })().catch(() => {
+      if (!res.headersSent) sendJson(res, 500, { ok: false, error: "internal error" });
+      else res.end();
+    });
+  });
+
+  const close = (): Promise<void> =>
+    new Promise((resolve, reject) => {
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+
+  if (args.signal !== undefined) {
+    if (args.signal.aborted) {
+      server.close();
+      throw new Error("aborted");
+    }
+    args.signal.addEventListener(
+      "abort",
+      () => {
+        server.close();
+      },
+      { once: true },
+    );
+  }
+
+  const port = await new Promise<number>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        reject(new Error("webhook listener failed to bind"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+
+  return { port, close };
+}

--- a/plugins/gtd-sidebar/lib/webhook-tunnel-status.ts
+++ b/plugins/gtd-sidebar/lib/webhook-tunnel-status.ts
@@ -1,0 +1,23 @@
+export type WebhookTunnelState =
+  | "off"
+  | "checking"
+  | "missing-cloudflared"
+  | "starting"
+  | "live"
+  | "error";
+
+export interface WebhookTunnelStatus {
+  enabled: boolean;
+  state: WebhookTunnelState;
+  url: string | null;
+  origin: string | null;
+  error: string | null;
+}
+
+export const WEBHOOK_TUNNEL_STATUS_OFF: WebhookTunnelStatus = {
+  enabled: false,
+  state: "off",
+  url: null,
+  origin: null,
+  error: null,
+};

--- a/plugins/gtd-sidebar/server.ts
+++ b/plugins/gtd-sidebar/server.ts
@@ -13,6 +13,18 @@ import { z } from "zod";
 import { parseArchivedThreadIds } from "./lib/lifecycle.ts";
 import { isWithinSettledWindow } from "./lib/settled-threads.ts";
 import { gitButlerHostContract } from "./lib/gitbutler.ts";
+import { createGhRunner, githubGraphql, githubRestJson, resolveGhPath } from "./lib/gh-cli.ts";
+import { formatAgentWakeMessage, canonicalPullRequestUrl } from "./lib/pr-watch.ts";
+import { pollSnoozedPullRequests, type StoredPrWatch } from "./lib/pr-watch-run.ts";
+import {
+  parseRestPull,
+  parseRestPulls,
+  parseRestRateLimit,
+  type CachedPullRow,
+  type RestPull,
+} from "./lib/pr-index.ts";
+import { resolveThreadPullRequests } from "./lib/pr-index-run.ts";
+import { upsertBrowserTab, type InAppBrowserTab } from "./lib/open-in-app-browser.ts";
 
 const migrations = [
   `CREATE TABLE IF NOT EXISTS thread_lifecycle (
@@ -25,7 +37,25 @@ const migrations = [
   // Without them, un-settling gives the parent back and leaves its children
   // archived for good.
   `ALTER TABLE thread_lifecycle ADD COLUMN archived_thread_ids TEXT`,
+  `CREATE TABLE IF NOT EXISTS snoozed_pr_watch (
+     thread_id       TEXT PRIMARY KEY,
+     pr_url          TEXT NOT NULL,
+     snapshot_json   TEXT,
+     last_polled_at  INTEGER
+   )`,
+  `CREATE TABLE IF NOT EXISTS thread_pr_index (
+     environment_id  TEXT PRIMARY KEY,
+     owner           TEXT,
+     repo            TEXT,
+     number          INTEGER,
+     title           TEXT,
+     url             TEXT,
+     state           TEXT,
+     attention       TEXT,
+     fetched_at      INTEGER NOT NULL
+   )`,
 ];
+const PR_WATCH_RATE_LIMIT_KEY = "pr-watch:rate-limit";
 
 export interface StoredLifecycleRow {
   threadId: string;
@@ -45,6 +75,31 @@ interface LifecycleDbRow {
 }
 
 const threadIdSchema = z.object({ threadId: z.string().trim().min(1) });
+
+function asPersistedBrowserTab(
+  candidate: {
+    environmentId?: unknown;
+    id: string;
+    kind: string;
+    title?: unknown;
+    url?: string;
+  },
+  fallback: InAppBrowserTab,
+): InAppBrowserTab {
+  if (candidate.kind !== "browser" || typeof candidate.url !== "string") return fallback;
+  const title = candidate.title;
+  const environmentId = candidate.environmentId;
+  return {
+    environmentId:
+      typeof environmentId === "string" || environmentId === null
+        ? environmentId
+        : fallback.environmentId,
+    id: candidate.id,
+    kind: "browser",
+    title: typeof title === "string" && title.length > 0 ? title : fallback.title,
+    url: candidate.url,
+  };
+}
 
 export const gtdSidebarRpcContract = defineRpcContract({
   listEnvironmentBranches: {
@@ -130,10 +185,89 @@ export const gtdSidebarRpcContract = defineRpcContract({
       threadId: z.string().trim().min(1),
       // Absolute wake time, so a snooze means the same thing on every device.
       snoozedUntil: z.number().int().positive(),
+      // Optional. The hourly GitHub watch uses it so the first poll does not
+      // have to call `gh pr view` for a thread the card already identified.
+      pullRequestUrl: z.string().url().optional(),
     }),
     output: z.object({ ok: z.boolean() }),
   },
   unsnooze: { input: threadIdSchema, output: z.object({ ok: z.boolean() }) },
+  listThreadPullRequests: {
+    input: z
+      .object({
+        threads: z
+          .array(
+            z
+              .object({
+                threadId: z.string().trim().min(1),
+                environmentId: z.string().trim().min(1).nullable(),
+                branchName: z.string().nullable(),
+                title: z.string(),
+              })
+              .strict(),
+          )
+          .max(100),
+      })
+      .strict(),
+    output: z.object({
+      pullRequests: z.array(
+        z.object({
+          threadId: z.string(),
+          number: z.number().int().positive(),
+          title: z.string(),
+          url: z.string(),
+          state: z.string(),
+          attention: z.string(),
+          source: z.enum(["rest", "cache", "title"]),
+        }),
+      ),
+    }),
+  },
+  logPrDebug: {
+    input: z
+      .object({
+        threadId: z.string().trim().min(1),
+        environmentId: z.string().nullable(),
+        isLoading: z.boolean(),
+        hasPullRequest: z.boolean(),
+        number: z.number().int().positive().nullable(),
+        state: z.string().nullable(),
+        attention: z.string().nullable(),
+      })
+      .strict(),
+    output: z.object({ ok: z.boolean() }),
+  },
+  // Persist a browser tab on the thread so the host's panel reconcile does
+  // not wipe the localStorage reveal the card writes on click.
+  openThreadBrowserTab: {
+    input: z
+      .object({
+        threadId: z.string().trim().min(1),
+        tab: z
+          .object({
+            environmentId: z.string().min(1).nullable(),
+            id: z.string().min(1),
+            kind: z.literal("browser"),
+            title: z.string().min(1).nullable(),
+            url: z.string().min(1),
+          })
+          .strict(),
+      })
+      .strict(),
+    output: z
+      .object({
+        tab: z
+          .object({
+            environmentId: z.string().min(1).nullable(),
+            id: z.string().min(1),
+            kind: z.literal("browser"),
+            title: z.string().min(1).nullable(),
+            url: z.string().min(1),
+          })
+          .strict(),
+      })
+      .strict(),
+  },
 });
 
 /** Channel the frontend re-reads on. */
@@ -152,10 +286,23 @@ export default function plugin(bb: BbPluginApi) {
         "The trailing glyph naming the agent a thread runs on. Turn it off to give the branch that space back.",
       default: true,
     },
+    debugPullRequests: {
+      type: "boolean",
+      label: "Debug GitHub PR badges",
+      description:
+        "Show the lookup source (rest, cache, title) next to each PR number. Off unless you are diagnosing a missing badge.",
+      default: false,
+    },
   });
 
   const db = bb.storage.database();
   bb.storage.migrate(db, migrations);
+
+  const shutdown = new AbortController();
+  bb.onDispose(() => shutdown.abort());
+  let resolvedGhPath: string | null | undefined;
+  const restPullsInFlight = new Map<string, Promise<ReturnType<typeof parseRestPulls>>>();
+  const restPullGetInFlight = new Map<string, Promise<RestPull | null>>();
 
   const readAll = (): StoredLifecycleRow[] =>
     (
@@ -215,7 +362,23 @@ export default function plugin(bb: BbPluginApi) {
 
   const clear = (threadId: string): void => {
     db.prepare(`DELETE FROM thread_lifecycle WHERE thread_id = ?`).run(threadId);
+    db.prepare(`DELETE FROM snoozed_pr_watch WHERE thread_id = ?`).run(threadId);
     bb.realtime.publish(LIFECYCLE_CHANNEL, { threadId });
+  };
+
+  const rememberPullRequestUrl = (threadId: string, url: string | undefined): void => {
+    const canonical = url === undefined ? null : canonicalPullRequestUrl(url);
+    if (canonical === null) return;
+    db.prepare(
+      `INSERT INTO snoozed_pr_watch (thread_id, pr_url, snapshot_json, last_polled_at)
+       VALUES (?, ?, NULL, 0)
+       ON CONFLICT(thread_id) DO UPDATE SET
+         snapshot_json = CASE
+           WHEN snoozed_pr_watch.pr_url = excluded.pr_url THEN snoozed_pr_watch.snapshot_json
+           ELSE NULL
+         END,
+         pr_url = excluded.pr_url`,
+    ).run(threadId, canonical);
   };
 
   /**
@@ -336,6 +499,148 @@ export default function plugin(bb: BbPluginApi) {
     async listLifecycle() {
       return { rows: readAll() };
     },
+    async listThreadPullRequests({ threads }) {
+      if (resolvedGhPath === undefined) {
+        resolvedGhPath = await resolveGhPath(shutdown.signal);
+      }
+      const gh = resolvedGhPath === null ? null : createGhRunner(shutdown.signal, resolvedGhPath);
+      let restRemaining: number | null = null;
+      if (gh !== null) {
+        const limit = await githubRestJson(gh, "rate_limit", 8_000);
+        restRemaining = parseRestRateLimit(limit.raw)?.restRemaining ?? null;
+      }
+
+      const readPrCache = (environmentId: string): CachedPullRow | undefined => {
+        const row = db
+          .prepare(
+            `SELECT environment_id, owner, repo, number, title, url, state, attention, fetched_at
+               FROM thread_pr_index
+              WHERE environment_id = ?`,
+          )
+          .get(environmentId) as
+          | {
+              environment_id: string;
+              owner: string | null;
+              repo: string | null;
+              number: number | null;
+              title: string | null;
+              url: string | null;
+              state: string | null;
+              attention: string | null;
+              fetched_at: number;
+            }
+          | undefined;
+        if (row === undefined) return undefined;
+        return {
+          environmentId: row.environment_id,
+          owner: row.owner,
+          repo: row.repo,
+          number: row.number,
+          title: row.title,
+          url: row.url,
+          state: row.state,
+          attention: row.attention,
+          fetchedAt: row.fetched_at,
+        };
+      };
+
+      const resolved = await resolveThreadPullRequests(threads, {
+        now: Date.now(),
+        restRemaining,
+        getCache: readPrCache,
+        putCache: (row) => {
+          db.prepare(
+            `INSERT INTO thread_pr_index
+               (environment_id, owner, repo, number, title, url, state, attention, fetched_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(environment_id) DO UPDATE SET
+               owner = excluded.owner,
+               repo = excluded.repo,
+               number = excluded.number,
+               title = excluded.title,
+               url = excluded.url,
+               state = excluded.state,
+               attention = excluded.attention,
+               fetched_at = excluded.fetched_at`,
+          ).run(
+            row.environmentId,
+            row.owner,
+            row.repo,
+            row.number,
+            row.title,
+            row.url,
+            row.state,
+            row.attention,
+            row.fetchedAt,
+          );
+        },
+        getRepo: async (environmentId) => {
+          const environment = await bb.sdk.environments.get({ environmentId });
+          if (!environment.isGitRepo || environment.path === null) return null;
+          const context = await gitButlerHost.call(
+            "githubRepoContext",
+            { cwd: environment.path },
+            { hostId: environment.hostId },
+          );
+          if (context.owner === null || context.repo === null) return null;
+          return { owner: context.owner, repo: context.repo };
+        },
+        listOpenPulls: async (repo) => {
+          if (gh === null) return [];
+          const key = `${repo.owner}/${repo.repo}`;
+          const inflight = restPullsInFlight.get(key);
+          if (inflight !== undefined) return inflight;
+          const path = `repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.repo)}/pulls?state=open&per_page=100`;
+          const pending = (async () => {
+            const listed = await githubRestJson(gh, path);
+            if (listed.exitCode !== 0) {
+              throw new Error(listed.stderr.trim() || `gh api ${path} exited ${listed.exitCode}`);
+            }
+            return parseRestPulls(listed.raw);
+          })().finally(() => {
+            restPullsInFlight.delete(key);
+          });
+          restPullsInFlight.set(key, pending);
+          return pending;
+        },
+        getPull: async (repo, number) => {
+          if (gh === null) return null;
+          const key = `${repo.owner}/${repo.repo}#${number}`;
+          const inflight = restPullGetInFlight.get(key);
+          if (inflight !== undefined) return inflight;
+          const path = `repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.repo)}/pulls/${number}`;
+          const pending = (async () => {
+            const listed = await githubRestJson(gh, path);
+            if (listed.exitCode !== 0) {
+              throw new Error(listed.stderr.trim() || `gh api ${path} exited ${listed.exitCode}`);
+            }
+            return parseRestPull(listed.raw);
+          })().finally(() => {
+            restPullGetInFlight.delete(key);
+          });
+          restPullGetInFlight.set(key, pending);
+          return pending;
+        },
+        listClosedPullsByHead: async (repo, branchName) => {
+          if (gh === null) return [];
+          const head = `${repo.owner}:${branchName}`;
+          const path = `repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.repo)}/pulls?state=closed&head=${encodeURIComponent(head)}&per_page=5`;
+          const listed = await githubRestJson(gh, path);
+          if (listed.exitCode !== 0) {
+            throw new Error(listed.stderr.trim() || `gh api ${path} exited ${listed.exitCode}`);
+          }
+          return parseRestPulls(listed.raw);
+        },
+        log: bb.log,
+      });
+
+      return {
+        pullRequests: [...resolved.entries()].map(([threadId, pullRequest]) => ({
+          threadId,
+          ...pullRequest,
+        })),
+      };
+    },
     /**
      * The archived threads this plugin settled in the last day, and only
      * those. A thread the user archived through bb itself has no row here and
@@ -433,7 +738,7 @@ export default function plugin(bb: BbPluginApi) {
       clear(threadId);
       return { ok: true };
     },
-    async snooze({ threadId, snoozedUntil }) {
+    async snooze({ threadId, snoozedUntil, pullRequestUrl }) {
       const now = Date.now();
       // Snoozing a settled thread takes the archive back first: a snoozed row
       // is not on the settled shelf, so the thread has nowhere to be drawn
@@ -446,11 +751,53 @@ export default function plugin(bb: BbPluginApi) {
         snoozedAt: now,
         archivedThreadIds: [],
       });
+      rememberPullRequestUrl(threadId, pullRequestUrl);
       return { ok: true };
     },
     async unsnooze({ threadId }) {
       clear(threadId);
       return { ok: true };
+    },
+    async logPrDebug(payload) {
+      const env = payload.environmentId ?? "none";
+      if (payload.hasPullRequest) {
+        bb.log.info(
+          `pr-debug ${payload.threadId} env=${env} #${payload.number} state=${payload.state} attention=${payload.attention}`,
+        );
+      } else {
+        bb.log.info(
+          `pr-debug ${payload.threadId} env=${env} loading=${payload.isLoading} pullRequest=null`,
+        );
+      }
+      return { ok: true };
+    },
+    async openThreadBrowserTab({ tab, threadId }) {
+      const browserTab: InAppBrowserTab = { ...tab, kind: "browser" };
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const current = await bb.sdk.threads.tabs.get({ threadId });
+        const persistable = current.tabs.filter((candidate) => candidate.kind !== "side-chat");
+        const next = upsertBrowserTab(persistable, browserTab);
+        const opened = asPersistedBrowserTab(next.tab, browserTab);
+        const alreadyThere = persistable.some((candidate) => candidate.id === opened.id);
+        if (alreadyThere) {
+          return { tab: opened };
+        }
+        try {
+          await bb.sdk.threads.tabs.update({
+            expectedRevision: current.revision,
+            tabs: next.tabs,
+            threadId,
+          });
+          return { tab: opened };
+        } catch (error) {
+          const status =
+            typeof error === "object" && error !== null && "status" in error
+              ? error.status
+              : null;
+          if (status !== 409 || attempt === 2) throw error;
+        }
+      }
+      return { tab: browserTab };
     },
   });
 
@@ -476,4 +823,105 @@ export default function plugin(bb: BbPluginApi) {
   bb.events.on("thread.active", republishIfSettled);
   bb.events.on("thread.idle", republishIfSettled);
   bb.events.on("thread.failed", republishIfSettled);
+
+  const readRateLimitHint = async (): Promise<{
+    remaining: number | null;
+    skipUntilMs: number | null;
+  }> => {
+    const stored = await bb.storage.kv.get<{ remaining?: unknown; skipUntilMs?: unknown }>(
+      PR_WATCH_RATE_LIMIT_KEY,
+    );
+    if (stored === undefined) return { remaining: null, skipUntilMs: null };
+    return {
+      remaining: typeof stored.remaining === "number" ? stored.remaining : null,
+      skipUntilMs: typeof stored.skipUntilMs === "number" ? stored.skipUntilMs : null,
+    };
+  };
+
+  bb.background.schedule("pr-watch", "0 * * * *", async () => {
+    if (shutdown.signal.aborted) return;
+    const ghPath = await resolveGhPath(shutdown.signal);
+    if (ghPath === null) {
+      bb.log.info("snoozed PR watch skipped: GitHub CLI not found on PATH");
+      return;
+    }
+
+    const gh = createGhRunner(shutdown.signal, ghPath);
+    const hint = await readRateLimitHint();
+    const now = Date.now();
+    const result = await pollSnoozedPullRequests({
+      now,
+      store: {
+        listSnoozed: () =>
+          readAll()
+            .filter((row) => row.snoozedUntil !== null)
+            .map((row) => ({
+              threadId: row.threadId,
+              snoozedUntil: row.snoozedUntil as number,
+            })),
+        getWatch: (threadId) => {
+          const row = db
+            .prepare(
+              `SELECT thread_id, pr_url, snapshot_json
+                 FROM snoozed_pr_watch
+                WHERE thread_id = ?`,
+            )
+            .get(threadId) as
+            | { thread_id: string; pr_url: string; snapshot_json: string | null }
+            | undefined;
+          if (row === undefined) return undefined;
+          return {
+            threadId: row.thread_id,
+            prUrl: row.pr_url,
+            snapshotJson: row.snapshot_json,
+          } satisfies StoredPrWatch;
+        },
+        upsertWatch: (row) => {
+          db.prepare(
+            `INSERT INTO snoozed_pr_watch
+               (thread_id, pr_url, snapshot_json, last_polled_at)
+             VALUES (?, ?, ?, ?)
+             ON CONFLICT(thread_id) DO UPDATE SET
+               pr_url = excluded.pr_url,
+               snapshot_json = excluded.snapshot_json,
+               last_polled_at = excluded.last_polled_at`,
+          ).run(row.threadId, row.prUrl, row.snapshotJson, row.lastPolledAt);
+        },
+      },
+      graphql: (query) => githubGraphql(gh, query),
+      resolvePrUrl: async (threadId) => {
+        const thread = await bb.sdk.threads.get({ threadId });
+        if (thread.environmentId === null) return null;
+        const pullRequest = await bb.sdk.environments.pullRequest({
+          environmentId: thread.environmentId,
+        });
+        if (pullRequest.outcome !== "available") return null;
+        return pullRequest.pullRequest.url;
+      },
+      wakeThread: async (threadId, snapshot, changes) => {
+        // Clear the shelf first so a successful agent turn cannot land back
+        // on Snoozed when it goes idle. Then start a turn with what changed.
+        clear(threadId);
+        await bb.sdk.threads.send({
+          threadId,
+          mode: "auto",
+          input: [
+            {
+              type: "text",
+              text: formatAgentWakeMessage(snapshot, changes),
+              mentions: [],
+            },
+          ],
+        });
+      },
+      log: bb.log,
+      remainingHint: hint.remaining,
+      skipUntilMs: hint.skipUntilMs,
+    });
+
+    await bb.storage.kv.set(PR_WATCH_RATE_LIMIT_KEY, {
+      remaining: result.remaining,
+      skipUntilMs: result.skipUntilMs,
+    });
+  });
 }

--- a/plugins/gtd-sidebar/server.ts
+++ b/plugins/gtd-sidebar/server.ts
@@ -18,6 +18,7 @@ import { createGhRunner, githubGraphql, githubRestJson, resolveGhPath } from "./
 import { formatAgentWakeMessage, canonicalPullRequestUrl } from "./lib/pr-watch.ts";
 import { pollSnoozedPullRequests, type StoredPrWatch } from "./lib/pr-watch-run.ts";
 import {
+  needsMergeStateLookup,
   parseRestPull,
   parseRestPulls,
   parseRestRateLimit,
@@ -386,6 +387,22 @@ export default function plugin(bb: BbPluginApi) {
       )
       .all() as Array<{ owner: string; repo: string }>;
 
+  /** The numbered GET, the only REST route that carries `mergeable_state`. */
+  const fetchPullDetail = async (
+    owner: string,
+    repo: string,
+    number: number,
+  ): Promise<RestPull | null> => {
+    if (resolvedGhPath === undefined) {
+      resolvedGhPath = await resolveGhPath(shutdown.signal);
+    }
+    if (resolvedGhPath === null) return null;
+    const gh = createGhRunner(shutdown.signal, resolvedGhPath);
+    const path = `repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${number}`;
+    const fetched = await githubRestJson(gh, path);
+    return fetched.exitCode === 0 ? parseRestPull(fetched.raw) : null;
+  };
+
   const applyPullToIndex = (owner: string, repo: string, pull: RestPull, now: number) => {
     const sidebar = sidebarPrFromRest(pull);
     db.prepare(
@@ -667,21 +684,23 @@ export default function plugin(bb: BbPluginApi) {
     const now = Date.now();
     const rows = [];
     if (direct !== null) {
-      rows.push(...applyPullToIndex(direct.owner, direct.repo, direct.pull, now));
+      let pull = direct.pull;
+      // `pull_request_review` and `issue_comment` embed a shortened pull with
+      // no `mergeable_state`, and a fresh `synchronize` has not recomputed it
+      // yet. Publishing that verbatim repaints a blocked PR green until the
+      // next ten-minute reconcile, so buy the real state now.
+      if (needsMergeStateLookup(pull)) {
+        const detailed = await fetchPullDetail(direct.owner, direct.repo, pull.number);
+        if (detailed !== null) pull = detailed;
+      }
+      rows.push(...applyPullToIndex(direct.owner, direct.repo, pull, now));
       if (SNOOZE_WAKE_EVENTS.has(input.event)) {
-        await wakeSnoozedForPullUrl(direct.pull.url, `GitHub ${input.event} on ${direct.pull.url}`);
+        await wakeSnoozedForPullUrl(pull.url, `GitHub ${input.event} on ${pull.url}`);
       }
     } else if (repo !== null) {
-      if (resolvedGhPath === undefined) {
-        resolvedGhPath = await resolveGhPath(shutdown.signal);
-      }
-      const gh = resolvedGhPath === null ? null : createGhRunner(shutdown.signal, resolvedGhPath);
       const numbers = webhookPrNumbers(input.event, payload);
       for (const number of numbers) {
-        if (gh === null) break;
-        const path = `repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.repo)}/pulls/${number}`;
-        const listed = await githubRestJson(gh, path);
-        const pull = listed.exitCode === 0 ? parseRestPull(listed.raw) : null;
+        const pull = await fetchPullDetail(repo.owner, repo.repo, number);
         if (pull === null) continue;
         rows.push(...applyPullToIndex(repo.owner, repo.repo, pull, now));
         if (SNOOZE_WAKE_EVENTS.has(input.event)) {

--- a/plugins/gtd-sidebar/server.ts
+++ b/plugins/gtd-sidebar/server.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import { parseArchivedThreadIds } from "./lib/lifecycle.ts";
 import { isWithinSettledWindow } from "./lib/settled-threads.ts";
 import { gitButlerHostContract } from "./lib/gitbutler.ts";
+import { randomBytes } from "node:crypto";
 import { createGhRunner, githubGraphql, githubRestJson, resolveGhPath } from "./lib/gh-cli.ts";
 import { formatAgentWakeMessage, canonicalPullRequestUrl } from "./lib/pr-watch.ts";
 import { pollSnoozedPullRequests, type StoredPrWatch } from "./lib/pr-watch-run.ts";
@@ -20,11 +21,27 @@ import {
   parseRestPull,
   parseRestPulls,
   parseRestRateLimit,
+  sidebarPrFromRest,
   type CachedPullRow,
   type RestPull,
 } from "./lib/pr-index.ts";
 import { resolveThreadPullRequests } from "./lib/pr-index-run.ts";
 import { upsertBrowserTab, type InAppBrowserTab } from "./lib/open-in-app-browser.ts";
+import { LIFECYCLE_CHANNEL, PR_INDEX_CHANNEL, WEBHOOK_TUNNEL_CHANNEL } from "./lib/channels.ts";
+import { ensureGithubRepoHook } from "./lib/github-hooks.ts";
+import {
+  parseRepoFromPayload,
+  parseWebhookPull,
+  resolveWebhookDeliveryUrl,
+  SNOOZE_WAKE_EVENTS,
+  verifyGithubSignature,
+  webhookPrNumbers,
+} from "./lib/github-webhook.ts";
+import {
+  maintainCloudflareWebhookTunnel,
+  WEBHOOK_TUNNEL_STATUS_OFF,
+  type WebhookTunnelStatus,
+} from "./lib/github-webhook-tunnel.ts";
 
 const migrations = [
   `CREATE TABLE IF NOT EXISTS thread_lifecycle (
@@ -202,6 +219,7 @@ export const gtdSidebarRpcContract = defineRpcContract({
                 threadId: z.string().trim().min(1),
                 environmentId: z.string().trim().min(1).nullable(),
                 branchName: z.string().nullable(),
+                branchNames: z.array(z.string().trim().min(1)).max(8).optional(),
                 title: z.string(),
               })
               .strict(),
@@ -268,17 +286,34 @@ export const gtdSidebarRpcContract = defineRpcContract({
       })
       .strict(),
   },
+  githubWebhookTunnelStatus: {
+    input: z.object({}).strict(),
+    output: z
+      .object({
+        enabled: z.boolean(),
+        state: z.enum([
+          "off",
+          "checking",
+          "missing-cloudflared",
+          "starting",
+          "live",
+          "error",
+        ]),
+        url: z.string().nullable(),
+        origin: z.string().nullable(),
+        error: z.string().nullable(),
+      })
+      .strict(),
+  },
 });
 
-/** Channel the frontend re-reads on. */
-export const LIFECYCLE_CHANNEL = "lifecycle";
+export { LIFECYCLE_CHANNEL, PR_INDEX_CHANNEL, WEBHOOK_TUNNEL_CHANNEL } from "./lib/channels.ts";
+const WEBHOOK_SECRET_KEY = "github-webhook-secret";
+const WEBHOOK_LAST_URL_KEY = "github-webhook-last-url";
 
 export default function plugin(bb: BbPluginApi) {
   const gitButlerHost = bb.hosts.experimental_client({ contract: gitButlerHostContract });
-  // Declared, never read here. The card is the only consumer and it reads the
-  // value through `useSettings()`, so this exists to put the toggle in the
-  // plugin's settings form and give it its default.
-  bb.settings.define({
+  const pluginSettings = bb.settings.define({
     showProviderIcon: {
       type: "boolean",
       label: "Show the agent icon on each card",
@@ -293,6 +328,19 @@ export default function plugin(bb: BbPluginApi) {
         "Show the lookup source (rest, cache, title) next to each PR number. Off unless you are diagnosing a missing badge.",
       default: false,
     },
+    githubWebhooksViaCloudflare: {
+      type: "boolean",
+      label: "GitHub webhooks via Cloudflare",
+      description:
+        "When on, check for cloudflared and open a trycloudflare HTTPS tunnel to a webhook-only local port (not the bb API). GitHub can then push PR status instead of waiting for the 10-minute reconcile. The public address changes when bb restarts.",
+      default: false,
+    },
+    githubWebhookBaseUrl: {
+      type: "string",
+      label: "GitHub webhook public URL (optional)",
+      description:
+        "Leave empty unless you already have an unauthenticated HTTPS origin that forwards to this bb. bb connect URLs (*.getbb.app) cannot receive GitHub POSTs. When the Cloudflare setting is on, this is ignored unless it is a real public origin.",
+    },
   });
 
   const db = bb.storage.database();
@@ -303,6 +351,127 @@ export default function plugin(bb: BbPluginApi) {
   let resolvedGhPath: string | null | undefined;
   const restPullsInFlight = new Map<string, Promise<ReturnType<typeof parseRestPulls>>>();
   const restPullGetInFlight = new Map<string, Promise<RestPull | null>>();
+  const hookEnsuredAt = new Map<string, number>();
+  const HOOK_ENSURE_TTL_MS = 60 * 60 * 1000;
+  let liveTunnelOrigin: string | null = null;
+  let hookPreviousUrl: string | null = null;
+  let tunnelStatus: WebhookTunnelStatus = WEBHOOK_TUNNEL_STATUS_OFF;
+
+  const webhookSecret = async (): Promise<string> => {
+    const stored = await bb.storage.kv.get<string>(WEBHOOK_SECRET_KEY);
+    if (typeof stored === "string" && stored.length >= 16) return stored;
+    const generated = randomBytes(32).toString("hex");
+    await bb.storage.kv.set(WEBHOOK_SECRET_KEY, generated);
+    return generated;
+  };
+
+  const webhookPublicUrl = async (): Promise<string | null> => {
+    const values = await pluginSettings.get();
+    const configured =
+      typeof values.githubWebhookBaseUrl === "string" ? values.githubWebhookBaseUrl.trim() : "";
+    const envOrigin = process.env.BB_PUBLIC_URL?.trim() ?? "";
+    return resolveWebhookDeliveryUrl({
+      configuredOrigin: configured.length > 0 ? configured : envOrigin,
+      tunnelOrigin: liveTunnelOrigin,
+      pluginId: bb.pluginId,
+    });
+  };
+
+  const listIndexedRepos = (): Array<{ owner: string; repo: string }> =>
+    db
+      .prepare(
+        `SELECT DISTINCT owner, repo
+           FROM thread_pr_index
+          WHERE owner IS NOT NULL AND repo IS NOT NULL`,
+      )
+      .all() as Array<{ owner: string; repo: string }>;
+
+  const applyPullToIndex = (owner: string, repo: string, pull: RestPull, now: number) => {
+    const sidebar = sidebarPrFromRest(pull);
+    db.prepare(
+      `UPDATE thread_pr_index
+          SET title = ?, url = ?, state = ?, attention = ?, fetched_at = ?
+        WHERE owner = ? AND repo = ? AND number = ?`,
+    ).run(
+      sidebar.title,
+      sidebar.url,
+      sidebar.state,
+      sidebar.attention,
+      now,
+      owner,
+      repo,
+      sidebar.number,
+    );
+    const updated = db
+      .prepare(
+        `SELECT environment_id, owner, repo, number, title, url, state, attention
+           FROM thread_pr_index
+          WHERE owner = ? AND repo = ? AND number = ?`,
+      )
+      .all(owner, repo, sidebar.number) as Array<{
+      environment_id: string;
+      owner: string;
+      repo: string;
+      number: number;
+      title: string;
+      url: string;
+      state: string;
+      attention: string;
+    }>;
+    return updated.map((row) => ({
+      environmentId: row.environment_id,
+      owner: row.owner,
+      repo: row.repo,
+      number: row.number,
+      title: row.title,
+      url: row.url,
+      state: row.state,
+      attention: row.attention,
+      source: "rest" as const,
+    }));
+  };
+
+  let hookEnsureQueue = Promise.resolve();
+  const ensureRepoHooks = (repos: ReadonlyArray<{ owner: string; repo: string }>) => {
+    hookEnsureQueue = hookEnsureQueue
+      .then(async () => {
+        const url = await webhookPublicUrl();
+        if (url === null) return;
+        if (resolvedGhPath === undefined) {
+          resolvedGhPath = await resolveGhPath(shutdown.signal);
+        }
+        if (resolvedGhPath === null) return;
+        const gh = createGhRunner(shutdown.signal, resolvedGhPath);
+        const secret = await webhookSecret();
+        const now = Date.now();
+        for (const repo of repos) {
+          const key = `${repo.owner}/${repo.repo}`;
+          const last = hookEnsuredAt.get(key);
+          if (last !== undefined && now - last < HOOK_ENSURE_TTL_MS) continue;
+          try {
+            const result = await ensureGithubRepoHook(gh, repo, url, secret, hookPreviousUrl);
+            if (result === "denied") {
+              bb.log.warn(`github webhook denied for ${key} (need admin:repo_hook)`);
+              hookEnsuredAt.set(key, now + 23 * 60 * 60 * 1000);
+              continue;
+            }
+            if (result === "error") {
+              bb.log.warn(`github webhook ensure failed for ${key}`);
+              continue;
+            }
+            hookEnsuredAt.set(key, now);
+            if (result !== "unchanged") {
+              bb.log.info(`github webhook ${result} for ${key}`);
+            }
+          } catch (error) {
+            bb.log.warn(`github webhook ensure ${key}: ${String(error)}`);
+          }
+        }
+      })
+      .catch((error) => {
+        bb.log.warn(`github webhook ensure: ${String(error)}`);
+      });
+  };
 
   const readAll = (): StoredLifecycleRow[] =>
     (
@@ -450,6 +619,105 @@ export default function plugin(bb: BbPluginApi) {
     }
     return collected;
   };
+
+  const wakeSnoozedForPullUrl = async (url: string, reason: string) => {
+    const canonical = canonicalPullRequestUrl(url);
+    if (canonical === null) return;
+    const watched = db
+      .prepare(`SELECT thread_id FROM snoozed_pr_watch WHERE pr_url = ?`)
+      .all(canonical) as Array<{ thread_id: string }>;
+    const now = Date.now();
+    for (const { thread_id: threadId } of watched) {
+      const row = readOne(threadId);
+      if (row === undefined || row.snoozedUntil === null || row.snoozedUntil <= now) continue;
+      clear(threadId);
+      try {
+        await bb.sdk.threads.send({
+          threadId,
+          mode: "auto",
+          input: [{ type: "text", text: reason, mentions: [] }],
+        });
+      } catch (error) {
+        bb.log.warn(`webhook unsnooze send ${threadId} failed: ${String(error)}`);
+      }
+    }
+  };
+
+  const deliverGithubWebhook = async (input: {
+    raw: string;
+    event: string;
+    signature: string | undefined;
+  }): Promise<{ status: number; body: unknown }> => {
+    const secret = await webhookSecret();
+    if (!verifyGithubSignature(secret, input.raw, input.signature)) {
+      return { status: 401, body: { ok: false, error: "invalid signature" } };
+    }
+    if (input.event === "ping") {
+      bb.log.info("github webhook ping");
+      return { status: 200, body: { ok: true, ping: true } };
+    }
+    let payload: unknown = null;
+    try {
+      payload = JSON.parse(input.raw) as unknown;
+    } catch {
+      return { status: 400, body: { ok: false, error: "invalid json" } };
+    }
+    const repo = parseRepoFromPayload(payload);
+    const direct = parseWebhookPull(payload);
+    const now = Date.now();
+    const rows = [];
+    if (direct !== null) {
+      rows.push(...applyPullToIndex(direct.owner, direct.repo, direct.pull, now));
+      if (SNOOZE_WAKE_EVENTS.has(input.event)) {
+        await wakeSnoozedForPullUrl(direct.pull.url, `GitHub ${input.event} on ${direct.pull.url}`);
+      }
+    } else if (repo !== null) {
+      if (resolvedGhPath === undefined) {
+        resolvedGhPath = await resolveGhPath(shutdown.signal);
+      }
+      const gh = resolvedGhPath === null ? null : createGhRunner(shutdown.signal, resolvedGhPath);
+      const numbers = webhookPrNumbers(input.event, payload);
+      for (const number of numbers) {
+        if (gh === null) break;
+        const path = `repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.repo)}/pulls/${number}`;
+        const listed = await githubRestJson(gh, path);
+        const pull = listed.exitCode === 0 ? parseRestPull(listed.raw) : null;
+        if (pull === null) continue;
+        rows.push(...applyPullToIndex(repo.owner, repo.repo, pull, now));
+        if (SNOOZE_WAKE_EVENTS.has(input.event)) {
+          await wakeSnoozedForPullUrl(pull.url, `GitHub ${input.event} on ${pull.url}`);
+        }
+      }
+    }
+    if (rows.length === 0) {
+      bb.realtime.publish(PR_INDEX_CHANNEL, { refresh: true });
+    } else {
+      bb.realtime.publish(PR_INDEX_CHANNEL, { rows });
+    }
+    const target =
+      direct !== null
+        ? ` ${direct.owner}/${direct.repo}#${direct.pull.number}`
+        : repo !== null
+          ? ` ${repo.owner}/${repo.repo}`
+          : "";
+    bb.log.info(`github webhook ${input.event}${target} updated ${rows.length}`);
+    return { status: 200, body: { ok: true, updated: rows.length } };
+  };
+
+  bb.http.route(
+    "POST",
+    "/github-webhook",
+    async (c) => {
+      const raw = await c.req.raw.text();
+      const result = await deliverGithubWebhook({
+        raw,
+        event: c.req.header("x-github-event") ?? "",
+        signature: c.req.header("x-hub-signature-256"),
+      });
+      return c.json(result.body, result.status as 200 | 400 | 401);
+    },
+    { auth: "none" },
+  );
 
   bb.rpc.register(gtdSidebarRpcContract, {
     async listEnvironmentBranches({ environmentIds }) {
@@ -621,10 +889,9 @@ export default function plugin(bb: BbPluginApi) {
           restPullGetInFlight.set(key, pending);
           return pending;
         },
-        listClosedPullsByHead: async (repo, branchName) => {
+        listRecentClosedPulls: async (repo) => {
           if (gh === null) return [];
-          const head = `${repo.owner}:${branchName}`;
-          const path = `repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.repo)}/pulls?state=closed&head=${encodeURIComponent(head)}&per_page=5`;
+          const path = `repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.repo)}/pulls?state=closed&sort=updated&direction=desc&per_page=100`;
           const listed = await githubRestJson(gh, path);
           if (listed.exitCode !== 0) {
             throw new Error(listed.stderr.trim() || `gh api ${path} exited ${listed.exitCode}`);
@@ -633,6 +900,8 @@ export default function plugin(bb: BbPluginApi) {
         },
         log: bb.log,
       });
+
+      ensureRepoHooks(listIndexedRepos());
 
       return {
         pullRequests: [...resolved.entries()].map(([threadId, pullRequest]) => ({
@@ -771,6 +1040,9 @@ export default function plugin(bb: BbPluginApi) {
       }
       return { ok: true };
     },
+    async githubWebhookTunnelStatus() {
+      return tunnelStatus;
+    },
     async openThreadBrowserTab({ tab, threadId }) {
       const browserTab: InAppBrowserTab = { ...tab, kind: "browser" };
       for (let attempt = 0; attempt < 3; attempt++) {
@@ -837,6 +1109,63 @@ export default function plugin(bb: BbPluginApi) {
       skipUntilMs: typeof stored.skipUntilMs === "number" ? stored.skipUntilMs : null,
     };
   };
+
+  bb.background.service("github-webhook-tunnel", {
+    async start(signal) {
+      const combined = new AbortController();
+      const stop = () => combined.abort();
+      signal.addEventListener("abort", stop);
+      shutdown.signal.addEventListener("abort", stop);
+      try {
+        await maintainCloudflareWebhookTunnel({
+          signal: combined.signal,
+          readSettings: async () => {
+            const values = await pluginSettings.get();
+            return {
+              enabled: values.githubWebhooksViaCloudflare === true,
+              configuredOrigin:
+                typeof values.githubWebhookBaseUrl === "string"
+                  ? values.githubWebhookBaseUrl.trim()
+                  : "",
+            };
+          },
+          onSettingsChange: (listener) => {
+            pluginSettings.onChange((next, prev) => {
+              if (
+                next.githubWebhooksViaCloudflare !== prev.githubWebhooksViaCloudflare ||
+                next.githubWebhookBaseUrl !== prev.githubWebhookBaseUrl
+              ) {
+                listener();
+              }
+            });
+            return () => undefined;
+          },
+          handle: deliverGithubWebhook,
+          onLive: ({ origin, url }) => {
+            void (async () => {
+              const previous = await bb.storage.kv.get<string>(WEBHOOK_LAST_URL_KEY);
+              hookPreviousUrl = typeof previous === "string" && previous !== url ? previous : null;
+              liveTunnelOrigin = origin;
+              await bb.storage.kv.set(WEBHOOK_LAST_URL_KEY, url);
+              hookEnsuredAt.clear();
+              ensureRepoHooks(listIndexedRepos());
+            })();
+          },
+          onStopped: () => {
+            liveTunnelOrigin = null;
+          },
+          onStatus: (status) => {
+            tunnelStatus = status;
+            bb.realtime.publish(WEBHOOK_TUNNEL_CHANNEL, status);
+          },
+          log: bb.log,
+        });
+      } finally {
+        signal.removeEventListener("abort", stop);
+        shutdown.signal.removeEventListener("abort", stop);
+      }
+    },
+  });
 
   bb.background.schedule("pr-watch", "0 * * * *", async () => {
     if (shutdown.signal.aborted) return;

--- a/plugins/gtd-sidebar/test/cloudflared.test.ts
+++ b/plugins/gtd-sidebar/test/cloudflared.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { describe, it } from "node:test";
+import {
+  parseTrycloudflareOrigin,
+  resolveCloudflaredPath,
+  startTrycloudflareTunnel,
+} from "../lib/cloudflared.ts";
+import { startWebhookListener } from "../lib/webhook-listener.ts";
+import { maintainCloudflareWebhookTunnel } from "../lib/github-webhook-tunnel.ts";
+import { createHmac } from "node:crypto";
+import { verifyGithubSignature } from "../lib/github-webhook.ts";
+
+describe("parseTrycloudflareOrigin", () => {
+  it("pulls the first trycloudflare URL out of cloudflared logs", () => {
+    const log = [
+      "INF Requesting new quick Tunnel on trycloudflare.com...",
+      "INF |  Your quick Tunnel has been created! Visit it at:",
+      "INF |  https://random-words-here.trycloudflare.com                                               |",
+    ].join("\n");
+    assert.equal(parseTrycloudflareOrigin(log), "https://random-words-here.trycloudflare.com");
+    assert.equal(parseTrycloudflareOrigin("no url here"), null);
+  });
+});
+
+describe("resolveCloudflaredPath", () => {
+  it("returns the first candidate whose --version succeeds", async () => {
+    const tried: string[] = [];
+    const path = await resolveCloudflaredPath(new AbortController().signal, async (file) => {
+      tried.push(file);
+      return { exitCode: file === "/opt/homebrew/bin/cloudflared" ? 0 : 1 };
+    });
+    assert.equal(path, "/opt/homebrew/bin/cloudflared");
+    assert.deepEqual(tried, ["cloudflared", "/opt/homebrew/bin/cloudflared"]);
+  });
+
+  it("returns null when nothing on PATH answers", async () => {
+    const path = await resolveCloudflaredPath(new AbortController().signal, async () => ({
+      exitCode: 1,
+    }));
+    assert.equal(path, null);
+  });
+});
+
+describe("startWebhookListener", () => {
+  it("accepts a signed POST on /github-webhook and 404s other paths", async () => {
+    const secret = "s3cret";
+    const body = '{"zen":"ok"}';
+    const signature = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+    const listener = await startWebhookListener({
+      handle: async (input) => {
+        if (!verifyGithubSignature(secret, input.raw, input.signature)) {
+          return { status: 401, body: { ok: false } };
+        }
+        return { status: 200, body: { ok: true, event: input.event } };
+      },
+    });
+    try {
+      const missed = await fetch(`http://127.0.0.1:${listener.port}/`);
+      assert.equal(missed.status, 404);
+      const health = await fetch(`http://127.0.0.1:${listener.port}/github-webhook`);
+      assert.equal(health.status, 200);
+      const posted = await fetch(`http://127.0.0.1:${listener.port}/github-webhook`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-github-event": "ping",
+          "x-hub-signature-256": signature,
+        },
+        body,
+      });
+      assert.equal(posted.status, 200);
+      assert.deepEqual(await posted.json(), { ok: true, event: "ping" });
+    } finally {
+      await listener.close();
+    }
+  });
+});
+
+describe("startTrycloudflareTunnel", () => {
+  it("resolves the origin printed on stderr and stops the child", async () => {
+    const run = new AbortController();
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter & { setEncoding: (enc: string) => void };
+      stderr: EventEmitter & { setEncoding: (enc: string) => void };
+      kill: (signal?: string) => boolean;
+      exitCode: number | null;
+      signalCode: string | null;
+    };
+    child.stdout = Object.assign(new EventEmitter(), { setEncoding() {} });
+    child.stderr = Object.assign(new EventEmitter(), { setEncoding() {} });
+    child.exitCode = null;
+    child.signalCode = null;
+    child.kill = () => {
+      child.exitCode = 0;
+      child.emit("exit", 0, null);
+      return true;
+    };
+    const pending = startTrycloudflareTunnel({
+      bin: "cloudflared",
+      localOrigin: "http://127.0.0.1:9",
+      signal: run.signal,
+      timeoutMs: 1_000,
+      spawnImpl: () => {
+        setImmediate(() => {
+          child.stderr.emit(
+            "data",
+            "INF |  https://unit-test.trycloudflare.com                                               |\n",
+          );
+        });
+        return child as never;
+      },
+    });
+    const tunnel = await pending;
+    assert.equal(tunnel.origin, "https://unit-test.trycloudflare.com");
+    tunnel.stop();
+    assert.equal(await tunnel.wait, 0);
+  });
+});
+
+describe("maintainCloudflareWebhookTunnel", () => {
+  it("reports missing-cloudflared when the binary is absent", async () => {
+    const run = new AbortController();
+    const statuses: string[] = [];
+    const done = maintainCloudflareWebhookTunnel({
+      signal: run.signal,
+      readSettings: async () => ({ enabled: true, configuredOrigin: "" }),
+      onSettingsChange: () => () => undefined,
+      handle: async () => ({ status: 200, body: { ok: true } }),
+      onLive: () => {
+        throw new Error("should not go live");
+      },
+      onStopped: () => undefined,
+      onStatus: (status) => {
+        statuses.push(status.state);
+        if (status.state === "missing-cloudflared") run.abort();
+      },
+      log: { info: () => undefined, warn: () => undefined },
+      resolveBin: async () => null,
+    });
+    await done;
+    assert.ok(statuses.includes("checking"));
+    assert.ok(statuses.includes("missing-cloudflared"));
+  });
+});

--- a/plugins/gtd-sidebar/test/cloudflared.test.ts
+++ b/plugins/gtd-sidebar/test/cloudflared.test.ts
@@ -142,4 +142,38 @@ describe("maintainCloudflareWebhookTunnel", () => {
     assert.ok(statuses.includes("checking"));
     assert.ok(statuses.includes("missing-cloudflared"));
   });
+
+  it("backs off when cloudflared exits after going live", async () => {
+    const run = new AbortController();
+    const liveAt: number[] = [];
+    const statuses: string[] = [];
+    const done = maintainCloudflareWebhookTunnel({
+      signal: run.signal,
+      readSettings: async () => ({ enabled: true, configuredOrigin: "" }),
+      onSettingsChange: () => () => undefined,
+      handle: async () => ({ status: 200, body: { ok: true } }),
+      onLive: () => {
+        liveAt.push(Date.now());
+        if (liveAt.length >= 2) run.abort();
+      },
+      onStopped: () => undefined,
+      onStatus: (status) => {
+        statuses.push(status.state);
+      },
+      log: { info: () => undefined, warn: () => undefined },
+      resolveBin: async () => "/opt/homebrew/bin/cloudflared",
+      startListener: async () => ({ port: 9, close: async () => undefined }),
+      startTunnel: async () => ({
+        origin: "https://unit-test.trycloudflare.com",
+        wait: Promise.resolve(1),
+        stop: () => undefined,
+      }),
+      retryDelayMs: 50,
+    });
+    await done;
+    assert.ok(statuses.includes("live"));
+    assert.ok(statuses.includes("error"));
+    assert.equal(liveAt.length, 2);
+    assert.ok(liveAt[1]! - liveAt[0]! >= 40);
+  });
 });

--- a/plugins/gtd-sidebar/test/github-hooks.test.ts
+++ b/plugins/gtd-sidebar/test/github-hooks.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { describe, it } from "node:test";
+import { ensureGithubRepoHook } from "../lib/github-hooks.ts";
+import type { GhRunner } from "../lib/gh-cli.ts";
+
+function runner(
+  hooks: unknown,
+  onPatch?: (body: unknown) => void,
+): GhRunner {
+  return {
+    async run(args) {
+      const path = args.at(-1) ?? "";
+      const methodIndex = args.indexOf("--method");
+      const method = methodIndex >= 0 ? args[methodIndex + 1] : "GET";
+      if (path.includes("/hooks/") && method === "PATCH") {
+        const inputIndex = args.indexOf("--input");
+        const inputPath = inputIndex >= 0 ? args[inputIndex + 1] : undefined;
+        if (inputPath !== undefined && onPatch !== undefined) {
+          onPatch(JSON.parse(await readFile(inputPath, "utf8")));
+        }
+        return { stdout: "{}", stderr: "", exitCode: 0 };
+      }
+      if (path.includes("/hooks") && method === "GET") {
+        return { stdout: JSON.stringify(hooks), stderr: "", exitCode: 0 };
+      }
+      return { stdout: "", stderr: "unexpected", exitCode: 1 };
+    },
+  };
+}
+
+describe("ensureGithubRepoHook", () => {
+  const url = "https://ours.trycloudflare.com/github-webhook";
+  const repo = { owner: "acme", repo: "app" };
+
+  it("PATCHes the secret even when URL and events already match", async () => {
+    let patched: unknown = null;
+    const result = await ensureGithubRepoHook(
+      runner(
+        [
+          {
+            id: 9,
+            events: [
+              "pull_request",
+              "pull_request_review",
+              "pull_request_review_comment",
+              "issue_comment",
+              "check_suite",
+              "deployment_status",
+            ],
+            config: { url },
+          },
+        ],
+        (body) => {
+          patched = body;
+        },
+      ),
+      repo,
+      url,
+      "new-secret",
+    );
+    assert.equal(result, "unchanged");
+    assert.equal(
+      (patched as { config?: { secret?: string } } | null)?.config?.secret,
+      "new-secret",
+    );
+  });
+});

--- a/plugins/gtd-sidebar/test/github-repo.test.ts
+++ b/plugins/gtd-sidebar/test/github-repo.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { githubPullUrl, parseGithubRemote, parsePrRefFromTitle } from "../lib/github-repo.ts";
+
+describe("parseGithubRemote", () => {
+  it("reads https, ssh, and git@ remotes", () => {
+    assert.deepEqual(parseGithubRemote("https://github.com/acme/app.git"), {
+      owner: "acme",
+      repo: "app",
+    });
+    assert.deepEqual(parseGithubRemote("git@github.com:acme/app.git"), {
+      owner: "acme",
+      repo: "app",
+    });
+    assert.deepEqual(parseGithubRemote("ssh://git@github.com/acme/app"), {
+      owner: "acme",
+      repo: "app",
+    });
+  });
+
+  it("rejects non-github remotes", () => {
+    assert.equal(parseGithubRemote("https://gitlab.com/acme/app.git"), null);
+  });
+});
+
+describe("parsePrRefFromTitle", () => {
+  it("reads owner/repo#number from a title", () => {
+    assert.deepEqual(parsePrRefFromTitle("ai-ecoverse/slicc#2406: Feature: curl"), {
+      owner: "ai-ecoverse",
+      repo: "slicc",
+      number: 2406,
+    });
+  });
+
+  it("reads a bare #number", () => {
+    assert.deepEqual(parsePrRefFromTitle("Verify APNs push on staging (#2213 for iOS)"), {
+      owner: null,
+      repo: null,
+      number: 2213,
+    });
+  });
+
+  it("returns null when there is no PR number", () => {
+    assert.equal(parsePrRefFromTitle("Investigate issue 388"), null);
+  });
+});
+
+describe("githubPullUrl", () => {
+  it("builds a canonical html URL", () => {
+    assert.equal(githubPullUrl("acme", "app", 12), "https://github.com/acme/app/pull/12");
+  });
+});

--- a/plugins/gtd-sidebar/test/github-webhook.test.ts
+++ b/plugins/gtd-sidebar/test/github-webhook.test.ts
@@ -154,4 +154,18 @@ describe("matchingGithubHook", () => {
     assert.equal(isTrycloudflareWebhookUrl(previous), true);
     assert.equal(isTrycloudflareWebhookUrl(next), true);
   });
+
+  it("does not claim an unrelated trycloudflare hook", () => {
+    const found = matchingManagedGithubHook(
+      [
+        {
+          id: 8,
+          config: { url: "https://someone-else.trycloudflare.com/github-webhook" },
+          events: ["pull_request"],
+        },
+      ],
+      "https://ours.trycloudflare.com/github-webhook",
+    );
+    assert.equal(found, null);
+  });
 });

--- a/plugins/gtd-sidebar/test/github-webhook.test.ts
+++ b/plugins/gtd-sidebar/test/github-webhook.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { describe, it } from "node:test";
+import {
+  dedicatedGithubWebhookUrl,
+  eventsMatch,
+  githubWebhookUrl,
+  isSessionGatedWebhookOrigin,
+  isTrycloudflareWebhookUrl,
+  matchingGithubHook,
+  matchingManagedGithubHook,
+  parseWebhookPull,
+  resolveWebhookDeliveryUrl,
+  shouldStartCloudflareTunnel,
+  verifyGithubSignature,
+  webhookPrNumbers,
+} from "../lib/github-webhook.ts";
+
+describe("githubWebhookUrl", () => {
+  it("joins the connect origin to the plugin HTTP path", () => {
+    assert.equal(
+      githubWebhookUrl("https://lars.getbb.app/", "gtd-sidebar"),
+      "https://lars.getbb.app/api/v1/plugins/gtd-sidebar/http/github-webhook",
+    );
+  });
+});
+
+describe("dedicatedGithubWebhookUrl", () => {
+  it("uses the webhook-only path on a trycloudflare origin", () => {
+    assert.equal(
+      dedicatedGithubWebhookUrl("https://random-words.trycloudflare.com/"),
+      "https://random-words.trycloudflare.com/github-webhook",
+    );
+  });
+});
+
+describe("resolveWebhookDeliveryUrl", () => {
+  it("prefers a real public origin, skips getbb.app, then uses the tunnel", () => {
+    assert.equal(
+      resolveWebhookDeliveryUrl({
+        configuredOrigin: "https://hooks.example.com",
+        tunnelOrigin: "https://random-words.trycloudflare.com",
+        pluginId: "gtd-sidebar",
+      }),
+      "https://hooks.example.com/api/v1/plugins/gtd-sidebar/http/github-webhook",
+    );
+    assert.equal(
+      resolveWebhookDeliveryUrl({
+        configuredOrigin: "https://lars.getbb.app",
+        tunnelOrigin: "https://random-words.trycloudflare.com",
+        pluginId: "gtd-sidebar",
+      }),
+      "https://random-words.trycloudflare.com/github-webhook",
+    );
+    assert.equal(
+      resolveWebhookDeliveryUrl({
+        configuredOrigin: "",
+        tunnelOrigin: null,
+        pluginId: "gtd-sidebar",
+      }),
+      null,
+    );
+  });
+});
+
+describe("shouldStartCloudflareTunnel", () => {
+  it("starts only when enabled and no usable manual origin is set", () => {
+    assert.equal(shouldStartCloudflareTunnel(false, ""), false);
+    assert.equal(shouldStartCloudflareTunnel(true, ""), true);
+    assert.equal(shouldStartCloudflareTunnel(true, "https://lars.getbb.app"), true);
+    assert.equal(shouldStartCloudflareTunnel(true, "https://hooks.example.com"), false);
+  });
+});
+
+describe("isSessionGatedWebhookOrigin", () => {
+  it("rejects bb connect hosts, which require a sign-in session", () => {
+    assert.equal(isSessionGatedWebhookOrigin("https://lars.getbb.app"), true);
+    assert.equal(isSessionGatedWebhookOrigin("https://lars--5717.getbb.app"), true);
+    assert.equal(isSessionGatedWebhookOrigin("https://example.com"), false);
+    assert.equal(
+      isSessionGatedWebhookOrigin("https://random-words.trycloudflare.com"),
+      false,
+    );
+  });
+});
+
+describe("verifyGithubSignature", () => {
+  it("accepts a matching sha256 HMAC and rejects a bad one", () => {
+    const secret = "s3cret";
+    const body = '{"ok":true}';
+    const header = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+    assert.equal(verifyGithubSignature(secret, body, header), true);
+    assert.equal(verifyGithubSignature(secret, body, "sha256=deadbeef"), false);
+    assert.equal(verifyGithubSignature(secret, body, undefined), false);
+  });
+});
+
+describe("parseWebhookPull", () => {
+  it("reads a pull_request event payload", () => {
+    const parsed = parseWebhookPull({
+      repository: { name: "slicc", owner: { login: "ai-ecoverse" } },
+      pull_request: {
+        number: 2423,
+        title: "refresh files panel",
+        html_url: "https://github.com/ai-ecoverse/slicc/pull/2423",
+        state: "open",
+        draft: false,
+        merged: false,
+        mergeable_state: "clean",
+        auto_merge: null,
+        head: { ref: "feat/files" },
+      },
+    });
+    assert.equal(parsed?.owner, "ai-ecoverse");
+    assert.equal(parsed?.repo, "slicc");
+    assert.equal(parsed?.pull.number, 2423);
+    assert.equal(parsed?.pull.mergeableState, "clean");
+  });
+});
+
+describe("webhookPrNumbers", () => {
+  it("reads check_suite pull_requests", () => {
+    const numbers = webhookPrNumbers("check_suite", {
+      check_suite: { pull_requests: [{ number: 12 }, { number: 13 }] },
+    });
+    assert.deepEqual(numbers, [12, 13]);
+  });
+});
+
+describe("matchingGithubHook", () => {
+  it("finds the hook with our URL", () => {
+    const url = "https://lars.getbb.app/api/v1/plugins/gtd-sidebar/http/github-webhook";
+    const found = matchingGithubHook(
+      [
+        { id: 1, config: { url: "https://example.com" }, events: ["push"] },
+        { id: 9, config: { url }, events: ["pull_request"] },
+      ],
+      url,
+    );
+    assert.deepEqual(found, { id: 9, events: ["pull_request"], url });
+    assert.equal(eventsMatch(["pull_request"], ["pull_request", "check_suite"]), false);
+    assert.equal(eventsMatch(["a", "b"], ["b", "a"]), true);
+  });
+
+  it("reuses a previous trycloudflare hook after the URL rotates", () => {
+    const previous = "https://old-words.trycloudflare.com/github-webhook";
+    const next = "https://new-words.trycloudflare.com/github-webhook";
+    const found = matchingManagedGithubHook(
+      [{ id: 3, config: { url: previous }, events: ["pull_request"] }],
+      next,
+      previous,
+    );
+    assert.deepEqual(found, { id: 3, events: ["pull_request"], url: previous });
+    assert.equal(isTrycloudflareWebhookUrl(previous), true);
+    assert.equal(isTrycloudflareWebhookUrl(next), true);
+  });
+});

--- a/plugins/gtd-sidebar/test/open-in-app-browser.test.ts
+++ b/plugins/gtd-sidebar/test/open-in-app-browser.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  createInAppBrowserTab,
+  hasAnyModifierKey,
+  openBrowserTabInPanelState,
+  panelStorageKey,
+  parsePanelState,
+  serializePanelState,
+  shouldDeferToSystemBrowser,
+  upsertBrowserTab,
+} from "../lib/open-in-app-browser.ts";
+
+describe("hasAnyModifierKey", () => {
+  const none = { altKey: false, ctrlKey: false, metaKey: false, shiftKey: false };
+
+  it("is false with no modifiers", () => {
+    assert.equal(hasAnyModifierKey(none), false);
+  });
+
+  it("is true for alt, ctrl, meta, or shift", () => {
+    assert.equal(hasAnyModifierKey({ ...none, altKey: true }), true);
+    assert.equal(hasAnyModifierKey({ ...none, ctrlKey: true }), true);
+    assert.equal(hasAnyModifierKey({ ...none, metaKey: true }), true);
+    assert.equal(hasAnyModifierKey({ ...none, shiftKey: true }), true);
+  });
+});
+
+describe("shouldDeferToSystemBrowser", () => {
+  const none = { altKey: false, button: 0, ctrlKey: false, metaKey: false, shiftKey: false };
+
+  it("keeps a plain left click for the in-app browser", () => {
+    assert.equal(shouldDeferToSystemBrowser(none), false);
+  });
+
+  it("defers a modifier click and a non-left click", () => {
+    assert.equal(shouldDeferToSystemBrowser({ ...none, metaKey: true }), true);
+    assert.equal(shouldDeferToSystemBrowser({ ...none, button: 1 }), true);
+  });
+});
+
+describe("panelStorageKey", () => {
+  it("matches bb's per-thread panel blob key", () => {
+    assert.equal(
+      panelStorageKey("thr_1"),
+      "bb.thread.fixedPanelTabsState-thr_1-1",
+    );
+    assert.equal(
+      panelStorageKey("thr/1"),
+      "bb.thread.fixedPanelTabsState-thr%2F1-1",
+    );
+  });
+});
+
+describe("createInAppBrowserTab", () => {
+  it("builds a host-shaped browser tab id", () => {
+    const tab = createInAppBrowserTab({
+      environmentId: "env_1",
+      instanceId: "abc",
+      title: " Fix login ",
+      url: "https://github.com/acme/app/pull/12",
+    });
+    assert.deepEqual(tab, {
+      environmentId: "env_1",
+      id: "browser:abc:env_1",
+      kind: "browser",
+      title: "Fix login",
+      url: "https://github.com/acme/app/pull/12",
+    });
+  });
+
+  it("uses none when the thread has no environment", () => {
+    const tab = createInAppBrowserTab({
+      environmentId: null,
+      instanceId: "abc",
+      title: "",
+      url: "https://example.com",
+    });
+    assert.equal(tab.id, "browser:abc:none");
+    assert.equal(tab.title, "Pull request");
+  });
+});
+
+describe("upsertBrowserTab", () => {
+  it("reuses a tab that already has the URL", () => {
+    const existing = {
+      environmentId: null,
+      id: "browser:old:none",
+      kind: "browser" as const,
+      title: "Old",
+      url: "https://github.com/acme/app/pull/12",
+    };
+    const next = upsertBrowserTab(
+      [existing],
+      createInAppBrowserTab({
+        environmentId: null,
+        instanceId: "new",
+        title: "New",
+        url: existing.url,
+      }),
+    );
+    assert.equal(next.tab, existing);
+    assert.equal(next.tabs.length, 1);
+  });
+
+  it("appends when the URL is new", () => {
+    const existing = {
+      id: "thread-info:thread-info:none",
+      kind: "thread-info",
+    };
+    const tab = createInAppBrowserTab({
+      environmentId: null,
+      instanceId: "new",
+      title: "PR",
+      url: "https://github.com/acme/app/pull/12",
+    });
+    const next = upsertBrowserTab([existing], tab);
+    assert.equal(next.tab, tab);
+    assert.deepEqual(next.tabs, [existing, tab]);
+  });
+});
+
+describe("openBrowserTabInPanelState", () => {
+  it("opens the panel onto the new tab", () => {
+    const tab = createInAppBrowserTab({
+      environmentId: null,
+      instanceId: "abc",
+      title: "PR",
+      url: "https://github.com/acme/app/pull/12",
+    });
+    const { state } = openBrowserTabInPanelState(null, tab, 1_700_000_000_000);
+    assert.equal(state.version, 1);
+    assert.equal(state.lastUsedAt, 1_700_000_000_000);
+    assert.equal(state.secondary.isOpen, true);
+    assert.equal(state.secondary.activeTabId, tab.id);
+    assert.deepEqual(state.secondary.tabs, [tab]);
+  });
+
+  it("round-trips through the host's storage JSON", () => {
+    const tab = createInAppBrowserTab({
+      environmentId: "env_1",
+      instanceId: "abc",
+      title: "PR",
+      url: "https://github.com/acme/app/pull/12",
+    });
+    const { state } = openBrowserTabInPanelState(null, tab, 10);
+    const parsed = parsePanelState(serializePanelState(state));
+    assert.deepEqual(parsed, state);
+  });
+
+  it("rejects a blob that is not panel state", () => {
+    assert.equal(parsePanelState("not-json"), null);
+    assert.equal(parsePanelState("{}"), null);
+  });
+});

--- a/plugins/gtd-sidebar/test/pr-index.test.ts
+++ b/plugins/gtd-sidebar/test/pr-index.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   isCacheFresh,
   matchPullForBranch,
+  needsMergeStateLookup,
   parseRestPull,
   parseRestPulls,
   PR_CACHE_FRESH_MS,
@@ -95,7 +96,10 @@ describe("sidebarPrFromRest", () => {
   it("maps GitHub mergeable_state onto bb attention", () => {
     assert.equal(sidebarPrFromRest(pull({ mergeableState: "clean" })).attention, "ready_to_merge");
     assert.equal(sidebarPrFromRest(pull({ mergeableState: "dirty" })).attention, "conflicts");
-    assert.equal(sidebarPrFromRest(pull({ mergeableState: "unstable" })).attention, "checks_failed");
+    assert.equal(
+      sidebarPrFromRest(pull({ mergeableState: "unstable" })).attention,
+      "checks_failed",
+    );
     assert.equal(sidebarPrFromRest(pull({ mergeableState: "blocked" })).attention, "blocked");
     assert.equal(sidebarPrFromRest(pull({ autoMerge: true })).attention, "queued");
   });
@@ -140,6 +144,17 @@ describe("isCacheFresh", () => {
       fetchedAt: 1_000,
     };
     assert.equal(isCacheFresh(row, 1_001), false);
+  });
+});
+
+describe("needsMergeStateLookup", () => {
+  it("asks for a numbered GET only when the list left the state unknown", () => {
+    assert.equal(needsMergeStateLookup(pull()), true);
+    assert.equal(needsMergeStateLookup(pull({ mergeableState: "clean" })), false);
+    assert.equal(needsMergeStateLookup(pull({ draft: true })), false);
+    assert.equal(needsMergeStateLookup(pull({ autoMerge: true })), false);
+    assert.equal(needsMergeStateLookup(pull({ state: "closed" })), false);
+    assert.equal(needsMergeStateLookup(pull({ merged: true })), false);
   });
 });
 
@@ -200,6 +215,71 @@ describe("resolveThreadPullRequests", () => {
     );
     assert.equal(resolved.get("thr_1")?.source, "title");
     assert.equal(resolved.get("thr_1")?.number, 12);
+  });
+
+  it("buys the merge state the open list omits, so a blocked PR is not green", async () => {
+    // `/repos/.../pulls` has no `mergeable_state`, so every listed open PR
+    // arrived as "unknown" -> attention "none" -> the open-PR green. #377 was
+    // blocked with failing checks and still read as healthy.
+    const lookedUp: number[] = [];
+    const resolved = await resolveThreadPullRequests([query()], {
+      now: 5_000,
+      restRemaining: 4_000,
+      getCache: () => undefined,
+      putCache: () => {},
+      getRepo: async () => ({ owner: "acme", repo: "app" }),
+      listOpenPulls: async () => [pull({ mergeableState: "unknown" })],
+      getPull: async (_repo, number) => {
+        lookedUp.push(number);
+        return pull({ number, mergeableState: "blocked" });
+      },
+      listRecentClosedPulls: async () => [],
+      log: { info() {}, warn() {} },
+    });
+    assert.deepEqual(lookedUp, [12]);
+    assert.equal(resolved.get("thr_1")?.attention, "blocked");
+  });
+
+  it("keeps the listed pull when the numbered lookup fails", async () => {
+    const resolved = await resolveThreadPullRequests([query()], {
+      now: 5_000,
+      restRemaining: 4_000,
+      getCache: () => undefined,
+      putCache: () => {},
+      getRepo: async () => ({ owner: "acme", repo: "app" }),
+      listOpenPulls: async () => [pull()],
+      getPull: async () => {
+        throw new Error("REST refused");
+      },
+      listRecentClosedPulls: async () => [],
+      log: { info() {}, warn() {} },
+    });
+    assert.equal(resolved.get("thr_1")?.number, 12);
+    assert.equal(resolved.get("thr_1")?.attention, "none");
+  });
+
+  it("spends no lookup on states the list already decides", async () => {
+    const resolved = await resolveThreadPullRequests(
+      [query(), query({ threadId: "thr_2", branchName: "feat/queued" })],
+      {
+        now: 5_000,
+        restRemaining: 4_000,
+        getCache: () => undefined,
+        putCache: () => {},
+        getRepo: async () => ({ owner: "acme", repo: "app" }),
+        listOpenPulls: async () => [
+          pull({ draft: true }),
+          pull({ number: 13, headRef: "feat/queued", autoMerge: true }),
+        ],
+        getPull: async () => {
+          throw new Error("should not look up a numbered PR");
+        },
+        listRecentClosedPulls: async () => [],
+        log: { info() {}, warn() {} },
+      },
+    );
+    assert.equal(resolved.get("thr_1")?.attention, "draft");
+    assert.equal(resolved.get("thr_2")?.attention, "queued");
   });
 
   it("serves a stale cache when REST is skipped and the title has no number", async () => {
@@ -264,22 +344,19 @@ describe("resolveThreadPullRequests", () => {
 
   it("does not treat a title #number as an open PR after REST listed the repo", async () => {
     const cached: CachedPullRow[] = [];
-    const resolved = await resolveThreadPullRequests(
-      [query({ title: "acme/app#2406 shipped" })],
-      {
-        now: 5_000,
-        restRemaining: 4_000,
-        getCache: () => undefined,
-        putCache: (row) => {
-          cached.push(row);
-        },
-        getRepo: async () => ({ owner: "acme", repo: "app" }),
-        listOpenPulls: async () => [],
-        getPull: async () => null,
-        listRecentClosedPulls: async () => [],
-        log: { info() {}, warn() {} },
+    const resolved = await resolveThreadPullRequests([query({ title: "acme/app#2406 shipped" })], {
+      now: 5_000,
+      restRemaining: 4_000,
+      getCache: () => undefined,
+      putCache: (row) => {
+        cached.push(row);
       },
-    );
+      getRepo: async () => ({ owner: "acme", repo: "app" }),
+      listOpenPulls: async () => [],
+      getPull: async () => null,
+      listRecentClosedPulls: async () => [],
+      log: { info() {}, warn() {} },
+    });
     assert.equal(resolved.get("thr_1"), undefined);
     assert.equal(cached.length, 1);
     assert.equal(cached[0]?.number, null);
@@ -309,7 +386,9 @@ describe("resolveThreadPullRequests", () => {
         }),
         putCache: () => {},
         getRepo: async () => ({ owner: "acme", repo: "app" }),
-        listOpenPulls: async () => [pull({ number: 2255, headRef: "feat/parent", title: "parent" })],
+        listOpenPulls: async () => [
+          pull({ number: 2255, headRef: "feat/parent", title: "parent" }),
+        ],
         listRecentClosedPulls: async () => [
           pull({
             number: 2450,

--- a/plugins/gtd-sidebar/test/pr-index.test.ts
+++ b/plugins/gtd-sidebar/test/pr-index.test.ts
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  isCacheFresh,
+  matchPullForBranch,
+  parseRestPull,
+  parseRestPulls,
+  PR_CACHE_FRESH_MS,
+  sidebarPrFromRest,
+  sidebarPrFromTitle,
+  type CachedPullRow,
+  type RestPull,
+} from "../lib/pr-index.ts";
+import { resolveThreadPullRequests, type ThreadPrQuery } from "../lib/pr-index-run.ts";
+
+const pull = (overrides: Partial<RestPull> = {}): RestPull => ({
+  number: 12,
+  title: "Dump curl headers",
+  url: "https://github.com/acme/app/pull/12",
+  draft: false,
+  state: "open",
+  merged: false,
+  headRef: "feat/curl-dump-header",
+  ...overrides,
+});
+
+describe("parseRestPulls", () => {
+  it("keeps well-formed pulls and drops junk", () => {
+    const parsed = parseRestPulls([
+      {
+        number: 12,
+        title: "Dump curl headers",
+        html_url: "https://github.com/acme/app/pull/12",
+        state: "open",
+        draft: true,
+        merged_at: null,
+        head: { ref: "feat/curl-dump-header" },
+      },
+      { number: "nope" },
+    ]);
+    assert.equal(parsed.length, 1);
+    assert.equal(parsed[0]?.draft, true);
+    assert.equal(parsed[0]?.headRef, "feat/curl-dump-header");
+  });
+});
+
+describe("parseRestPull", () => {
+  it("treats merged true and merged_at as merged", () => {
+    assert.equal(
+      parseRestPull({
+        number: 2406,
+        title: "Done",
+        html_url: "https://github.com/acme/app/pull/2406",
+        state: "closed",
+        merged: true,
+        merged_at: null,
+        head: { ref: "feat/done" },
+      })?.merged,
+      true,
+    );
+    assert.equal(
+      parseRestPull({
+        number: 2406,
+        title: "Done",
+        html_url: "https://github.com/acme/app/pull/2406",
+        state: "closed",
+        merged_at: "2026-08-26T00:00:00Z",
+        head: { ref: "feat/done" },
+      })?.merged,
+      true,
+    );
+  });
+});
+
+describe("matchPullForBranch", () => {
+  it("matches an open PR for the branch and ignores GitButler's workspace ref", () => {
+    const pulls = [pull(), pull({ number: 13, headRef: "other", state: "open" })];
+    assert.equal(matchPullForBranch(pulls, "feat/curl-dump-header")?.number, 12);
+    assert.equal(matchPullForBranch(pulls, "gitbutler/workspace"), null);
+    assert.equal(matchPullForBranch(pulls, null), null);
+  });
+});
+
+describe("sidebarPrFromRest", () => {
+  it("maps draft, merged, and open onto sidebar states", () => {
+    assert.equal(sidebarPrFromRest(pull({ draft: true })).state, "draft");
+    assert.equal(sidebarPrFromRest(pull({ draft: true })).attention, "draft");
+    assert.equal(sidebarPrFromRest(pull({ merged: true, state: "closed" })).state, "merged");
+    assert.equal(sidebarPrFromRest(pull()).attention, "none");
+  });
+});
+
+describe("sidebarPrFromTitle", () => {
+  it("fills owner/repo from the git remote when the title only has a number", () => {
+    const pr = sidebarPrFromTitle("Verify APNs (#2213)", { owner: "acme", repo: "app" });
+    assert.equal(pr?.number, 2213);
+    assert.equal(pr?.url, "https://github.com/acme/app/pull/2213");
+    assert.equal(pr?.source, "title");
+  });
+});
+
+describe("isCacheFresh", () => {
+  it("treats a merged hit as fresh for 15 minutes", () => {
+    const row: CachedPullRow = {
+      environmentId: "env_1",
+      owner: "acme",
+      repo: "app",
+      number: 12,
+      title: "Dump",
+      url: "https://github.com/acme/app/pull/12",
+      state: "merged",
+      attention: "merged",
+      fetchedAt: 1_000,
+    };
+    assert.equal(isCacheFresh(row, 1_000 + PR_CACHE_FRESH_MS - 1), true);
+    assert.equal(isCacheFresh(row, 1_000 + PR_CACHE_FRESH_MS), false);
+  });
+
+  it("does not trust an open hit, so a merge is visible on the next tick", () => {
+    const row: CachedPullRow = {
+      environmentId: "env_1",
+      owner: "acme",
+      repo: "app",
+      number: 12,
+      title: "Dump",
+      url: "https://github.com/acme/app/pull/12",
+      state: "open",
+      attention: "none",
+      fetchedAt: 1_000,
+    };
+    assert.equal(isCacheFresh(row, 1_001), false);
+  });
+});
+
+describe("resolveThreadPullRequests", () => {
+  const query = (overrides: Partial<ThreadPrQuery> = {}): ThreadPrQuery => ({
+    threadId: "thr_1",
+    environmentId: "env_1",
+    branchName: "feat/curl-dump-header",
+    title: "Dump curl headers",
+    ...overrides,
+  });
+
+  it("lists each repository once and matches by branch", async () => {
+    let restCalls = 0;
+    const resolved = await resolveThreadPullRequests(
+      [query(), query({ threadId: "thr_2", title: "same repo other thread" })],
+      {
+        now: 5_000,
+        restRemaining: 4_000,
+        getCache: () => undefined,
+        putCache: () => {},
+        getRepo: async () => ({ owner: "acme", repo: "app" }),
+        listOpenPulls: async () => {
+          restCalls += 1;
+          return [pull()];
+        },
+        getPull: async () => {
+          throw new Error("should not look up a numbered PR");
+        },
+        listClosedPullsByHead: async () => [],
+        log: { info() {}, warn() {} },
+      },
+    );
+    assert.equal(restCalls, 1);
+    assert.equal(resolved.get("thr_1")?.number, 12);
+    assert.equal(resolved.get("thr_1")?.source, "rest");
+    assert.equal(resolved.get("thr_2")?.number, 12);
+  });
+
+  it("falls back to the title when REST is too tight to spend", async () => {
+    const resolved = await resolveThreadPullRequests(
+      [query({ title: "acme/app#12 Dump curl headers" })],
+      {
+        now: 5_000,
+        restRemaining: 10,
+        getCache: () => undefined,
+        putCache: () => {},
+        getRepo: async () => ({ owner: "acme", repo: "app" }),
+        listOpenPulls: async () => {
+          throw new Error("should not hit REST");
+        },
+        getPull: async () => {
+          throw new Error("should not look up a numbered PR");
+        },
+        listClosedPullsByHead: async () => [],
+        log: { info() {}, warn() {} },
+      },
+    );
+    assert.equal(resolved.get("thr_1")?.source, "title");
+    assert.equal(resolved.get("thr_1")?.number, 12);
+  });
+
+  it("serves a stale cache when REST is skipped and the title has no number", async () => {
+    const resolved = await resolveThreadPullRequests([query()], {
+      now: 5_000 + PR_CACHE_FRESH_MS + 1,
+      restRemaining: 0,
+      getCache: () => ({
+        environmentId: "env_1",
+        owner: "acme",
+        repo: "app",
+        number: 12,
+        title: "Dump curl headers",
+        url: "https://github.com/acme/app/pull/12",
+        state: "open",
+        attention: "none",
+        fetchedAt: 5_000,
+      }),
+      putCache: () => {
+        throw new Error("must not refresh TTL from a stale hit");
+      },
+      getRepo: async () => ({ owner: "acme", repo: "app" }),
+      listOpenPulls: async () => {
+        throw new Error("should not hit REST");
+      },
+      getPull: async () => {
+        throw new Error("should not look up a numbered PR");
+      },
+      listClosedPullsByHead: async () => [],
+      log: { info() {}, warn() {} },
+    });
+    assert.equal(resolved.get("thr_1")?.source, "cache");
+  });
+
+  it("looks up a titled PR that has left the open list, so a merge turns purple", async () => {
+    const resolved = await resolveThreadPullRequests(
+      [query({ title: "acme/app#2406 shipped", branchName: "feat/shipped" })],
+      {
+        now: 5_000,
+        restRemaining: 4_000,
+        getCache: () => undefined,
+        putCache: () => {},
+        getRepo: async () => ({ owner: "acme", repo: "app" }),
+        listOpenPulls: async () => [],
+        getPull: async (_repo, number) =>
+          pull({
+            number,
+            title: "shipped",
+            url: "https://github.com/acme/app/pull/2406",
+            state: "closed",
+            merged: true,
+            headRef: "feat/shipped",
+          }),
+        listClosedPullsByHead: async () => {
+          throw new Error("numbered lookup should win");
+        },
+        log: { info() {}, warn() {} },
+      },
+    );
+    assert.equal(resolved.get("thr_1")?.number, 2406);
+    assert.equal(resolved.get("thr_1")?.state, "merged");
+    assert.equal(resolved.get("thr_1")?.attention, "merged");
+    assert.equal(resolved.get("thr_1")?.source, "rest");
+  });
+
+  it("does not cache a title fallback as open", async () => {
+    const cached: CachedPullRow[] = [];
+    const resolved = await resolveThreadPullRequests(
+      [query({ title: "acme/app#2406 shipped" })],
+      {
+        now: 5_000,
+        restRemaining: 4_000,
+        getCache: () => undefined,
+        putCache: (row) => {
+          cached.push(row);
+        },
+        getRepo: async () => ({ owner: "acme", repo: "app" }),
+        listOpenPulls: async () => [],
+        getPull: async () => null,
+        listClosedPullsByHead: async () => [],
+        log: { info() {}, warn() {} },
+      },
+    );
+    assert.equal(resolved.get("thr_1")?.source, "title");
+    assert.equal(cached.length, 0);
+  });
+});

--- a/plugins/gtd-sidebar/test/pr-index.test.ts
+++ b/plugins/gtd-sidebar/test/pr-index.test.ts
@@ -21,6 +21,8 @@ const pull = (overrides: Partial<RestPull> = {}): RestPull => ({
   state: "open",
   merged: false,
   headRef: "feat/curl-dump-header",
+  mergeableState: "unknown",
+  autoMerge: false,
   ...overrides,
 });
 
@@ -77,6 +79,7 @@ describe("matchPullForBranch", () => {
     const pulls = [pull(), pull({ number: 13, headRef: "other", state: "open" })];
     assert.equal(matchPullForBranch(pulls, "feat/curl-dump-header")?.number, 12);
     assert.equal(matchPullForBranch(pulls, "gitbutler/workspace"), null);
+    assert.equal(matchPullForBranch(pulls, "3 GitButler branches"), null);
     assert.equal(matchPullForBranch(pulls, null), null);
   });
 });
@@ -87,6 +90,14 @@ describe("sidebarPrFromRest", () => {
     assert.equal(sidebarPrFromRest(pull({ draft: true })).attention, "draft");
     assert.equal(sidebarPrFromRest(pull({ merged: true, state: "closed" })).state, "merged");
     assert.equal(sidebarPrFromRest(pull()).attention, "none");
+  });
+
+  it("maps GitHub mergeable_state onto bb attention", () => {
+    assert.equal(sidebarPrFromRest(pull({ mergeableState: "clean" })).attention, "ready_to_merge");
+    assert.equal(sidebarPrFromRest(pull({ mergeableState: "dirty" })).attention, "conflicts");
+    assert.equal(sidebarPrFromRest(pull({ mergeableState: "unstable" })).attention, "checks_failed");
+    assert.equal(sidebarPrFromRest(pull({ mergeableState: "blocked" })).attention, "blocked");
+    assert.equal(sidebarPrFromRest(pull({ autoMerge: true })).attention, "queued");
   });
 });
 
@@ -158,7 +169,7 @@ describe("resolveThreadPullRequests", () => {
         getPull: async () => {
           throw new Error("should not look up a numbered PR");
         },
-        listClosedPullsByHead: async () => [],
+        listRecentClosedPulls: async () => [],
         log: { info() {}, warn() {} },
       },
     );
@@ -183,7 +194,7 @@ describe("resolveThreadPullRequests", () => {
         getPull: async () => {
           throw new Error("should not look up a numbered PR");
         },
-        listClosedPullsByHead: async () => [],
+        listRecentClosedPulls: async () => [],
         log: { info() {}, warn() {} },
       },
     );
@@ -216,7 +227,7 @@ describe("resolveThreadPullRequests", () => {
       getPull: async () => {
         throw new Error("should not look up a numbered PR");
       },
-      listClosedPullsByHead: async () => [],
+      listRecentClosedPulls: async () => [],
       log: { info() {}, warn() {} },
     });
     assert.equal(resolved.get("thr_1")?.source, "cache");
@@ -241,9 +252,7 @@ describe("resolveThreadPullRequests", () => {
             merged: true,
             headRef: "feat/shipped",
           }),
-        listClosedPullsByHead: async () => {
-          throw new Error("numbered lookup should win");
-        },
+        listRecentClosedPulls: async () => [],
         log: { info() {}, warn() {} },
       },
     );
@@ -253,7 +262,7 @@ describe("resolveThreadPullRequests", () => {
     assert.equal(resolved.get("thr_1")?.source, "rest");
   });
 
-  it("does not cache a title fallback as open", async () => {
+  it("does not treat a title #number as an open PR after REST listed the repo", async () => {
     const cached: CachedPullRow[] = [];
     const resolved = await resolveThreadPullRequests(
       [query({ title: "acme/app#2406 shipped" })],
@@ -267,11 +276,91 @@ describe("resolveThreadPullRequests", () => {
         getRepo: async () => ({ owner: "acme", repo: "app" }),
         listOpenPulls: async () => [],
         getPull: async () => null,
-        listClosedPullsByHead: async () => [],
+        listRecentClosedPulls: async () => [],
         log: { info() {}, warn() {} },
       },
     );
-    assert.equal(resolved.get("thr_1")?.source, "title");
-    assert.equal(cached.length, 0);
+    assert.equal(resolved.get("thr_1"), undefined);
+    assert.equal(cached.length, 1);
+    assert.equal(cached[0]?.number, null);
+  });
+
+  it("colours a merged PR from the closed list even when the title cites a parent", async () => {
+    const resolved = await resolveThreadPullRequests(
+      [
+        query({
+          title: "docs(webapp): say why curlwright is outside the #2255 flag sweep",
+          branchName: "gitbutler/workspace",
+        }),
+      ],
+      {
+        now: 5_000,
+        restRemaining: 4_000,
+        getCache: () => ({
+          environmentId: "env_1",
+          owner: "acme",
+          repo: "app",
+          number: 2450,
+          title: "docs(webapp): say why curlwright is outside the #2255 flag sweep",
+          url: "https://github.com/acme/app/pull/2450",
+          state: "open",
+          attention: "none",
+          fetchedAt: 1_000,
+        }),
+        putCache: () => {},
+        getRepo: async () => ({ owner: "acme", repo: "app" }),
+        listOpenPulls: async () => [pull({ number: 2255, headRef: "feat/parent", title: "parent" })],
+        listRecentClosedPulls: async () => [
+          pull({
+            number: 2450,
+            title: "docs",
+            url: "https://github.com/acme/app/pull/2450",
+            state: "closed",
+            merged: true,
+            headRef: "bb/curlwright-note",
+          }),
+        ],
+        getPull: async () => {
+          throw new Error("closed list should match the cached number");
+        },
+        log: { info() {}, warn() {} },
+      },
+    );
+    assert.equal(resolved.get("thr_1")?.number, 2450);
+    assert.equal(resolved.get("thr_1")?.state, "merged");
+    assert.equal(resolved.get("thr_1")?.source, "rest");
+  });
+
+  it("does not keep a stale open colour after the PR leaves the open list", async () => {
+    const resolved = await resolveThreadPullRequests([query({ title: "no number here" })], {
+      now: 5_000,
+      restRemaining: 4_000,
+      getCache: () => ({
+        environmentId: "env_1",
+        owner: "acme",
+        repo: "app",
+        number: 2421,
+        title: "old",
+        url: "https://github.com/acme/app/pull/2421",
+        state: "open",
+        attention: "none",
+        fetchedAt: 1_000,
+      }),
+      putCache: () => {},
+      getRepo: async () => ({ owner: "acme", repo: "app" }),
+      listOpenPulls: async () => [],
+      listRecentClosedPulls: async () => [],
+      getPull: async (_repo, number) =>
+        pull({
+          number,
+          title: "merged now",
+          url: "https://github.com/acme/app/pull/2421",
+          state: "closed",
+          merged: true,
+        }),
+      log: { info() {}, warn() {} },
+    });
+    assert.equal(resolved.get("thr_1")?.number, 2421);
+    assert.equal(resolved.get("thr_1")?.state, "merged");
   });
 });

--- a/plugins/gtd-sidebar/test/pr-index.test.ts
+++ b/plugins/gtd-sidebar/test/pr-index.test.ts
@@ -363,4 +363,33 @@ describe("resolveThreadPullRequests", () => {
     assert.equal(resolved.get("thr_1")?.number, 2421);
     assert.equal(resolved.get("thr_1")?.state, "merged");
   });
+
+  it("looks up owner/repo#N from the title even when the checkout is another repository", async () => {
+    const lookups: string[] = [];
+    const resolved = await resolveThreadPullRequests(
+      [query({ title: "see other/repo#123 for context", branchName: "local-notes" })],
+      {
+        now: 5_000,
+        restRemaining: 4_000,
+        getCache: () => undefined,
+        putCache: () => {},
+        getRepo: async () => ({ owner: "acme", repo: "app" }),
+        listOpenPulls: async () => [pull({ number: 99, headRef: "feat/unrelated" })],
+        listRecentClosedPulls: async () => [],
+        getPull: async (repo, number) => {
+          lookups.push(`${repo.owner}/${repo.repo}#${number}`);
+          return pull({
+            number,
+            title: "the cited one",
+            url: `https://github.com/${repo.owner}/${repo.repo}/pull/${number}`,
+            headRef: "feat/cited",
+          });
+        },
+        log: { info() {}, warn() {} },
+      },
+    );
+    assert.deepEqual(lookups, ["other/repo#123"]);
+    assert.equal(resolved.get("thr_1")?.number, 123);
+    assert.equal(resolved.get("thr_1")?.url, "https://github.com/other/repo/pull/123");
+  });
 });

--- a/plugins/gtd-sidebar/test/pr-status.test.ts
+++ b/plugins/gtd-sidebar/test/pr-status.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { prNumberClassName, prNumberLabel } from "../lib/pr-status.ts";
+
+describe("prNumberClassName", () => {
+  it("colours a draft grey, distinct from an open PR", () => {
+    assert.equal(
+      prNumberClassName({ state: "draft", attention: "draft" }),
+      "text-muted-foreground/50",
+    );
+    assert.equal(prNumberClassName({ state: "open", attention: "none" }), "text-muted-foreground");
+    assert.equal(
+      prNumberClassName({ state: "open", attention: "ready_to_merge" }),
+      "text-success-foreground",
+    );
+  });
+
+  it("colours a merge-queue PR with the attention token", () => {
+    assert.equal(
+      prNumberClassName({ state: "open", attention: "queued" }),
+      "text-[color:var(--attention)]",
+    );
+  });
+
+  it("keeps merged purple and failures red", () => {
+    assert.equal(
+      prNumberClassName({ state: "merged", attention: "merged" }),
+      "text-[color:var(--pr-merged)]",
+    );
+    assert.equal(
+      prNumberClassName({ state: "open", attention: "checks_failed" }),
+      "text-destructive-text",
+    );
+    assert.equal(
+      prNumberClassName({ state: "open", attention: "conflicts" }),
+      "text-destructive-text",
+    );
+  });
+
+  it("lets attention outrank state so a queued draft still reads as queued", () => {
+    assert.equal(
+      prNumberClassName({ state: "draft", attention: "queued" }),
+      "text-[color:var(--attention)]",
+    );
+  });
+});
+
+describe("prNumberLabel", () => {
+  it("names draft and merge-queue for the title", () => {
+    assert.equal(prNumberLabel({ state: "draft", attention: "draft" }), "Draft pull request");
+    assert.equal(
+      prNumberLabel({ state: "open", attention: "queued" }),
+      "Pull request in merge queue",
+    );
+  });
+});

--- a/plugins/gtd-sidebar/test/pr-status.test.ts
+++ b/plugins/gtd-sidebar/test/pr-status.test.ts
@@ -12,10 +12,10 @@ describe("prNumberClassName", () => {
     assert.equal(prNumberClassName({ state: "open", attention: "ready_to_merge" }), "text-success");
   });
 
-  it("colours a merge-queue PR with the attention token", () => {
+  it("colours a merge-queue PR with the warning-text ochre Full Access uses", () => {
     assert.equal(
       prNumberClassName({ state: "open", attention: "queued" }),
-      "text-[color:var(--attention)]",
+      "text-[color:var(--warning-text)]",
     );
   });
 
@@ -40,7 +40,7 @@ describe("prNumberClassName", () => {
   it("lets attention outrank state so a queued draft still reads as queued", () => {
     assert.equal(
       prNumberClassName({ state: "draft", attention: "queued" }),
-      "text-[color:var(--attention)]",
+      "text-[color:var(--warning-text)]",
     );
   });
 });

--- a/plugins/gtd-sidebar/test/pr-status.test.ts
+++ b/plugins/gtd-sidebar/test/pr-status.test.ts
@@ -3,15 +3,15 @@ import { describe, it } from "node:test";
 import { prNumberClassName, prNumberLabel } from "../lib/pr-status.ts";
 
 describe("prNumberClassName", () => {
-  it("colours a draft grey, distinct from an open PR", () => {
+  it("colours a draft muted and an open PR with bb's success token", () => {
     assert.equal(
       prNumberClassName({ state: "draft", attention: "draft" }),
-      "text-muted-foreground/50",
+      "text-muted-foreground",
     );
-    assert.equal(prNumberClassName({ state: "open", attention: "none" }), "text-muted-foreground");
+    assert.equal(prNumberClassName({ state: "open", attention: "none" }), "text-success");
     assert.equal(
       prNumberClassName({ state: "open", attention: "ready_to_merge" }),
-      "text-success-foreground",
+      "text-success",
     );
   });
 

--- a/plugins/gtd-sidebar/test/pr-status.test.ts
+++ b/plugins/gtd-sidebar/test/pr-status.test.ts
@@ -9,10 +9,7 @@ describe("prNumberClassName", () => {
       "text-muted-foreground",
     );
     assert.equal(prNumberClassName({ state: "open", attention: "none" }), "text-success");
-    assert.equal(
-      prNumberClassName({ state: "open", attention: "ready_to_merge" }),
-      "text-success",
-    );
+    assert.equal(prNumberClassName({ state: "open", attention: "ready_to_merge" }), "text-success");
   });
 
   it("colours a merge-queue PR with the attention token", () => {
@@ -31,9 +28,12 @@ describe("prNumberClassName", () => {
       prNumberClassName({ state: "open", attention: "checks_failed" }),
       "text-destructive-text",
     );
+  });
+
+  it("strikes a conflicting PR through so it reads apart from the other reds", () => {
     assert.equal(
       prNumberClassName({ state: "open", attention: "conflicts" }),
-      "text-destructive-text",
+      "text-destructive-text line-through hover:[text-decoration-line:underline_line-through]!",
     );
   });
 

--- a/plugins/gtd-sidebar/test/pr-watch-run.test.ts
+++ b/plugins/gtd-sidebar/test/pr-watch-run.test.ts
@@ -1,0 +1,240 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  pollSnoozedPullRequests,
+  type PrWatchPollStore,
+  type StoredPrWatch,
+} from "../lib/pr-watch-run.ts";
+import {
+  MAX_PR_BACKFILL_PER_TICK,
+  serializeSnapshot,
+  type PrWatchSnapshot,
+} from "../lib/pr-watch.ts";
+
+const now = Date.parse("2026-08-26T10:00:00Z");
+
+const snapshot = (overrides: Partial<PrWatchSnapshot> = {}): PrWatchSnapshot => ({
+  nodeId: "PR_kw1",
+  url: "https://github.com/acme/app/pull/12",
+  number: 12,
+  title: "Fix the flaky test",
+  updatedAt: "2026-08-26T09:00:00Z",
+  commentCount: 1,
+  reviewCount: 0,
+  reviewThreadCount: 0,
+  latestReviewState: null,
+  latestReviewAuthor: null,
+  checkRollup: "SUCCESS",
+  latestDeployment: null,
+  ...overrides,
+});
+
+function graphqlPayload(pr: PrWatchSnapshot, remaining = 4_000) {
+  return {
+    data: {
+      rateLimit: {
+        cost: 8,
+        remaining,
+        resetAt: "2026-08-26T11:00:00Z",
+        limit: 5_000,
+      },
+      p0: {
+        id: pr.nodeId,
+        url: pr.url,
+        number: pr.number,
+        title: pr.title,
+        updatedAt: pr.updatedAt,
+        comments: { totalCount: pr.commentCount },
+        reviews: { totalCount: pr.reviewCount },
+        reviewThreads: { totalCount: pr.reviewThreadCount },
+        latestReviews: {
+          nodes:
+            pr.latestReviewState === null
+              ? []
+              : [{ state: pr.latestReviewState, author: { login: pr.latestReviewAuthor } }],
+        },
+        commits: {
+          nodes: [
+            {
+              commit: {
+                statusCheckRollup: pr.checkRollup === null ? null : { state: pr.checkRollup },
+                deployments: { nodes: pr.latestDeployment === null ? [] : [pr.latestDeployment] },
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+function memoryStore(
+  snoozed: { threadId: string; snoozedUntil: number }[],
+  watches: StoredPrWatch[] = [],
+): PrWatchPollStore & { watches: Map<string, StoredPrWatch> } {
+  const watchMap = new Map(watches.map((watch) => [watch.threadId, watch]));
+  return {
+    watches: watchMap,
+    listSnoozed: () => snoozed,
+    getWatch: (threadId) => watchMap.get(threadId),
+    upsertWatch(row) {
+      watchMap.set(row.threadId, {
+        threadId: row.threadId,
+        prUrl: row.prUrl,
+        snapshotJson: row.snapshotJson,
+      });
+    },
+  };
+}
+
+describe("pollSnoozedPullRequests", () => {
+  it("baselines the first observation instead of waking", async () => {
+    const store = memoryStore(
+      [{ threadId: "thr_1", snoozedUntil: now + 60_000 }],
+      [{ threadId: "thr_1", prUrl: "https://github.com/acme/app/pull/12", snapshotJson: null }],
+    );
+    const woken: string[] = [];
+    const result = await pollSnoozedPullRequests({
+      now,
+      store,
+      graphql: async () => ({ raw: graphqlPayload(snapshot()), stderr: "", exitCode: 0 }),
+      resolvePrUrl: async () => null,
+      wakeThread: async (threadId) => {
+        woken.push(threadId);
+      },
+      log: { info() {}, warn() {} },
+      remainingHint: null,
+      skipUntilMs: null,
+    });
+    assert.equal(result.baselined, 1);
+    assert.equal(result.woken, 0);
+    assert.deepEqual(woken, []);
+    assert.ok(store.getWatch("thr_1")?.snapshotJson);
+  });
+
+  it("wakes when comments or checks change", async () => {
+    const previous = snapshot();
+    const store = memoryStore(
+      [{ threadId: "thr_1", snoozedUntil: now + 60_000 }],
+      [
+        {
+          threadId: "thr_1",
+          prUrl: "https://github.com/acme/app/pull/12",
+          snapshotJson: serializeSnapshot(previous),
+        },
+      ],
+    );
+    const woken: { threadId: string; text: string[] }[] = [];
+    const result = await pollSnoozedPullRequests({
+      now,
+      store,
+      graphql: async () => ({
+        raw: graphqlPayload(
+          snapshot({
+            updatedAt: "2026-08-26T10:00:00Z",
+            commentCount: 4,
+            checkRollup: "FAILURE",
+          }),
+        ),
+        stderr: "",
+        exitCode: 0,
+      }),
+      resolvePrUrl: async () => null,
+      wakeThread: async (threadId, _snapshot, changes) => {
+        woken.push({ threadId, text: changes.map((change) => change.text) });
+      },
+      log: { info() {}, warn() {} },
+      remainingHint: null,
+      skipUntilMs: null,
+    });
+    assert.equal(result.woken, 1);
+    assert.equal(woken[0]?.threadId, "thr_1");
+    assert.ok(woken[0]?.text.some((text) => text.includes("new comment")));
+    assert.ok(woken[0]?.text.some((text) => text.includes("FAILURE")));
+  });
+
+  it("skips the tick when remaining points are too low", async () => {
+    let queried = false;
+    const result = await pollSnoozedPullRequests({
+      now,
+      store: memoryStore([{ threadId: "thr_1", snoozedUntil: now + 60_000 }]),
+      graphql: async () => {
+        queried = true;
+        return { raw: {}, stderr: "", exitCode: 0 };
+      },
+      resolvePrUrl: async () => {
+        throw new Error("should not backfill while rate-limited");
+      },
+      wakeThread: async () => {
+        throw new Error("should not wake");
+      },
+      log: { info() {}, warn() {} },
+      remainingHint: 10,
+      skipUntilMs: null,
+    });
+    assert.equal(queried, false);
+    assert.equal(result.queried, 0);
+  });
+
+  it("caps PR backfill so a cold shelf cannot burst the REST rate limit", async () => {
+    const snoozed = Array.from({ length: MAX_PR_BACKFILL_PER_TICK + 5 }, (_, i) => ({
+      threadId: `thr_${i}`,
+      snoozedUntil: now + 60_000,
+    }));
+    const store = memoryStore(snoozed);
+    let resolved = 0;
+    await pollSnoozedPullRequests({
+      now,
+      store,
+      graphql: async () => ({
+        raw: {
+          data: {
+            rateLimit: { cost: 1, remaining: 4000, resetAt: "2026-08-26T11:00:00Z", limit: 5000 },
+          },
+        },
+        stderr: "",
+        exitCode: 0,
+      }),
+      resolvePrUrl: async () => {
+        resolved += 1;
+        return `https://github.com/acme/app/pull/${resolved}`;
+      },
+      wakeThread: async () => {},
+      log: { info() {}, warn() {} },
+      remainingHint: null,
+      skipUntilMs: null,
+    });
+    assert.equal(resolved, MAX_PR_BACKFILL_PER_TICK);
+  });
+
+  it("issues a single GraphQL query for every watched URL", async () => {
+    const store = memoryStore(
+      [
+        { threadId: "thr_1", snoozedUntil: now + 60_000 },
+        { threadId: "thr_2", snoozedUntil: now + 60_000 },
+      ],
+      [
+        { threadId: "thr_1", prUrl: "https://github.com/acme/app/pull/12", snapshotJson: null },
+        { threadId: "thr_2", prUrl: "https://github.com/acme/app/pull/13", snapshotJson: null },
+      ],
+    );
+    const queries: string[] = [];
+    await pollSnoozedPullRequests({
+      now,
+      store,
+      graphql: async (query) => {
+        queries.push(query);
+        return { raw: graphqlPayload(snapshot()), stderr: "", exitCode: 0 };
+      },
+      resolvePrUrl: async () => null,
+      wakeThread: async () => {},
+      log: { info() {}, warn() {} },
+      remainingHint: null,
+      skipUntilMs: null,
+    });
+    assert.equal(queries.length, 1);
+    assert.match(queries[0] ?? "", /p0: resource/);
+    assert.match(queries[0] ?? "", /p1: resource/);
+    assert.equal([...(queries[0] ?? "").matchAll(/^query /gm)].length, 1);
+  });
+});

--- a/plugins/gtd-sidebar/test/pr-watch.test.ts
+++ b/plugins/gtd-sidebar/test/pr-watch.test.ts
@@ -1,0 +1,235 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildSnoozedPrWatchQuery,
+  canonicalPullRequestUrl,
+  diffSnapshots,
+  fingerprintOf,
+  formatAgentWakeMessage,
+  parseStoredSnapshot,
+  serializeSnapshot,
+  isGraphqlRateLimited,
+  MAX_WATCHED_PRS,
+  MIN_RATE_LIMIT_REMAINING,
+  parseSnoozedPrWatchResponse,
+  shouldSkipForRateLimit,
+  skipUntilMsFromResetAt,
+  watchedUrlsForQuery,
+  type PrWatchSnapshot,
+} from "../lib/pr-watch.ts";
+
+const snapshot = (overrides: Partial<PrWatchSnapshot> = {}): PrWatchSnapshot => ({
+  nodeId: "PR_kw1",
+  url: "https://github.com/acme/app/pull/12",
+  number: 12,
+  title: "Fix the flaky test",
+  updatedAt: "2026-08-26T10:00:00Z",
+  commentCount: 1,
+  reviewCount: 0,
+  reviewThreadCount: 0,
+  latestReviewState: null,
+  latestReviewAuthor: null,
+  checkRollup: "SUCCESS",
+  latestDeployment: null,
+  ...overrides,
+});
+
+describe("canonicalPullRequestUrl", () => {
+  it("strips tab paths and query strings", () => {
+    assert.equal(
+      canonicalPullRequestUrl("https://github.com/acme/app/pull/12/files?w=1"),
+      "https://github.com/acme/app/pull/12",
+    );
+  });
+
+  it("rejects non-github and non-PR URLs", () => {
+    assert.equal(canonicalPullRequestUrl("https://gitlab.com/acme/app/pull/12"), null);
+    assert.equal(canonicalPullRequestUrl("https://github.com/acme/app/issues/12"), null);
+  });
+});
+
+describe("watchedUrlsForQuery", () => {
+  it("dedupes, canonicalises, and caps", () => {
+    const urls = [
+      "https://github.com/acme/app/pull/12/files",
+      "https://github.com/acme/app/pull/12",
+      "https://example.com/not-a-pr",
+      ...Array.from(
+        { length: MAX_WATCHED_PRS },
+        (_, i) => `https://github.com/acme/app/pull/${i + 1}`,
+      ),
+    ];
+    const watched = watchedUrlsForQuery(urls);
+    assert.equal(watched.length, MAX_WATCHED_PRS);
+    assert.equal(watched[0], "https://github.com/acme/app/pull/12");
+    assert.equal(new Set(watched).size, watched.length);
+  });
+});
+
+describe("buildSnoozedPrWatchQuery", () => {
+  it("is one query with a shared fragment and a rateLimit field", () => {
+    const query = buildSnoozedPrWatchQuery([
+      "https://github.com/acme/app/pull/12",
+      "https://github.com/acme/app/pull/13",
+    ]);
+    assert.match(query, /^query GtdSnoozedPrWatch \{/);
+    assert.equal([...query.matchAll(/^query /gm)].length, 1);
+    assert.match(query, /rateLimit \{ cost remaining resetAt limit \}/);
+    assert.match(query, /p0: resource\(url: "https:\/\/github\.com\/acme\/app\/pull\/12"\)/);
+    assert.match(query, /p1: resource\(url: "https:\/\/github\.com\/acme\/app\/pull\/13"\)/);
+    assert.match(query, /fragment PrWatchFields on PullRequest/);
+    assert.match(query, /statusCheckRollup \{ state \}/);
+    assert.match(query, /deployments\(last: 3\)/);
+  });
+});
+
+describe("parseSnoozedPrWatchResponse", () => {
+  it("reads aliased PRs and the rate limit", () => {
+    const parsed = parseSnoozedPrWatchResponse({
+      data: {
+        rateLimit: {
+          cost: 12,
+          remaining: 4800,
+          resetAt: "2026-08-26T12:00:00Z",
+          limit: 5000,
+        },
+        p0: {
+          id: "PR_kw1",
+          url: "https://github.com/acme/app/pull/12",
+          number: 12,
+          title: "Fix the flaky test",
+          updatedAt: "2026-08-26T10:00:00Z",
+          comments: { totalCount: 3 },
+          reviews: { totalCount: 1 },
+          reviewThreads: { totalCount: 2 },
+          latestReviews: {
+            nodes: [{ state: "CHANGES_REQUESTED", author: { login: "riley" } }],
+          },
+          commits: {
+            nodes: [
+              {
+                commit: {
+                  statusCheckRollup: { state: "FAILURE" },
+                  deployments: {
+                    nodes: [
+                      {
+                        createdAt: "2026-08-26T09:00:00Z",
+                        state: "PENDING",
+                        environment: "staging",
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+        },
+        p1: null,
+      },
+    });
+    assert.equal(parsed.rateLimit?.remaining, 4800);
+    assert.equal(parsed.snapshots.length, 1);
+    assert.deepEqual(parsed.snapshots[0], {
+      nodeId: "PR_kw1",
+      url: "https://github.com/acme/app/pull/12",
+      number: 12,
+      title: "Fix the flaky test",
+      updatedAt: "2026-08-26T10:00:00Z",
+      commentCount: 3,
+      reviewCount: 1,
+      reviewThreadCount: 2,
+      latestReviewState: "CHANGES_REQUESTED",
+      latestReviewAuthor: "riley",
+      checkRollup: "FAILURE",
+      latestDeployment: {
+        createdAt: "2026-08-26T09:00:00Z",
+        state: "PENDING",
+        environment: "staging",
+      },
+    });
+  });
+});
+
+describe("diffSnapshots", () => {
+  it("reports new comments, reviews, checks, and deployments", () => {
+    const previous = snapshot();
+    const next = snapshot({
+      updatedAt: "2026-08-26T11:00:00Z",
+      commentCount: 3,
+      reviewCount: 1,
+      latestReviewState: "APPROVED",
+      latestReviewAuthor: "riley",
+      checkRollup: "FAILURE",
+      latestDeployment: {
+        createdAt: "2026-08-26T10:30:00Z",
+        state: "ACTIVE",
+        environment: "production",
+      },
+    });
+    const kinds = diffSnapshots(previous, next).map((change) => change.kind);
+    assert.deepEqual(kinds, ["comments", "reviews", "checks", "deployments"]);
+  });
+
+  it("does not wake on an identical fingerprint", () => {
+    const row = snapshot();
+    assert.deepEqual(diffSnapshots(row, { ...row }), []);
+    assert.equal(fingerprintOf(row), fingerprintOf({ ...row }));
+  });
+
+  it("round-trips a stored snapshot", () => {
+    const row = snapshot({
+      latestReviewState: "APPROVED",
+      latestReviewAuthor: "riley",
+      latestDeployment: {
+        createdAt: "2026-08-26T09:00:00Z",
+        state: "ACTIVE",
+        environment: "production",
+      },
+    });
+    assert.deepEqual(parseStoredSnapshot(serializeSnapshot(row)), row);
+    assert.equal(parseStoredSnapshot("not json"), null);
+  });
+
+  it("falls back to a generic update when only updatedAt moved", () => {
+    const changes = diffSnapshots(snapshot(), snapshot({ updatedAt: "2026-08-26T11:00:00Z" }));
+    assert.deepEqual(changes, [{ kind: "updated", text: "PR updated on GitHub" }]);
+  });
+});
+
+describe("formatAgentWakeMessage", () => {
+  it("names the PR and lists the changes", () => {
+    const message = formatAgentWakeMessage(snapshot(), [
+      { kind: "comments", text: "2 new comments" },
+      { kind: "checks", text: "checks SUCCESS → FAILURE" },
+    ]);
+    assert.match(message, /#12/);
+    assert.match(message, /Fix the flaky test/);
+    assert.match(message, /2 new comments/);
+    assert.match(message, /checks SUCCESS → FAILURE/);
+    assert.match(message, /inspect the pull request/);
+  });
+});
+
+describe("shouldSkipForRateLimit", () => {
+  it("skips while remaining is below the floor or a reset is in the future", () => {
+    assert.equal(shouldSkipForRateLimit(null, null, 1_000), false);
+    assert.equal(shouldSkipForRateLimit(MIN_RATE_LIMIT_REMAINING, null, 1_000), false);
+    assert.equal(shouldSkipForRateLimit(MIN_RATE_LIMIT_REMAINING - 1, null, 1_000), true);
+    assert.equal(shouldSkipForRateLimit(5_000, 2_000, 1_000), true);
+    assert.equal(shouldSkipForRateLimit(5_000, 2_000, 2_000), false);
+  });
+
+  it("waits until GitHub's resetAt, not a guessed hour", () => {
+    const now = Date.parse("2026-08-26T10:00:00Z");
+    const resetAt = "2026-08-26T10:45:00Z";
+    assert.equal(skipUntilMsFromResetAt(resetAt, now), Date.parse(resetAt));
+  });
+});
+
+describe("isGraphqlRateLimited", () => {
+  it("recognises primary and secondary limit wording", () => {
+    assert.equal(isGraphqlRateLimited({ errors: [{ type: "RATE_LIMITED" }] }, ""), true);
+    assert.equal(isGraphqlRateLimited(null, "You have exceeded a secondary rate limit"), true);
+    assert.equal(isGraphqlRateLimited({ data: {} }, ""), false);
+  });
+});


### PR DESCRIPTION
Draft — opening for direction on scope before polishing.

Thread cards in the GTD sidebar currently say nothing about the pull request a
branch belongs to. This adds that: the PR number on the card, coloured by what
the PR actually needs from you.

## What's here

**PR index (REST, not GraphQL).** bb's own hook spends GraphQL points per
environment on mount, and reloading the plugin stampedes it until every badge
goes blank. This takes the separate REST budget instead: one open-PR list per
repository per tick, a numbered GET when the list misses (merged PRs drop off
it), then title-text and a local cache when REST is too tight to spend.

**Live colour via webhooks.** A Cloudflare `trycloudflare` tunnel receives
`pull_request`, `check_run`, `check_suite`, `status` and review events and
repaints the affected card without waiting for the ten-minute reconcile. The
tunnel is opt-in, its status is surfaced in settings, and hooks are registered
per repository on demand. It needs `cloudflared` on PATH and falls back to the
polling path when it is absent.

**Snooze that wakes on the PR.** Snoozing a thread against its PR polls hourly
and wakes the thread when the PR moves, so "come back when CI is green" becomes
expressible.

**In-app browser.** PR links open in a bb tab rather than bouncing out to the
system browser.

**The bug behind the last commit.** `/repos/:owner/:repo/pulls` does not return
`mergeable_state` — GitHub computes it lazily and serves it only from the
numbered GET. Every PR matched off the open list therefore parsed as
`"unknown"`, collapsed to attention `"none"`, and fell through to the open-PR
green, so conflicts, failing checks and branch protection were all invisible.
Listed open PRs whose state the list cannot decide now buy it with a numbered
GET, deduped per PR and bounded by the existing per-tick cap; draft,
auto-merge, merged and closed stay decidable from the list and spend nothing.
The webhook path had the same hole — `pull_request_review` and `issue_comment`
embed a shortened pull with no `mergeable_state` — so it refetches too.
Conflicts additionally gain a strikethrough, separating the one red that needs
a local rebase from the reds that need a re-run or a review.

## Commits

    9ad0f10  feat: GitHub PR badges, snooze watch, in-app browser
    9e6fa6a  feat: GitHub webhooks via Cloudflare trycloudflare
    7498bcd  fix: address webhook PR review comments
    34733b0  fix: read merge state the PR list omits

Eight changesets, all `@smsunarto/bb-plugin-gtd-sidebar`: six patch, two minor.

## Verification

Typecheck and the plugin's 217 tests pass. I also rebased this onto current
`main` (`b5fe05b`) in a scratch worktree: all four commits cherry-pick with no
conflicts, `bun install --frozen-lockfile` is clean, and typecheck passes there
too — including against the SDK 0.4.21 pin, which is newer than the 0.4.8 this
was written against.

Two things not run locally:

- **`bb plugin build`.** `config.bbVersion` on main is 0.40.0 and I have 0.39.0
  installed; the build scripts hard-fail on a pin mismatch. CI installs the
  pinned `bb-app` and will cover it.
- **This branch is based on `d86a264`**, the merge-base, rather than current
  main — deliberately, so the diff is these four commits and nothing else. My
  token has no `workflow` scope, so I cannot push a branch carrying main's newer
  `.github/workflows` changes to my fork. Happy to rebase onto current main if
  you would prefer; it applies cleanly, as above.

## Open question

Is this the right scope for one PR? It is ~5,400 lines across four commits. The
PR index and the webhook transport could reasonably be separate reviews, though
`server.ts` interleaves them and splitting after the fact is the expensive
direction. Glad to carve it up if you would rather review it in pieces.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GitHub PR status badges, webhook integration, and snooze watch to gtd-sidebar thread cards
> - Adds per-thread PR badges on thread cards showing state (open, merged, draft, queued, conflicts) with color-coded styling from [pr-status.ts](https://github.com/smsunarto/bb-plugins/pull/89/files#diff-14a11bb3c24bbc8794623085bc769d1b81c8cc058121b39c91a47a0a2c8457d4) and batched resolution via `listThreadPullRequests` RPC with caching in [server.ts](https://github.com/smsunarto/bb-plugins/pull/89/files#diff-4a70c6a434a54eb0db5c48ef88c688a6b96c9be7cbeaabe3793d0532651f184a)
> - Introduces signed GitHub webhook delivery over a managed Cloudflare trycloudflare tunnel in [github-webhook-tunnel.ts](https://github.com/smsunarto/bb-plugins/pull/89/files#diff-168e1930b0a0845bdf67e8affdc174bc02140798a6c46b2eb2ac2bee760ebddd), verifying HMAC signatures, updating cached PR rows in realtime, and unsnoozing threads when watched PRs change
> - Adds an hourly GraphQL-based watch in [pr-watch-run.ts](https://github.com/smsunarto/bb-plugins/pull/89/files#diff-1e6e47b69fffec8b792022b2b63b96a85f67c86d13ec5207d68a3a08c360648b) that baselines and diffs snoozed PR snapshots (comments, reviews, checks, deployments), waking threads on changes with rate-limit backoff
> - Opens PR links in the in-app thread browser panel via [open-in-app-browser.ts](https://github.com/smsunarto/bb-plugins/pull/89/files#diff-82997bea5fdfcf31d81720b38e1e83abc8ff36527f0b0f73fb5112511bee8de6), with modifier-key override to defer to the system browser
> - Snoozing a thread now seeds a `snoozed_pr_watch` row so both webhooks and the hourly poller can wake it on PR activity; new settings expose Cloudflare tunnel enablement, public URL override, and PR debug labels
> - Behavioral Change: snooze RPC and `onSnooze` callback now carry an optional `pullRequestUrl`; `ThreadCard` no longer uses `experimental_useSidebarThreadPullRequest` and instead receives PR data as props from `useThreadPullRequests`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d583a08.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->