### PR TITLE
docs(amp): point troubleshooting at the Orb toggle

### DIFF
--- a/plugins/amp/README.md
+++ b/plugins/amp/README.md
@@ -188,7 +188,7 @@ auth: handled by the Amp CLI — run `amp login` once, or export AMP_API_KEY in 
 | "Could not find a usable Amp CLI"  | The recorded `AMP_CLI_PATH` no longer exists. Reinstall Amp, then run `bb plugin reload amp`    |
 | Local tool calls rejected          | Use bb **Full** to force-allow all tools, or adjust Amp's own rules and use **Accept Edits**    |
 | Orb tool calls rejected            | Change the permission settings in the Amp project                                               |
-| Orb opens the wrong repository     | Export `AMP_ACP_ORB_PROJECT` in the environment bb runs in, then start a new Orb thread         |
+| Orb opens the wrong repository     | Orb infers the project from the thread's working directory. Start the thread in that repository |
 | Orb toggle was on, thread ran Local | The armed toggle expires after 10 minutes. Toggle Orb off, then on, then send the first prompt   |
 | `Unknown session <id>` on resume   | The session mapping was pruned or removed. Start a new thread                                   |
 

--- a/plugins/amp/README.md
+++ b/plugins/amp/README.md
@@ -189,7 +189,7 @@ auth: handled by the Amp CLI — run `amp login` once, or export AMP_API_KEY in 
 | Local tool calls rejected          | Use bb **Full** to force-allow all tools, or adjust Amp's own rules and use **Accept Edits**    |
 | Orb tool calls rejected            | Change the permission settings in the Amp project                                               |
 | Orb opens the wrong repository     | Export `AMP_ACP_ORB_PROJECT` in the environment bb runs in, then start a new Orb thread         |
-| Orb toggle was on, thread ran Local | The armed toggle expires after 10 minutes. Press Orb again, then send the first prompt          |
+| Orb toggle was on, thread ran Local | The armed toggle expires after 10 minutes. Toggle Orb off, then on, then send the first prompt   |
 | `Unknown session <id>` on resume   | The session mapping was pruned or removed. Start a new thread                                   |
 
 ## Develop from source

--- a/plugins/amp/README.md
+++ b/plugins/amp/README.md
@@ -188,8 +188,8 @@ auth: handled by the Amp CLI — run `amp login` once, or export AMP_API_KEY in 
 | "Could not find a usable Amp CLI"  | The recorded `AMP_CLI_PATH` no longer exists. Reinstall Amp, then run `bb plugin reload amp`    |
 | Local tool calls rejected          | Use bb **Full** to force-allow all tools, or adjust Amp's own rules and use **Accept Edits**    |
 | Orb tool calls rejected            | Change the permission settings in the Amp project                                               |
-| Orb opens the wrong repository     | Export `AMP_ACP_ORB_PROJECT` in the environment bb runs in, then start a new thread with `/orb` |
-| `/orb` is rejected in a thread     | That Amp thread is already Local. Start a new bb thread with `/orb` in its first prompt         |
+| Orb opens the wrong repository     | Export `AMP_ACP_ORB_PROJECT` in the environment bb runs in, then start a new Orb thread         |
+| Orb toggle was on, thread ran Local | The armed toggle expires after 10 minutes. Press Orb again, then send the first prompt          |
 | `Unknown session <id>` on resume   | The session mapping was pruned or removed. Start a new thread                                   |
 
 ## Develop from source


### PR DESCRIPTION
Updates the Amp README troubleshooting table to describe the Orb toggle instead of the removed `/orb` token.

Docs only. No code changes.

## Commits

- `docs(amp)` point troubleshooting at the Orb toggle

## Stack

Review bottom-up. Each PR targets the one below it, not `main`.

1. #91 `fable/amp-native-bridge`
2. #92 `codex/migrate-bun-mocks`
3. #93 `fable/amp-own-spawn`
4. #94 `codex/bun-toolchain`
5. #95 `fable/orb-toggle-docs`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update AMP troubleshooting table for Orb toggle behavior
> Updates two rows in [README.md](https://github.com/smsunarto/bb-plugins/pull/95/files#diff-d86019146d8981dce1171edfcc2862872815e434314dcb57fc3004ab0456866f). The "Orb opens the wrong repository" row now explains Orb infers the project from the thread's working directory. The rejected `/orb` entry is replaced with a note that the armed Orb toggle expires after 10 minutes, advising users to toggle Orb off and on before sending the first prompt.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f1eeee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->