### PR TITLE
fix(amp): ship the plugin SDK as a runtime dependency

### DIFF
--- a/.changeset/amp-sdk-runtime-dep.md
+++ b/.changeset/amp-sdk-runtime-dep.md
@@ -1,0 +1,5 @@
+---
+"@smsunarto/bb-plugin-amp": patch
+---
+
+Put `@get-bb/plugin-sdk` in `dependencies` so a git install can bundle the provider bridge. Managed installs run `npm install --omit=dev`; a devDependency-only pin left the host builder without the SDK subpath it inlines.

--- a/plugins/amp/package.json
+++ b/plugins/amp/package.json
@@ -63,10 +63,10 @@
     "src/"
   ],
   "dependencies": {
+    "@get-bb/plugin-sdk": "0.4.21",
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@get-bb/plugin-sdk": "0.4.21",
     "@pierre/diffs": "^1.2.9",
     "@radix-ui/react-alert-dialog": "^1.1.19",
     "@radix-ui/react-context-menu": "^2.3.3",

--- a/plugins/amp/test/public-sdk-scan.test.ts
+++ b/plugins/amp/test/public-sdk-scan.test.ts
@@ -1,10 +1,23 @@
 import assert from "node:assert/strict";
 import { test } from "bun:test";
+import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { experimental_scanPublicSdkOnly as scanPublicSdkOnly } from "@get-bb/plugin-sdk/testing";
 
 const PLUGIN_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+test("the SDK pin is a runtime dependency so git installs can bundle the provider bridge", () => {
+  const manifest = JSON.parse(readFileSync(join(PLUGIN_ROOT, "package.json"), "utf8")) as {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  };
+  // The host builder inlines `@get-bb/plugin-sdk/provider-bridge` from this
+  // package's own install. Managed git installs run `npm install --omit=dev`,
+  // so a devDependency-only pin is missing when the host artifact is built.
+  assert.equal(manifest.dependencies?.["@get-bb/plugin-sdk"], "0.4.21");
+  assert.equal(manifest.devDependencies?.["@get-bb/plugin-sdk"], undefined);
+});
 
 test("the plugin imports only the public SDK and its declared dependencies", () => {
   const report = scanPublicSdkOnly(PLUGIN_ROOT, {


### PR DESCRIPTION
bb 0.40.0 refuses the published Amp 0.4.0 tag (`engines.bb` is `>=0.38.0 <0.39.0`). Main already has the native `bb.providers.register` rewrite and `>=0.40.0 <1.0.0`, but a git marketplace install still cannot build the host artifact.

`bb plugin build` inlines `@get-bb/plugin-sdk/provider-bridge` from the plugin's own install. Managed git installs run `npm install --omit=dev`, so a `devDependencies`-only pin leaves that subpath missing. Echo-provider puts the same pin in `dependencies` for this reason.

This moves the exact `0.4.21` pin into `dependencies` and guards it with a scan test. After this lands, the pending Amp 0.4.2 release (engines + native bridge + this pin) is what `bb plugin update amp` can load on 0.40.

## Test plan
- [x] `bun run --filter '@smsunarto/bb-plugin-amp' typecheck`
- [x] `bun run --filter '@smsunarto/bb-plugin-amp' test` (144 pass, including the new pin guard and the recorded-bridge parity cells after build)
- [x] `bb plugin build .` in `plugins/amp` against bb 0.40.0 (emits `dist/host.js` + `host.meta.json` stamped `sdkVersion` 0.4.21 / `bbVersion` 0.40.0)
- [ ] After merge and the 0.4.2 tag: `bb plugin update amp` on a 0.40 host, pick Amp, start a local thread

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the `@get-bb/plugin-sdk` pin from `devDependencies` to `dependencies` so git marketplace installs can build the host artifact on bb 0.40. Managed installs run `npm install --omit=dev`, so a devDependency-only pin left the provider bridge missing during `bb plugin build`.

- Adds a scan test that asserts the SDK is a runtime dependency and absent from `devDependencies`.

<sup>Written for commit c8356dfcc42079483b83c5c0c32846598da31738. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/smsunarto/bb-plugins/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

