### PR TITLE
test(amp): migrate mocks to Bun helpers

### DIFF
--- a/plugins/amp/package.json
+++ b/plugins/amp/package.json
@@ -77,7 +77,7 @@
   "scripts": {
     "dev": "bun ../../scripts/dev-plugin.ts",
     "typecheck": "tsc --noEmit",
-    "test": "node --test --experimental-strip-types test/*.test.ts",
+    "test": "bun test --timeout=30000 test/*.test.ts",
     "build:bridge": "esbuild src/amp-cli-shim.ts --bundle --platform=node --format=esm --target=node20 --outdir=dist --entry-names=[name] --banner:js=\"import { createRequire as __bbCreateRequire } from 'node:module'; const require = __bbCreateRequire(import.meta.url);\"",
     "build": "bun run build:bridge && bb plugin build .",
     "clean": "rm -rf dist"

--- a/plugins/amp/test/amp-cli-shim.test.ts
+++ b/plugins/amp/test/amp-cli-shim.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import test from "node:test";
+import { test } from "bun:test";
 import { fileURLToPath } from "node:url";
 import { createUserMessage, execute } from "@ampcode/sdk";
 import {

--- a/plugins/amp/test/bridge-conformance.test.ts
+++ b/plugins/amp/test/bridge-conformance.test.ts
@@ -1,7 +1,5 @@
-// Must be first: bb SDK modules expect a CJS-style global require.
-import "./helpers/global-require.ts";
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "bun:test";
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -74,31 +72,7 @@ test("the amp bridge passes the SDK conformance suite", async () => {
   // The Amp SDK resolves its CLI from process.env, not from execute options.
   const previousCliPath = process.env.AMP_CLI_PATH;
   process.env.AMP_CLI_PATH = fakeCli;
-  // Under `node --test`, this child process streams binary v8-serialized
-  // reporter events through the same stdout the kit captures. Layer a filter
-  // over the kit's patch: JSON lines (the bridge's wire) go to the kit,
-  // everything else passes through to the real stdout untouched.
-  const realWrite = process.stdout.write;
   const output = captureBridgeJsonRpcOutput();
-  const kitWrite = process.stdout.write;
-  const filteredWrite = (chunk: unknown, ...rest: unknown[]): boolean => {
-    const text =
-      typeof chunk === "string" ? chunk : Buffer.from(chunk as Uint8Array).toString("utf8");
-    const lines = text.split("\n").filter((line) => line.trim().length > 0);
-    const allJson =
-      lines.length > 0 &&
-      lines.every((line) => {
-        try {
-          JSON.parse(line);
-          return true;
-        } catch {
-          return false;
-        }
-      });
-    const write = allJson ? kitWrite : realWrite;
-    return Reflect.apply(write, process.stdout, [chunk, ...rest]) as boolean;
-  };
-  process.stdout.write = filteredWrite as typeof process.stdout.write;
   try {
     experimental_providerBridge.start?.({ pluginId: "amp", dataDir, tempDir });
     const report = await runBridgeConformance({
@@ -117,7 +91,6 @@ test("the amp bridge passes the SDK conformance suite", async () => {
     }
     assert.equal(report.passed, true, formatConformanceReport(report));
   } finally {
-    if (process.stdout.write === filteredWrite) process.stdout.write = kitWrite;
     output.restore();
     if (previousCliPath === undefined) delete process.env.AMP_CLI_PATH;
     else process.env.AMP_CLI_PATH = previousCliPath;

--- a/plugins/amp/test/bridge-conversation.test.ts
+++ b/plugins/amp/test/bridge-conversation.test.ts
@@ -6,7 +6,7 @@
  * bag, and the Orb variant.
  */
 import assert from "node:assert/strict";
-import test from "node:test";
+import { mock, test } from "bun:test";
 import { setImmediate as tick } from "node:timers/promises";
 import { AMP_CLI_SHIM_FAST_ENV } from "../src/amp-cli-shim.ts";
 import {
@@ -32,23 +32,12 @@ function shape(overrides: Partial<SessionShape> = {}): SessionShape {
   };
 }
 
-interface ExecuteCall {
-  prompt: unknown;
-  options: Record<string, unknown>;
-}
-
-type ExecuteArgs = Parameters<AmpExecuteFn>[0];
-
-/** Fake execute() recording each call and delegating it to the next script. */
-function fakeExecute(scripts: ReadonlyArray<(args: ExecuteArgs) => AsyncIterable<unknown>>) {
-  const calls: ExecuteCall[] = [];
-  const execute: AmpExecuteFn = (args) => {
-    calls.push({ prompt: args.prompt, options: (args.options ?? {}) as Record<string, unknown> });
-    const script = scripts[calls.length - 1];
-    if (script === undefined) throw new Error(`unexpected execute() call #${calls.length}`);
-    return script(args);
-  };
-  return { calls, execute };
+function mockExecute(scripts: ReadonlyArray<AmpExecuteFn>) {
+  const execute = mock<AmpExecuteFn>(() => {
+    throw new Error(`unexpected execute() call #${execute.mock.calls.length}`);
+  });
+  for (const script of scripts) execute.mockImplementationOnce(script);
+  return execute;
 }
 
 function depsFor(execute: AmpExecuteFn, overrides: Record<string, unknown> = {}) {
@@ -127,7 +116,7 @@ test("MultiTurnPrompt delivers at handoff once committed", async () => {
 });
 
 test("createAmpConversation never spawns when closed unsent", async () => {
-  const { calls, execute } = fakeExecute([]);
+  const execute = mockExecute([]);
   const conversation = createAmpConversation({
     shape: shape(),
     continueFrom: null,
@@ -136,16 +125,16 @@ test("createAmpConversation never spawns when closed unsent", async () => {
     deps: depsFor(execute),
   });
   await tick();
-  assert.equal(calls.length, 0);
+  assert.equal(execute.mock.calls.length, 0);
   conversation.closeInput();
   assert.deepEqual(await drain(conversation.batches()), []);
-  assert.equal(calls.length, 0);
+  assert.equal(execute.mock.calls.length, 0);
   assert.equal(conversation.closed, true);
   assert.equal(conversation.aborted, false);
 });
 
 test("createAmpConversation builds the spawn bag from the shape", async () => {
-  const { calls, execute } = fakeExecute([
+  const execute = mockExecute([
     async function* ({ prompt }) {
       for await (const _message of prompt as AsyncIterable<unknown>) {
         yield { type: "system" };
@@ -163,10 +152,10 @@ test("createAmpConversation builds the spawn bag from the shape", async () => {
   const sent = conversation.send("hi");
   const received = await drain(conversation.batches());
   await sent;
-  assert.equal(calls.length, 1);
+  assert.equal(execute.mock.calls.length, 1);
   assert.equal(received.length, 1);
   assert.equal(conversation.committed, true);
-  const options = calls[0]?.options ?? {};
+  const options = execute.mock.calls[0]?.[0].options ?? {};
   assert.equal(options.cwd, "/work/repo");
   assert.equal(options.mode, "medium");
   assert.equal(options.thinking, true);
@@ -183,7 +172,7 @@ test("createAmpConversation builds the spawn bag from the shape", async () => {
 });
 
 test("createAmpConversation continues a thread without the fast marker", async () => {
-  const { calls, execute } = fakeExecute([
+  const execute = mockExecute([
     async function* ({ prompt }) {
       for await (const _message of prompt as AsyncIterable<unknown>) {
         yield { type: "system" };
@@ -201,7 +190,7 @@ test("createAmpConversation continues a thread without the fast marker", async (
   const sent = conversation.send("hi");
   await drain(conversation.batches());
   await sent;
-  const options = calls[0]?.options ?? {};
+  const options = execute.mock.calls[0]?.[0].options ?? {};
   assert.equal(options.continue, "T-1");
   assert.equal("labels" in options, false);
   assert.equal("mcpConfig" in options, false);
@@ -213,7 +202,7 @@ test("createAmpConversation continues a thread without the fast marker", async (
 test("createAmpConversation drops an unsupported option and replays the prompt", async () => {
   let firstSeen: unknown;
   let secondSeen: unknown;
-  const { calls, execute } = fakeExecute([
+  const execute = mockExecute([
     async function* ({ prompt }) {
       const iterator = (prompt as AsyncIterable<unknown>)[Symbol.asyncIterator]();
       firstSeen = (await iterator.next()).value;
@@ -238,10 +227,10 @@ test("createAmpConversation drops an unsupported option and replays the prompt",
   const sent = conversation.send("hi");
   const received = await drain(conversation.batches());
   await sent;
-  assert.equal(calls.length, 2);
+  assert.equal(execute.mock.calls.length, 2);
   assert.equal(received.length, 1);
-  assert.equal(calls[0]?.options.dangerouslyAllowAll, true);
-  assert.equal(calls[1]?.options.dangerouslyAllowAll, undefined);
+  assert.equal(execute.mock.calls[0]?.[0].options?.dangerouslyAllowAll, true);
+  assert.equal(execute.mock.calls[1]?.[0].options?.dangerouslyAllowAll, undefined);
   assert.equal(retry.droppedOptions.has("dangerouslyAllowAll"), true);
   assert.equal(retry.attemptedFlags.has("settings-file"), true);
   assert.notEqual(firstSeen, undefined);
@@ -249,7 +238,7 @@ test("createAmpConversation drops an unsupported option and replays the prompt",
 });
 
 test("runOrb builds the Orb bag and ignores Local-only shape controls", async () => {
-  const { calls, execute } = fakeExecute([
+  const execute = mockExecute([
     async function* () {
       yield { type: "system" };
     },
@@ -263,10 +252,10 @@ test("runOrb builds the Orb bag and ignores Local-only shape controls", async ()
     deps: depsFor(execute),
   });
   const received = await drain(run.batches());
-  assert.equal(calls.length, 1);
+  assert.equal(execute.mock.calls.length, 1);
   assert.equal(received.length, 1);
-  assert.equal(calls[0]?.prompt, "go");
-  const options = calls[0]?.options ?? {};
+  assert.equal(execute.mock.calls[0]?.[0].prompt, "go");
+  const options = execute.mock.calls[0]?.[0].options ?? {};
   assert.equal(options.executor, "orb");
   assert.equal(options.project, "acme/site");
   assert.equal(options.continue, undefined);
@@ -277,7 +266,7 @@ test("runOrb builds the Orb bag and ignores Local-only shape controls", async ()
 });
 
 test("runOrb continues a thread and drops the project selector", async () => {
-  const { calls, execute } = fakeExecute([
+  const execute = mockExecute([
     async function* () {
       yield { type: "system" };
     },
@@ -291,14 +280,14 @@ test("runOrb continues a thread and drops the project selector", async () => {
     deps: depsFor(execute),
   });
   await drain(run.batches());
-  const options = calls[0]?.options ?? {};
+  const options = execute.mock.calls[0]?.[0].options ?? {};
   assert.equal(options.continue, "T-9");
   assert.equal("project" in options, false);
 });
 
 test("runOrb fails closed on an unknown '--orb-execute' flag", async () => {
   const retry = createRetryState();
-  const { calls, execute } = fakeExecute([
+  const execute = mockExecute([
     // eslint-disable-next-line require-yield
     async function* () {
       throw new Error("error: unknown option '--orb-execute'");
@@ -313,7 +302,7 @@ test("runOrb fails closed on an unknown '--orb-execute' flag", async () => {
     deps: depsFor(execute, { retry }),
   });
   await assert.rejects(drain(run.batches()), /--orb-execute/);
-  assert.equal(calls.length, 1);
+  assert.equal(execute.mock.calls.length, 1);
   assert.equal(retry.droppedOptions.size, 0);
 });
 

--- a/plugins/amp/test/bridge-options.test.ts
+++ b/plugins/amp/test/bridge-options.test.ts
@@ -4,7 +4,7 @@
  * `BridgeExecutionOptions` schema, not the architect sketch's vocabulary.
  */
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "bun:test";
 import {
   readProviderOptions,
   toAmpPermissions,

--- a/plugins/amp/test/bridge-parity.test.ts
+++ b/plugins/amp/test/bridge-parity.test.ts
@@ -5,10 +5,8 @@
 //
 // Four of the SDK's eight conformance cells are recorded; the other four do
 // not exist for this provider (see parity-fixture.ts).
-// Must be first: bb SDK modules expect a CJS-style global require.
-import "./helpers/global-require.ts";
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "bun:test";
 import { chmodSync, existsSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -32,14 +30,9 @@ import {
 const PLUGIN_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const HOST_MODULE = join(PLUGIN_ROOT, "dist", "host.js");
 const RECORDINGS_ROOT = join(PLUGIN_ROOT, "test", "recordings");
+const parityTest = existsSync(HOST_MODULE) ? test : test.skip;
 
-test("the built bridge replays the recorded parity cells", async (t) => {
-  if (!existsSync(HOST_MODULE)) {
-    // Same self-skip the retired stdio test used: recordings replay the
-    // built artifact, and an unbuilt checkout has nothing to replay.
-    t.skip(`dist/host.js is unbuilt — run \`bun run build\`, then rerun for parity coverage`);
-    return;
-  }
+parityTest("the built bridge replays the recorded parity cells", async () => {
   // The recordings reference fixed paths (the fake CLI, the workspace cwd);
   // recreate them so the replayed bridge can spawn its provider for real.
   prepareParityRoot();

--- a/plugins/amp/test/bridge-stream.test.ts
+++ b/plugins/amp/test/bridge-stream.test.ts
@@ -2,9 +2,8 @@
 // @get-bb/plugin-sdk/provider-bridge/testing. The bridge's captured JSON-RPC
 // output is run through the exact translation the runtime performs, and the
 // assertions are on canonical ThreadEvents.
-import "./helpers/global-require.ts";
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { describe, it, mock } from "bun:test";
 import { experimental_createBridgeDeltaEventCollector } from "@get-bb/plugin-sdk/provider-bridge/testing";
 import type { AmpEvent, AmpUsage } from "../src/bridge/events.ts";
 import {
@@ -41,22 +40,20 @@ function makeHarness() {
 }
 
 function makeOracle() {
-  const calls: string[] = [];
   const writes = new Map<string, string[]>();
   let nextReport = 0;
+  const begin = mock<OracleReports["begin"]>((_question) => {
+    nextReport += 1;
+    const reportId = `report-${nextReport}`;
+    writes.set(reportId, []);
+    return { reportId, write: (text) => void writes.get(reportId)?.push(text) };
+  });
+  const finish = mock<OracleReports["finish"]>(() => {});
   const oracle: OracleReports = {
-    begin(question) {
-      nextReport += 1;
-      const reportId = `report-${nextReport}`;
-      calls.push(`begin:${question}`);
-      writes.set(reportId, []);
-      return { reportId, write: (text) => void writes.get(reportId)?.push(text) };
-    },
-    finish(reportId, status) {
-      calls.push(`finish:${reportId}:${status}`);
-    },
+    begin,
+    finish,
   };
-  return { oracle, calls, writes };
+  return { oracle, begin, finish, writes };
 }
 
 function makeContext(
@@ -100,7 +97,7 @@ describe("bridge stream (U2)", () => {
     });
 
     const scribe = writer.scribe();
-    const { oracle, calls, writes } = makeOracle();
+    const { oracle, begin, finish, writes } = makeOracle();
     const ctx = makeContext(writer, scribe, oracle);
     scribe.accept("creq_abcdefgh23");
     const ampEvents: AmpEvent[] = [
@@ -204,7 +201,12 @@ describe("bridge stream (U2)", () => {
       reportId: "report-1",
       question: "Why is the sky blue?",
     });
-    assert.deepEqual(calls, ["begin:Why is the sky blue?", "finish:report-1:completed"]);
+    assert.deepEqual(begin.mock.calls, [["Why is the sky blue?"]]);
+    assert.deepEqual(finish.mock.calls, [["report-1", "completed"]]);
+    assert.ok(
+      (begin.mock.invocationCallOrder[0] ?? 0) < (finish.mock.invocationCallOrder[0] ?? 0),
+      "oracle begins before it finishes",
+    );
     assert.deepEqual(writes.get("report-1"), ["Rayleigh scattering."]);
 
     const [message] = byType("agentMessage") as any[];
@@ -237,7 +239,7 @@ describe("bridge stream (U2)", () => {
   it("drains still-open items as interrupted and fails the oracle report", () => {
     const { messages, writer } = makeHarness();
     const scribe = writer.scribe();
-    const { oracle, calls } = makeOracle();
+    const { oracle, finish } = makeOracle();
     const ctx = makeContext(writer, scribe, oracle);
     projectAmpEvent(
       {
@@ -266,7 +268,10 @@ describe("bridge stream (U2)", () => {
     const last: any = events[events.length - 1];
     assert.equal(last.type, "turn/completed");
     assert.equal(last.status, "interrupted");
-    assert.ok(calls.includes("finish:report-1:error"), "oracle report finished as error");
+    assert.ok(
+      finish.mock.calls.some(([reportId, status]) => reportId === "report-1" && status === "error"),
+      "oracle report finished as error",
+    );
   });
 
   it("resultError settles the turn as failed through provider.error", () => {

--- a/plugins/amp/test/bridge-tool-proxy.test.ts
+++ b/plugins/amp/test/bridge-tool-proxy.test.ts
@@ -1,9 +1,8 @@
 // U4 gate, round-trip half: `startToolProxy` binds a real loopback socket and
 // the test acts as the MCP child, driving `handleMcpRequest` from the exact
 // env block Amp would hand the spawned server.
-import "./helpers/global-require.ts";
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { describe, it, mock } from "bun:test";
 import {
   AMP_BRIDGE_MCP_SERVER_NAME,
   handleMcpRequest,
@@ -105,133 +104,123 @@ describe("bridge tool proxy (U4)", () => {
   });
 
   it("round trips initialize, tools/list, and a tools/call to the bridge", async () => {
-    const calls: ProxiedToolCall[] = [];
-    await withProxy(
-      proxyArgs({
-        callTool: (call) => {
-          calls.push(call);
-          return Promise.resolve({ content: "hello from bb", isError: false });
-        },
-      }),
-      async (proxy) => {
-        const env = childEnvFor(proxy);
-        const { writes, write } = makeChildWriter();
-
-        await handleMcpRequest(
-          env,
-          { id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } },
-          write,
-        );
-        assert.deepEqual(writes[0]?.result?.serverInfo, {
-          name: AMP_BRIDGE_MCP_SERVER_NAME,
-          version: "1.0.0",
-        });
-        assert.equal(writes[0]?.result?.protocolVersion, "2025-06-18");
-
-        await handleMcpRequest(env, { id: 2, method: "tools/list" }, write);
-        const listed = writes[1]?.result?.tools;
-        assert.ok(Array.isArray(listed));
-        assert.deepEqual(
-          listed.map((tool: { name: string }) => tool.name),
-          ["my_tool", "ask_user"],
-        );
-
-        await handleMcpRequest(
-          env,
-          { id: 3, method: "tools/call", params: { name: "my_tool", arguments: { city: "Oslo" } } },
-          write,
-        );
-        assert.equal(calls.length, 1);
-        assert.equal(calls[0]?.tool, "my_tool");
-        assert.deepEqual(calls[0]?.arguments, { city: "Oslo" });
-        assert.match(calls[0]?.callId ?? "", /^amp-mcp-my_tool-/u);
-        assert.deepEqual(writes[2]?.result, {
-          content: [{ type: "text", text: "hello from bb" }],
-        });
-
-        await handleMcpRequest(
-          env,
-          { id: 4, method: "tools/call", params: { name: "nope" } },
-          write,
-        );
-        assert.equal(writes[3]?.error?.code, -32602);
-
-        await handleMcpRequest(env, { id: 5, method: "prompts/list" }, write);
-        assert.equal(writes[4]?.error?.code, -32601);
-      },
+    const callTool = mock((_call: ProxiedToolCall) =>
+      Promise.resolve({ content: "hello from bb", isError: false }),
     );
+    await withProxy(proxyArgs({ callTool }), async (proxy) => {
+      const env = childEnvFor(proxy);
+      const child = makeChildWriter();
+
+      await handleMcpRequest(
+        env,
+        { id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } },
+        child.write,
+      );
+      assert.deepEqual(child.writes[0]?.result?.serverInfo, {
+        name: AMP_BRIDGE_MCP_SERVER_NAME,
+        version: "1.0.0",
+      });
+      assert.equal(child.writes[0]?.result?.protocolVersion, "2025-06-18");
+
+      await handleMcpRequest(env, { id: 2, method: "tools/list" }, child.write);
+      const listed = child.writes[1]?.result?.tools;
+      assert.ok(Array.isArray(listed));
+      assert.deepEqual(
+        listed.map((tool: { name: string }) => tool.name),
+        ["my_tool", "ask_user"],
+      );
+
+      await handleMcpRequest(
+        env,
+        { id: 3, method: "tools/call", params: { name: "my_tool", arguments: { city: "Oslo" } } },
+        child.write,
+      );
+      assert.equal(callTool.mock.calls.length, 1);
+      const call = callTool.mock.calls[0]?.[0];
+      assert.equal(call?.tool, "my_tool");
+      assert.deepEqual(call?.arguments, { city: "Oslo" });
+      assert.match(call?.callId ?? "", /^amp-mcp-my_tool-/u);
+      assert.deepEqual(child.writes[2]?.result, {
+        content: [{ type: "text", text: "hello from bb" }],
+      });
+
+      await handleMcpRequest(
+        env,
+        { id: 4, method: "tools/call", params: { name: "nope" } },
+        child.write,
+      );
+      assert.equal(child.writes[3]?.error?.code, -32602);
+
+      await handleMcpRequest(env, { id: 5, method: "prompts/list" }, child.write);
+      assert.equal(child.writes[4]?.error?.code, -32601);
+    });
   });
 
   it("rejects a tampered token as an error result", () =>
     withProxy(proxyArgs(), async (proxy) => {
       const env: McpChildEnvironment = { ...childEnvFor(proxy), token: "deadbeef" };
-      const { writes, write } = makeChildWriter();
+      const child = makeChildWriter();
       await handleMcpRequest(
         env,
         { id: 1, method: "tools/call", params: { name: "my_tool", arguments: {} } },
-        write,
+        child.write,
       );
-      assert.equal(writes[0]?.result?.isError, true);
-      assert.deepEqual(writes[0]?.result?.content, [
+      assert.equal(child.writes[0]?.result?.isError, true);
+      assert.deepEqual(child.writes[0]?.result?.content, [
         { type: "text", text: "Invalid dynamic tool request" },
       ]);
     }));
 
   it("turns callTool failures and junk results into isError results", async () => {
-    let junk = false;
-    await withProxy(
-      proxyArgs({
-        callTool: () => (junk ? Promise.resolve(42) : Promise.reject(new Error("boom"))),
-      }),
-      async (proxy) => {
-        const env = childEnvFor(proxy);
-        const { writes, write } = makeChildWriter();
+    const callTool = mock<StartToolProxyArgs["callTool"]>();
+    callTool.mockRejectedValueOnce(new Error("boom"));
+    callTool.mockResolvedValueOnce(42 as never);
+    await withProxy(proxyArgs({ callTool }), async (proxy) => {
+      const env = childEnvFor(proxy);
+      const child = makeChildWriter();
 
-        await handleMcpRequest(
-          env,
-          { id: 1, method: "tools/call", params: { name: "my_tool", arguments: {} } },
-          write,
-        );
-        assert.equal(writes[0]?.result?.isError, true);
-        assert.deepEqual(writes[0]?.result?.content, [{ type: "text", text: "boom" }]);
+      await handleMcpRequest(
+        env,
+        { id: 1, method: "tools/call", params: { name: "my_tool", arguments: {} } },
+        child.write,
+      );
+      assert.equal(child.writes[0]?.result?.isError, true);
+      assert.deepEqual(child.writes[0]?.result?.content, [{ type: "text", text: "boom" }]);
 
-        junk = true;
-        await handleMcpRequest(
-          env,
-          { id: 2, method: "tools/call", params: { name: "my_tool", arguments: {} } },
-          write,
-        );
-        assert.equal(writes[1]?.result?.isError, true);
-        assert.deepEqual(writes[1]?.result?.content, [
-          { type: "text", text: 'Tool "my_tool" returned an unrecognized result' },
-        ]);
-      },
-    );
+      await handleMcpRequest(
+        env,
+        { id: 2, method: "tools/call", params: { name: "my_tool", arguments: {} } },
+        child.write,
+      );
+      assert.equal(child.writes[1]?.result?.isError, true);
+      assert.deepEqual(child.writes[1]?.result?.content, [
+        { type: "text", text: 'Tool "my_tool" returned an unrecognized result' },
+      ]);
+    });
   });
 
   it("heartbeats notifications/progress while a call waits", async () => {
-    await withProxy(
-      proxyArgs({
-        callTool: () =>
-          new Promise((resolve) => setTimeout(() => resolve({ content: "done" }), 40)),
-      }),
-      async (proxy) => {
-        const env: McpChildEnvironment = { ...childEnvFor(proxy), progressIntervalMs: 5 };
-        const { writes, write } = makeChildWriter();
-        await handleMcpRequest(
-          env,
-          {
-            id: 1,
-            method: "tools/call",
-            params: { name: "my_tool", arguments: {}, _meta: { progressToken: "tok-1" } },
-          },
-          write,
-        );
-        const progress = writes.filter((message) => message.method === "notifications/progress");
-        assert.ok(progress.length >= 1, "expected at least one progress notification");
-        const last = writes.at(-1);
-        assert.deepEqual(last?.result?.content, [{ type: "text", text: "done" }]);
-      },
+    const callTool = mock<StartToolProxyArgs["callTool"]>(
+      () => new Promise((resolve) => setTimeout(() => resolve({ content: "done" }), 40)),
     );
+    await withProxy(proxyArgs({ callTool }), async (proxy) => {
+      const env: McpChildEnvironment = { ...childEnvFor(proxy), progressIntervalMs: 5 };
+      const child = makeChildWriter();
+      await handleMcpRequest(
+        env,
+        {
+          id: 1,
+          method: "tools/call",
+          params: { name: "my_tool", arguments: {}, _meta: { progressToken: "tok-1" } },
+        },
+        child.write,
+      );
+      const progress = child.writes.filter(
+        (message) => message.method === "notifications/progress",
+      );
+      assert.ok(progress.length >= 1, "expected at least one progress notification");
+      const last = child.writes.at(-1);
+      assert.deepEqual(last?.result?.content, [{ type: "text", text: "done" }]);
+    });
   });
 });

--- a/plugins/amp/test/cli-stub.test.ts
+++ b/plugins/amp/test/cli-stub.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createRequire } from "node:module";
-import test from "node:test";
+import { test } from "bun:test";
 
 // The bridge ships no bundled Amp CLI: the SDK must resolve the binary from
 // AMP_CLI_PATH, set by the managed provider entry. This matters more than it

--- a/plugins/amp/test/declaration.test.ts
+++ b/plugins/amp/test/declaration.test.ts
@@ -1,7 +1,5 @@
-// Must be first: bb SDK modules expect a CJS-style global require.
-import "./helpers/global-require.ts";
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "bun:test";
 import { validatePluginProviderDeclaration } from "@get-bb/plugin-sdk/internal/host-policy";
 import {
   buildAmpProviderDeclaration,

--- a/plugins/amp/test/events.test.ts
+++ b/plugins/amp/test/events.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { describe, it } from "bun:test";
 import {
   classifyAmpError,
   parseAmpBatch,

--- a/plugins/amp/test/oracle-report-store.test.ts
+++ b/plugins/amp/test/oracle-report-store.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import test from "node:test";
+import { test } from "bun:test";
 import {
   appendOracleTrace,
   completeOracleReport,

--- a/plugins/amp/test/orb-directive.test.ts
+++ b/plugins/amp/test/orb-directive.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "bun:test";
 import { findOrbDirectiveRanges, stripOrbDirectives } from "../src/orb-directive.ts";
 
 test("findOrbDirectiveRanges finds case-insensitive standalone tokens anywhere", () => {

--- a/plugins/amp/test/orb-usage.test.ts
+++ b/plugins/amp/test/orb-usage.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "bun:test";
 import { threadLinkToOrbUsageView } from "../src/orb-usage.ts";
 
 test("local execution hides the banner", () => {

--- a/plugins/amp/test/provision.test.ts
+++ b/plugins/amp/test/provision.test.ts
@@ -1,8 +1,15 @@
 import assert from "node:assert/strict";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import test from "node:test";
+import { test } from "bun:test";
 import {
   cleanupLegacyAmpEntry,
   inspectLegacyAmpEntry,
@@ -168,10 +175,10 @@ test("cleanup leaves an entry with customized fields the plugin never wrote", ()
   });
   const result = cleanupLegacyAmpEntry(f.paths);
   assert.equal(result.kind, "kept");
-  assert.deepEqual(
-    result.kind === "kept" ? result.deviations.toSorted() : [],
-    ["logo", "supportsManualCompaction"],
-  );
+  assert.deepEqual(result.kind === "kept" ? result.deviations.toSorted() : [], [
+    "logo",
+    "supportsManualCompaction",
+  ]);
 });
 
 test("deviation shape checks: args, env, displayName, skill roots", () => {

--- a/plugins/amp/test/public-sdk-scan.test.ts
+++ b/plugins/amp/test/public-sdk-scan.test.ts
@@ -1,7 +1,5 @@
-// Must be first: bb SDK modules expect a CJS-style global require.
-import "./helpers/global-require.ts";
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "bun:test";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { experimental_scanPublicSdkOnly as scanPublicSdkOnly } from "@get-bb/plugin-sdk/testing";
@@ -12,6 +10,7 @@ test("the plugin imports only the public SDK and its declared dependencies", () 
   const report = scanPublicSdkOnly(PLUGIN_ROOT, {
     allow: [
       /^@ampcode\/sdk$/,
+      /^bun:test$/,
       /^zod$/,
       /^react$/,
       // The scanner extends its allowlist for `*.test.*` files only; the

--- a/plugins/amp/test/session-store.test.ts
+++ b/plugins/amp/test/session-store.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import test from "node:test";
+import { test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";


### PR DESCRIPTION
Migrates the Amp test mocks onto Bun's own helpers.

Authored by another agent on `codex/migrate-bun-mocks`. It sits in this stack because #93 builds on it. I pushed the branch and opened this PR so the stack has a base; I did not write the change. Its commits were rebased when I repaired the lockfile below.

## Commits

- `test(amp)` migrate mocks to Bun helpers

## Stack

Review bottom-up. Each PR targets the one below it, not `main`.

1. #91 `fable/amp-native-bridge`
2. #92 `codex/migrate-bun-mocks`
3. #93 `fable/amp-own-spawn`
4. #94 `codex/bun-toolchain`
5. #95 `fable/orb-toggle-docs`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate `amp` test suite to Bun test runner and mocking APIs
> - Changes the test script in [package.json](https://github.com/smsunarto/bb-plugins/pull/92/files#diff-ef2cc9795a3513a261018bfdba72ca1c4e569a7f0d128bab2941b865168dee65) to use `bun test --timeout=30000` instead of `node --test`.
> - Updates all test files to import `test`, `describe`, `it`, and `mock` from `bun:test` instead of `node:test`.
> - Replaces custom call recording and stdout shims with Bun's `mock` helper, including new `mockExecute` and `makeOracle` utilities.
> - Behavioral Change: the `amp` package tests now require Bun to run and no longer execute under Node's test runner.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea04373.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->