### PR TITLE
Add Cloudflare tunnel support for Agent Proxy Cursor BYOK

### DIFF
--- a/plugins/agent-proxy/README.md
+++ b/plugins/agent-proxy/README.md
@@ -28,11 +28,13 @@ the machine that runs the bb server and gives it a management UI inside bb.
 - **Outlives bb** — the core runs as a login service, `launchd` on macOS and `systemd` on Linux, so it keeps serving after bb closes.
 - **Green when it is up** — the sidebar row tints by core state: green running, amber starting or stopping, red crashed, dimmed when stopped.
 - **One-click wiring** — point Claude Code, Codex, or anything else at the proxy without clobbering a config you generate yourself.
+- **Opt-in Cursor endpoint.** Expose only the OpenAI-compatible `/v1` API through a Cloudflare Quick Tunnel for Cursor BYOK.
 - **Installed and signed in from the panel** — one button for the core, browser OAuth for Claude and Codex, and each credential's quota state.
 
 > **Stop is not permanent.** Stop disables the login job, but with `autostart` on
-> (the default) the next bb start or `bb plugin reload` brings the core back. Turn
-> `autostart` off for a stop that survives a reload.
+> (the default) the next bb start or `bb plugin reload` brings the core back. An
+> enabled Quick Tunnel also keeps the core running. Turn both settings off for a
+> stop that survives a reload.
 
 | Client            | What Apply does                                                                                                                                                                         |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -85,6 +87,7 @@ plugin fetches or builds on your machine, and OAuth sign-in opens a browser.
 - Outbound HTTPS to GitHub, to fetch the core.
 - At least one upstream account: a Claude or ChatGPT subscription for the OAuth flows, or an Anthropic / OpenAI / Gemini / OpenAI-compatible API key.
 - A free TCP port on loopback (8317 by default). A conflict shows up as a crash loop on the Home page.
+- `cloudflared` on `PATH` or in a common install location. You need it only for the optional Cursor Quick Tunnel.
 
 ## Endpoints
 
@@ -96,29 +99,51 @@ plugin fetches or builds on your machine, and OAuth sign-in opens a browser.
 
 The proxy listens on loopback of the bb server machine only.
 
+## Use the Cursor Quick Tunnel
+
+1. Install `cloudflared` on the bb server machine.
+2. Enable **Cloudflare Quick Tunnel for Cursor** in Agent Proxy settings.
+3. Open Agent Proxy Home and wait for **Public OpenAI base URL** to become ready.
+4. Set Cursor's OpenAI base URL to the public URL from the card.
+5. Set Cursor's OpenAI API key to the local API key from the same card.
+
+The public URL ends in `/v1`. The gateway rejects every other path before it
+reaches CLIProxyAPI. It also checks the local bearer key. CLIProxyAPI checks the
+key again.
+
+The helper runs as a login service and survives bb closing. Stop shuts down the
+helper before it stops CLIProxyAPI. A port change updates the helper config but
+keeps the current public hostname. A helper restart assigns a new hostname.
+
+Quick Tunnels are for development. Cloudflare Quick Tunnels do not support SSE,
+so Cursor requests that require SSE may fail. A temporary CLIProxyAPI outage
+returns HTTP 503 through the existing public URL. This release has not verified
+a live Cursor request.
+
 ## Commands
 
-| Command                                | What it does                                                                                |
-| -------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `bb agent-proxy status`                | State, pid, port, service manager, definition path, installed and latest version, endpoints |
-| `bb agent-proxy start`                 | Enable and start the login service                                                          |
-| `bb agent-proxy stop`                  | Stop _and_ disable the login service                                                        |
-| `bb agent-proxy restart`               | Rewrite the definition if it changed, then restart                                          |
-| `bb agent-proxy endpoints`             | Print the three base URLs and the local API key                                             |
-| `bb agent-proxy install [ref]`         | Install the configured source, or a one-off ref without changing the saved setting          |
-| `bb agent-proxy oauth <claude\|codex>` | Start a browser OAuth flow and poll for up to 3 minutes                                     |
-| `bb agent-proxy providers`             | Count configured entries per collection, then list auth files                               |
-| `bb agent-proxy usage`                 | Print the usage report as JSON                                                              |
+| Command                                | What it does                                                                       |
+| -------------------------------------- | ---------------------------------------------------------------------------------- |
+| `bb agent-proxy status`                | Core state, versions, local endpoints, tunnel state, and the ready public endpoint |
+| `bb agent-proxy start`                 | Enable and start the login service                                                 |
+| `bb agent-proxy stop`                  | Stop _and_ disable the login service                                               |
+| `bb agent-proxy restart`               | Rewrite the definition if it changed, then restart                                 |
+| `bb agent-proxy endpoints`             | Print local URLs, the local API key, tunnel state, and the ready public endpoint   |
+| `bb agent-proxy install [ref]`         | Install the configured source, or a one-off ref without changing the saved setting |
+| `bb agent-proxy oauth <claude\|codex>` | Start a browser OAuth flow and poll for up to 3 minutes                            |
+| `bb agent-proxy providers`             | Count configured entries per collection, then list auth files                      |
+| `bb agent-proxy usage`                 | Print the usage report as JSON                                                     |
 
 ## Settings
 
-| Key                | Default                     | Meaning                                                                             |
-| ------------------ | --------------------------- | ----------------------------------------------------------------------------------- |
-| `autostart`        | `true`                      | Keep the login service enabled, so the core starts at login and survives bb closing |
-| `port`             | `8317`                      | Listen port. Out-of-range or unparseable values fall back to 8317                   |
-| `sourceRepository` | `router-for-me/CLIProxyAPI` | Public GitHub source                                                                |
-| `sourceBranch`     | `latest`                    | `latest` resolves to the newest published release; or a branch, tag, or commit      |
-| `managementKey`    | _(generated)_               | Secret. Overrides the auto-generated management key                                 |
+| Key                              | Default                     | Meaning                                                                              |
+| -------------------------------- | --------------------------- | ------------------------------------------------------------------------------------ |
+| `autostart`                      | `true`                      | Keep the login service enabled, so the core starts at login and survives bb closing  |
+| `cloudflareQuickTunnelForCursor` | `false`                     | Expose the OpenAI-compatible `/v1` API through a development Quick Tunnel for Cursor |
+| `port`                           | `8317`                      | Listen port. Out-of-range or unparseable values fall back to 8317                    |
+| `sourceRepository`               | `router-for-me/CLIProxyAPI` | Public GitHub source                                                                 |
+| `sourceBranch`                   | `latest`                    | `latest` resolves to the newest published release; or a branch, tag, or commit       |
+| `managementKey`                  | _(generated)_               | Secret. Overrides the auto-generated management key                                  |
 
 Autostart applies immediately. The core reads the port and the management key only
 at startup, so a change to either stops the service, rewrites `config.yaml`, and
@@ -129,15 +154,18 @@ is applied on its next start.
 
 Everything lives under `<bb dataDir>/plugins/agent-proxy/`:
 
-| Path                    | Contents                                                                |
-| ----------------------- | ----------------------------------------------------------------------- |
-| `core/auth/`            | Your OAuth credentials                                                  |
-| `core/secrets/`         | Generated API keys                                                      |
-| `backups/`              | Timestamped copies of any file the plugin edits, taken before it writes |
-| `core/service/core.log` | The log behind the Home page's tail                                     |
+| Path                                 | Contents                                                                  |
+| ------------------------------------ | ------------------------------------------------------------------------- |
+| `core/auth/`                         | Your OAuth credentials                                                    |
+| `core/secrets/`                      | Generated API keys                                                        |
+| `backups/`                           | Timestamped copies of any file the plugin edits, taken before it writes   |
+| `core/service/core.log`              | The log behind the Home page's tail                                       |
+| `cloudflare-tunnel/desired.json`     | Plugin-owned helper config. It contains paths, not keys or the public URL |
+| `cloudflare-tunnel/observation.json` | Helper-owned state and the current public origin                          |
+| `cloudflare-tunnel/tunnel.log`       | Helper and `cloudflared` output                                           |
 
-Credentials and keys are written `0600` and never leave this directory — the
-service definition holds only paths and service settings.
+Credential and key files are written `0600`. Service definitions contain only
+paths and service settings.
 
 ## Troubleshooting
 
@@ -145,6 +173,11 @@ service definition holds only paths and service settings.
 - **"Unavailable — is the core running?"** on OAuth, Providers, or Usage — those pages talk to the core's management API, so the core must be up first.
 - **Removed the plugin, service still there** — the operating system owns the process by design. Run `bb agent-proxy stop` _before_ you remove the plugin, or delete the definition by hand.
 - **macOS Gatekeeper kills the binary** — it should not be quarantined, but if it happens: `xattr -d com.apple.quarantine <core/bin/current/cli-proxy-api>`.
+- **Tunnel says `cloudflared` is missing.** Install `cloudflared`, then disable and re-enable the setting.
+- **Tunnel says the host runtime cannot run the helper.** Update or reinstall bb, then disable and re-enable the setting.
+- **Tunnel stays on starting.** Read `cloudflare-tunnel/tunnel.log`. Cloudflare must be reachable from the bb server machine.
+- **The public endpoint returns 401.** Use the local API key shown on Home as a bearer token.
+- **The public endpoint returns 503.** Start the CLIProxyAPI core or resolve its port conflict. The helper keeps the public hostname while the core recovers.
 
 ## Develop from source
 

--- a/plugins/agent-proxy/README.md
+++ b/plugins/agent-proxy/README.md
@@ -136,6 +136,9 @@ a live Cursor request.
 
 ## Settings
 
+Configure Agent Proxy on its **Advanced** page. The plugin entry in bb Settings links to that page
+instead of duplicating the form.
+
 | Key                              | Default                     | Meaning                                                                              |
 | -------------------------------- | --------------------------- | ------------------------------------------------------------------------------------ |
 | `autostart`                      | `true`                      | Keep the login service enabled, so the core starts at login and survives bb closing  |
@@ -144,6 +147,7 @@ a live Cursor request.
 | `sourceRepository`               | `router-for-me/CLIProxyAPI` | Public GitHub source                                                                 |
 | `sourceBranch`                   | `latest`                    | `latest` resolves to the newest published release; or a branch, tag, or commit       |
 | `managementKey`                  | _(generated)_               | Secret. Overrides the auto-generated management key                                  |
+| `routingStrategy`                | `round-robin`               | Select credentials with round robin, fill first, or weighted round robin             |
 
 Autostart applies immediately. The core reads the port and the management key only
 at startup, so a change to either stops the service, rewrites `config.yaml`, and

--- a/plugins/agent-proxy/app.tsx
+++ b/plugins/agent-proxy/app.tsx
@@ -1,6 +1,7 @@
 import "./app.css";
 import { definePluginApp, useBbNavigate } from "@get-bb/plugin-sdk/app";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 import { CORE_STATE_STYLES } from "@/components/status-badge";
 import { mountSidebarNavStatus } from "@/components/sidebar-nav-status";
 import { useCoreStatus } from "@/components/use-core-status";
@@ -84,7 +85,23 @@ function AgentProxyPanel({ subPath }: { subPath: string }) {
   );
 }
 
+function SettingsShortcut() {
+  const navigate = useBbNavigate();
+  return (
+    <Button
+      type="button"
+      onClick={() => navigate.toPluginPanel("agent-proxy", { subPath: "advanced" })}
+    >
+      Open Agent Proxy settings
+    </Button>
+  );
+}
+
 export default definePluginApp((app) => {
+  app.slots.settingsSection({
+    id: "settings-shortcut",
+    component: SettingsShortcut,
+  });
   app.slots.navPanel({
     id: "agent-proxy",
     title: NAV_TITLE,

--- a/plugins/agent-proxy/components/pages/advanced.tsx
+++ b/plugins/agent-proxy/components/pages/advanced.tsx
@@ -6,29 +6,81 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import type { rpcContract } from "../../server";
 
-interface SourceSettings {
-  repository: string;
-  branch: string;
-  error: string | null;
-  defaultRepository: string;
-  defaultBranch: string;
+type RoutingStrategy = "round-robin" | "fill-first" | "weighted-round-robin";
+
+interface SettingsValues {
+  autostart: boolean;
+  cloudflareQuickTunnelForCursor: boolean;
+  port: number;
+  sourceRepository: string;
+  sourceBranch: string;
+  routingStrategy: RoutingStrategy;
+}
+
+interface SettingsView {
+  values: SettingsValues;
+  defaults: SettingsValues;
+  managementKeyConfigured: boolean;
+  sourceError: string | null;
+}
+
+const EMPTY_SETTINGS: SettingsValues = {
+  autostart: true,
+  cloudflareQuickTunnelForCursor: false,
+  port: 8317,
+  sourceRepository: "router-for-me/CLIProxyAPI",
+  sourceBranch: "latest",
+  routingStrategy: "round-robin",
+};
+
+function ToggleSetting({
+  checked,
+  description,
+  disabled,
+  label,
+  onChange,
+}: {
+  checked: boolean;
+  description: string;
+  disabled: boolean;
+  label: string;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <label
+      aria-label={label}
+      className="flex items-start gap-3 rounded-md border border-border p-3 text-sm"
+    >
+      <input
+        type="checkbox"
+        className="mt-0.5 size-4 shrink-0 accent-primary"
+        checked={checked}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.checked)}
+      />
+      <span className="space-y-1">
+        <span className="block font-medium text-foreground">{label}</span>
+        <span className="block text-xs text-muted-foreground">{description}</span>
+      </span>
+    </label>
+  );
 }
 
 export function AdvancedPage() {
   const rpc = useRpc<typeof rpcContract>();
-  const [saved, setSaved] = useState<SourceSettings | null>(null);
-  const [repository, setRepository] = useState("");
-  const [branch, setBranch] = useState("");
+  const [saved, setSaved] = useState<SettingsView | null>(null);
+  const [draft, setDraft] = useState<SettingsValues>(EMPTY_SETTINGS);
+  const [managementKey, setManagementKey] = useState("");
+  const [clearManagementKey, setClearManagementKey] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
   const load = useCallback(async () => {
     try {
-      const next = await rpc.call("sourceSettings");
+      const next = await rpc.call("configuration");
       setSaved(next);
-      setRepository(next.repository);
-      setBranch(next.branch);
-      setError(next.error);
+      setDraft(next.values);
+      setError(next.sourceError);
     } catch (cause) {
       setError(String(cause instanceof Error ? cause.message : cause));
     }
@@ -38,23 +90,29 @@ export function AdvancedPage() {
     void load();
   }, [load]);
 
-  const save = async (
-    nextRepository: string,
-    nextBranch: string,
-    successMessage = "Core source saved",
-  ) => {
+  const update = <Key extends keyof SettingsValues>(key: Key, value: SettingsValues[Key]) => {
+    setDraft((current) => ({ ...current, [key]: value }));
+  };
+
+  const save = async () => {
     setSaving(true);
     setError(null);
     try {
-      const next = await rpc.call("sourceSettingsUpdate", {
-        repository: nextRepository,
-        branch: nextBranch,
+      const key = managementKey.trim();
+      const next = await rpc.call("configurationUpdate", {
+        ...draft,
+        managementKey: clearManagementKey
+          ? { action: "clear" }
+          : key
+            ? { action: "set", value: key }
+            : { action: "keep" },
       });
       setSaved(next);
-      setRepository(next.repository);
-      setBranch(next.branch);
-      setError(next.error);
-      toast.success(successMessage);
+      setDraft(next.values);
+      setManagementKey("");
+      setClearManagementKey(false);
+      setError(next.sourceError);
+      toast.success("Agent Proxy settings saved");
     } catch (cause) {
       const message = String(cause instanceof Error ? cause.message : cause);
       setError(message);
@@ -64,39 +122,143 @@ export function AdvancedPage() {
     }
   };
 
-  const dirty = saved !== null && (repository !== saved.repository || branch !== saved.branch);
-
-  // The saved source can already be the defaults. Writing them again would
-  // look like a dead button: no field moves and the save toast claims a change
-  // that never happened. Revert the edited fields instead, and only call the
-  // server when the stored source actually differs.
-  const savedIsDefault =
-    saved !== null &&
-    saved.error === null &&
-    saved.repository === saved.defaultRepository &&
-    saved.branch === saved.defaultBranch;
-  const fieldsAreDefault =
-    saved !== null && repository === saved.defaultRepository && branch === saved.defaultBranch;
-
   const reset = () => {
     if (saved === null) return;
-    if (!savedIsDefault) {
-      void save(saved.defaultRepository, saved.defaultBranch, "Core source reset to defaults");
-      return;
-    }
-    setRepository(saved.defaultRepository);
-    setBranch(saved.defaultBranch);
+    setDraft(saved.defaults);
+    setManagementKey("");
+    setClearManagementKey(saved.managementKeyConfigured);
     setError(null);
-    toast.success("Core source is back to the defaults");
   };
+
+  const dirty =
+    saved !== null &&
+    (JSON.stringify(draft) !== JSON.stringify(saved.values) ||
+      managementKey.trim().length > 0 ||
+      clearManagementKey);
+  const disabled = saved === null || saving;
 
   return (
     <div className="space-y-4">
       <Card>
         <CardHeader>
+          <CardTitle className="text-base">Service</CardTitle>
+          <CardDescription>
+            Control the local CLIProxyAPI process and credential routing.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <ToggleSetting
+            checked={draft.autostart}
+            disabled={disabled}
+            label="Keep the proxy running as a login service"
+            description="The operating system starts it at login and keeps it running when bb is closed."
+            onChange={(checked) => update("autostart", checked)}
+          />
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label htmlFor="agent-proxy-port" className="block space-y-1.5 text-sm">
+              <span className="font-medium text-foreground">Proxy listen port</span>
+              <Input
+                id="agent-proxy-port"
+                type="number"
+                min={1}
+                max={65_535}
+                value={draft.port}
+                disabled={disabled}
+                onChange={(event) => update("port", Number(event.target.value))}
+              />
+            </label>
+
+            <label htmlFor="agent-proxy-routing" className="block space-y-1.5 text-sm">
+              <span className="font-medium text-foreground">Credential routing</span>
+              <select
+                id="agent-proxy-routing"
+                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
+                value={draft.routingStrategy}
+                disabled={disabled}
+                onChange={(event) =>
+                  update("routingStrategy", event.target.value as RoutingStrategy)
+                }
+              >
+                <option value="round-robin">Round robin</option>
+                <option value="fill-first">Fill first</option>
+                <option value="weighted-round-robin">Weighted round robin</option>
+              </select>
+              <span className="block text-xs text-muted-foreground">
+                Fill first preserves upstream prompt caches. Round robin rotates each request.
+              </span>
+            </label>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Cursor BYOK</CardTitle>
+          <CardDescription>
+            Expose the OpenAI-compatible endpoint through Cloudflare.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ToggleSetting
+            checked={draft.cloudflareQuickTunnelForCursor}
+            disabled={disabled}
+            label="Cloudflare Quick Tunnel"
+            description="Development only. The hostname changes after helper restarts, and Quick Tunnels do not support SSE."
+            onChange={(checked) => update("cloudflareQuickTunnelForCursor", checked)}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Management API</CardTitle>
+          <CardDescription>
+            Override the generated management key used between this plugin and CLIProxyAPI.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <label htmlFor="agent-proxy-management-key" className="block space-y-1.5 text-sm">
+            <span className="font-medium text-foreground">Management key override</span>
+            <Input
+              id="agent-proxy-management-key"
+              type="password"
+              value={managementKey}
+              disabled={disabled || clearManagementKey}
+              placeholder={
+                saved?.managementKeyConfigured
+                  ? "Leave blank to keep the saved override"
+                  : "Leave blank to use the generated key"
+              }
+              autoComplete="off"
+              onChange={(event) => setManagementKey(event.target.value)}
+            />
+          </label>
+          {saved?.managementKeyConfigured ? (
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={disabled}
+                onClick={() => setClearManagementKey((current) => !current)}
+              >
+                {clearManagementKey ? "Keep saved override" : "Clear saved override"}
+              </Button>
+              <span className="text-xs text-muted-foreground">
+                {clearManagementKey
+                  ? "The generated key will be used after you save."
+                  : "A saved override is configured. Its value is never sent to the browser."}
+              </span>
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
           <CardTitle className="text-base">Core source</CardTitle>
           <CardDescription>
-            Choose the public GitHub repository and branch used for update checks and source builds.
+            Choose the public GitHub repository and ref used for update checks and installs.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -104,11 +266,11 @@ export function AdvancedPage() {
             <span className="font-medium text-foreground">Repository</span>
             <Input
               id="agent-proxy-source-repository"
-              value={repository}
-              disabled={saved === null || saving}
+              value={draft.sourceRepository}
+              disabled={disabled}
               placeholder="owner/repository"
               spellCheck={false}
-              onChange={(event) => setRepository(event.target.value)}
+              onChange={(event) => update("sourceRepository", event.target.value)}
             />
             <span className="block text-xs text-muted-foreground">
               Use owner/name, an HTTPS github.com URL, or a git@github.com source.
@@ -119,59 +281,37 @@ export function AdvancedPage() {
             <span className="font-medium text-foreground">Branch or ref</span>
             <Input
               id="agent-proxy-source-ref"
-              value={branch}
-              disabled={saved === null || saving}
+              value={draft.sourceBranch}
+              disabled={disabled}
               placeholder="latest"
               spellCheck={false}
-              onChange={(event) => setBranch(event.target.value)}
+              onChange={(event) => update("sourceBranch", event.target.value)}
             />
             <span className="block text-xs text-muted-foreground">
-              Use <span className="font-medium text-foreground">latest</span> for the newest
-              published release, or give a branch, tag, or full commit SHA. Branch names can contain
-              slashes.
+              Use latest for the newest release, or enter a branch, tag, or full commit SHA.
             </span>
           </label>
 
-          {error ? <div className="text-sm text-destructive">{error}</div> : null}
-
-          <div className="flex flex-wrap gap-2">
-            <Button
-              size="sm"
-              disabled={!dirty || saving}
-              onClick={() => void save(repository, branch)}
-            >
-              {saving ? "Saving…" : "Save source"}
-            </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              disabled={saved === null || saving || (savedIsDefault && fieldsAreDefault)}
-              onClick={reset}
-            >
-              Reset to defaults
-            </Button>
-            {savedIsDefault && fieldsAreDefault ? (
-              <span className="self-center text-xs text-muted-foreground">
-                This is the default source.
-              </span>
-            ) : null}
-          </div>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">How source changes apply</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-2 text-sm text-muted-foreground">
-          <p>Saving does not replace or restart the running core.</p>
-          <p>
-            Use <span className="font-medium text-foreground">Install core</span> on Home to resolve
-            the saved ref, build that exact commit, and atomically switch the binary.
+          <p className="text-xs text-muted-foreground">
+            Saving does not replace the running binary. Use Install core on Home after a source
+            change.
           </p>
-          <p>The repository must keep the CLIProxyAPI Go entrypoint at cmd/server.</p>
         </CardContent>
       </Card>
+
+      {error ? <div className="text-sm text-destructive">{error}</div> : null}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Button size="sm" disabled={!dirty || saving} onClick={() => void save()}>
+          {saving ? "Saving…" : "Save settings"}
+        </Button>
+        <Button size="sm" variant="outline" disabled={disabled} onClick={reset}>
+          Reset to defaults
+        </Button>
+        {!dirty && saved !== null ? (
+          <span className="text-xs text-muted-foreground">All changes are saved.</span>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/plugins/agent-proxy/components/pages/advanced.tsx
+++ b/plugins/agent-proxy/components/pages/advanced.tsx
@@ -4,34 +4,25 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import {
+  DEFAULT_AGENT_PROXY_SETTINGS,
+  type AgentProxySettings,
+  type RoutingStrategy,
+} from "../../lib/plugin-settings.ts";
 import type { rpcContract } from "../../server";
 
-type RoutingStrategy = "round-robin" | "fill-first" | "weighted-round-robin";
-
-interface SettingsValues {
-  autostart: boolean;
-  cloudflareQuickTunnelForCursor: boolean;
-  port: number;
-  sourceRepository: string;
-  sourceBranch: string;
-  routingStrategy: RoutingStrategy;
-}
+type SettingsDraft = Omit<AgentProxySettings, "port"> & { port: string };
 
 interface SettingsView {
-  values: SettingsValues;
-  defaults: SettingsValues;
+  values: AgentProxySettings;
+  defaults: AgentProxySettings;
   managementKeyConfigured: boolean;
   sourceError: string | null;
 }
 
-const EMPTY_SETTINGS: SettingsValues = {
-  autostart: true,
-  cloudflareQuickTunnelForCursor: false,
-  port: 8317,
-  sourceRepository: "router-for-me/CLIProxyAPI",
-  sourceBranch: "latest",
-  routingStrategy: "round-robin",
-};
+function settingsDraft(values: AgentProxySettings): SettingsDraft {
+  return { ...values, port: String(values.port) };
+}
 
 function ToggleSetting({
   checked,
@@ -69,7 +60,9 @@ function ToggleSetting({
 export function AdvancedPage() {
   const rpc = useRpc<typeof rpcContract>();
   const [saved, setSaved] = useState<SettingsView | null>(null);
-  const [draft, setDraft] = useState<SettingsValues>(EMPTY_SETTINGS);
+  const [draft, setDraft] = useState<SettingsDraft>(() =>
+    settingsDraft(DEFAULT_AGENT_PROXY_SETTINGS),
+  );
   const [managementKey, setManagementKey] = useState("");
   const [clearManagementKey, setClearManagementKey] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -79,7 +72,7 @@ export function AdvancedPage() {
     try {
       const next = await rpc.call("configuration");
       setSaved(next);
-      setDraft(next.values);
+      setDraft(settingsDraft(next.values));
       setError(next.sourceError);
     } catch (cause) {
       setError(String(cause instanceof Error ? cause.message : cause));
@@ -90,17 +83,23 @@ export function AdvancedPage() {
     void load();
   }, [load]);
 
-  const update = <Key extends keyof SettingsValues>(key: Key, value: SettingsValues[Key]) => {
+  const update = <Key extends keyof SettingsDraft>(key: Key, value: SettingsDraft[Key]) => {
     setDraft((current) => ({ ...current, [key]: value }));
   };
 
   const save = async () => {
+    const port = Number(draft.port);
+    if (!Number.isInteger(port) || port <= 0 || port >= 65_536) {
+      setError("Proxy listen port must be an integer from 1 to 65535.");
+      return;
+    }
     setSaving(true);
     setError(null);
     try {
       const key = managementKey.trim();
       const next = await rpc.call("configurationUpdate", {
         ...draft,
+        port,
         managementKey: clearManagementKey
           ? { action: "clear" }
           : key
@@ -108,7 +107,7 @@ export function AdvancedPage() {
             : { action: "keep" },
       });
       setSaved(next);
-      setDraft(next.values);
+      setDraft(settingsDraft(next.values));
       setManagementKey("");
       setClearManagementKey(false);
       setError(next.sourceError);
@@ -124,7 +123,7 @@ export function AdvancedPage() {
 
   const reset = () => {
     if (saved === null) return;
-    setDraft(saved.defaults);
+    setDraft(settingsDraft(saved.defaults));
     setManagementKey("");
     setClearManagementKey(saved.managementKeyConfigured);
     setError(null);
@@ -132,7 +131,7 @@ export function AdvancedPage() {
 
   const dirty =
     saved !== null &&
-    (JSON.stringify(draft) !== JSON.stringify(saved.values) ||
+    (JSON.stringify(draft) !== JSON.stringify(settingsDraft(saved.values)) ||
       managementKey.trim().length > 0 ||
       clearManagementKey);
   const disabled = saved === null || saving;
@@ -165,7 +164,7 @@ export function AdvancedPage() {
                 max={65_535}
                 value={draft.port}
                 disabled={disabled}
-                onChange={(event) => update("port", Number(event.target.value))}
+                onChange={(event) => update("port", event.target.value)}
               />
             </label>
 

--- a/plugins/agent-proxy/components/pages/home.tsx
+++ b/plugins/agent-proxy/components/pages/home.tsx
@@ -7,6 +7,25 @@ import { CopyField } from "@/components/copy-field";
 import { StatusBadge } from "@/components/status-badge";
 import { useCoreStatus } from "@/components/use-core-status";
 import { canStopService } from "@/lib/service-actions";
+import type { CoreStatus } from "../../server";
+
+function tunnelStatusText(tunnel: CoreStatus["tunnel"]): string {
+  switch (tunnel.state) {
+    case "disabled":
+      return "Disabled. Enable Cloudflare Quick Tunnel for Cursor in Agent Proxy settings.";
+    case "missing-binary":
+      return tunnel.detail;
+    case "stopped":
+      return "Stopped with the local proxy.";
+    case "stopping":
+    case "starting":
+    case "running-without-url":
+    case "crashed":
+      return tunnel.detail;
+    case "ready":
+      return "Ready for Cursor BYOK.";
+  }
+}
 
 export function HomePage() {
   const { status, error, refresh, rpc } = useCoreStatus();
@@ -207,6 +226,31 @@ export function HomePage() {
               />
               <CopyField label="Gemini base URL" value={status.endpoints.gemini} />
               {apiKey ? <CopyField label="Local API key" value={apiKey} masked /> : null}
+            </>
+          ) : (
+            <div className="text-sm text-muted-foreground">Loading…</div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Public OpenAI base URL</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {status ? (
+            <>
+              <div className="text-sm text-muted-foreground">{tunnelStatusText(status.tunnel)}</div>
+              {status.tunnel.state === "ready" ? (
+                <>
+                  <CopyField label="Cursor OpenAI base URL" value={status.tunnel.openaiBaseUrl} />
+                  {apiKey ? <CopyField label="Cursor API key" value={apiKey} masked /> : null}
+                </>
+              ) : null}
+              <div className="text-xs text-muted-foreground">
+                Quick Tunnels are for development. The hostname changes after the helper restarts.
+                Cloudflare Quick Tunnels do not support SSE, so some Cursor requests can fail.
+              </div>
             </>
           ) : (
             <div className="text-sm text-muted-foreground">Loading…</div>

--- a/plugins/agent-proxy/lib/cloudflare-tunnel-runtime.mjs
+++ b/plugins/agent-proxy/lib/cloudflare-tunnel-runtime.mjs
@@ -1,0 +1,502 @@
+import { spawn } from "node:child_process";
+import { randomUUID, timingSafeEqual } from "node:crypto";
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, request as httpRequest } from "node:http";
+import { dirname, isAbsolute, resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+
+const CONFIG_VERSION = 1;
+const RETRY_DELAYS_MS = [1_000, 2_000, 5_000, 10_000, 30_000];
+const STABLE_CHILD_MS = 30_000;
+const FIXED_REQUEST_HEADERS = new Set([
+  "connection",
+  "expect",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "proxy-connection",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+  "forwarded",
+  "cf-connecting-ip",
+  "cf-ipcountry",
+  "cf-ray",
+  "cf-visitor",
+  "cdn-loop",
+  "true-client-ip",
+  "x-real-ip",
+]);
+const FIXED_RESPONSE_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "proxy-connection",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+  "via",
+]);
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPort(value) {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 && value < 65_536;
+}
+
+function parseConfig(value) {
+  if (!isRecord(value) || value.version !== CONFIG_VERSION || !isPort(value.corePort)) return null;
+  if (typeof value.cloudflaredPath !== "string" || !isAbsolute(value.cloudflaredPath)) return null;
+  if (typeof value.localApiKeyPath !== "string" || !isAbsolute(value.localApiKeyPath)) return null;
+  return {
+    version: CONFIG_VERSION,
+    corePort: value.corePort,
+    cloudflaredPath: value.cloudflaredPath,
+    localApiKeyPath: value.localApiKeyPath,
+  };
+}
+
+function readConfig(path) {
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    throw new Error(
+      `cannot read desired tunnel config: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+  const config = parseConfig(parsed);
+  if (config === null) throw new Error("desired tunnel config is invalid");
+  return config;
+}
+
+function writeAtomic(path, value) {
+  mkdirSync(dirname(path), { recursive: true });
+  const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    writeFileSync(temporary, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+    renameSync(temporary, path);
+  } finally {
+    rmSync(temporary, { force: true });
+  }
+}
+
+function publicOrigin(value) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return null;
+  }
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.port !== "" ||
+    parsed.pathname !== "/" ||
+    parsed.search !== "" ||
+    parsed.hash !== "" ||
+    !/^[a-z0-9-]+\.trycloudflare\.com$/i.test(parsed.hostname)
+  ) {
+    return null;
+  }
+  return parsed.origin;
+}
+
+function extractPublicOrigin(output) {
+  for (const match of output.matchAll(
+    /https:\/\/[a-z0-9-]+\.trycloudflare\.com\/?(?![a-z0-9.-])/gi,
+  )) {
+    const origin = publicOrigin(match[0]);
+    if (origin !== null) return origin;
+  }
+  return null;
+}
+
+function inspectRequestTarget(rawTarget) {
+  if (typeof rawTarget !== "string" || !rawTarget.startsWith("/") || rawTarget.startsWith("//")) {
+    return { accepted: false, status: 400, detail: "absolute request targets are not allowed" };
+  }
+  const queryIndex = rawTarget.indexOf("?");
+  const rawPath = queryIndex === -1 ? rawTarget : rawTarget.slice(0, queryIndex);
+  if (rawPath.includes("#") || rawPath.includes("\\")) {
+    return { accepted: false, status: 400, detail: "invalid request target" };
+  }
+  let decoded = rawPath;
+  for (let depth = 0; ; depth += 1) {
+    if (depth === 16) {
+      return { accepted: false, status: 400, detail: "request target is encoded too deeply" };
+    }
+    let next;
+    try {
+      next = decodeURIComponent(decoded);
+    } catch {
+      return { accepted: false, status: 400, detail: "invalid request target encoding" };
+    }
+    if (next.includes("\\") || next.split("/").length !== decoded.split("/").length) {
+      return { accepted: false, status: 400, detail: "encoded path separators are not allowed" };
+    }
+    if (next.split("/").some((segment) => segment === "." || segment === "..")) {
+      return { accepted: false, status: 400, detail: "dot segments are not allowed" };
+    }
+    if (next === decoded) break;
+    decoded = next;
+  }
+  if (rawPath !== "/v1" && !rawPath.startsWith("/v1/")) {
+    return { accepted: false, status: 404, detail: "not found" };
+  }
+  return { accepted: true, target: rawTarget };
+}
+
+function connectionHeaderNames(headers) {
+  const value = headers.connection;
+  const values = Array.isArray(value) ? value : value === undefined ? [] : [value];
+  return new Set(
+    values
+      .flatMap((entry) => entry.split(","))
+      .map((entry) => entry.trim().toLowerCase())
+      .filter((entry) => entry.length > 0),
+  );
+}
+
+function requestHeaders(headers, corePort) {
+  const connectionNames = connectionHeaderNames(headers);
+  const clean = {};
+  for (const [name, value] of Object.entries(headers)) {
+    const lower = name.toLowerCase();
+    if (
+      value === undefined ||
+      FIXED_REQUEST_HEADERS.has(lower) ||
+      connectionNames.has(lower) ||
+      lower === "via" ||
+      lower.startsWith("cf-") ||
+      lower.startsWith("x-forwarded-")
+    ) {
+      continue;
+    }
+    clean[lower] = value;
+  }
+  clean.host = `127.0.0.1:${corePort}`;
+  clean.authorization = headers.authorization;
+  return clean;
+}
+
+function responseHeaders(headers) {
+  const connectionNames = connectionHeaderNames(headers);
+  const clean = {};
+  for (const [name, value] of Object.entries(headers)) {
+    const lower = name.toLowerCase();
+    if (value === undefined || FIXED_RESPONSE_HEADERS.has(lower) || connectionNames.has(lower)) {
+      continue;
+    }
+    clean[lower] = value;
+  }
+  return clean;
+}
+
+function validBearer(value, expected) {
+  if (typeof value !== "string" || !value.startsWith("Bearer ")) return false;
+  const received = Buffer.from(value.slice("Bearer ".length));
+  const wanted = Buffer.from(expected);
+  return received.length === wanted.length && timingSafeEqual(received, wanted);
+}
+
+function send(response, status, detail) {
+  if (response.headersSent) {
+    response.destroy();
+    return;
+  }
+  const body = `${detail}\n`;
+  response.writeHead(status, {
+    "content-type": "text/plain; charset=utf-8",
+    "content-length": Buffer.byteLength(body),
+    connection: "close",
+  });
+  response.end(body);
+}
+
+function createGateway(configPath) {
+  const handleRequest = (incoming, outgoing, continueAfterAuth = false) => {
+    const target = inspectRequestTarget(incoming.url);
+    if (!target.accepted) {
+      send(outgoing, target.status, target.detail);
+      return;
+    }
+    if (
+      incoming.headers.upgrade !== undefined ||
+      /(?:^|,)\s*upgrade\s*(?:,|$)/i.test(incoming.headers.connection ?? "")
+    ) {
+      send(outgoing, 426, "protocol upgrades are not allowed");
+      return;
+    }
+    let config;
+    let key;
+    try {
+      config = readConfig(configPath);
+      key = readFileSync(config.localApiKeyPath, "utf8").trim();
+      if (key.length === 0) throw new Error("the local API key is empty");
+    } catch {
+      send(outgoing, 503, "gateway configuration is unavailable");
+      return;
+    }
+    if (!validBearer(incoming.headers.authorization, key)) {
+      outgoing.setHeader("www-authenticate", "Bearer");
+      send(outgoing, 401, "unauthorized");
+      return;
+    }
+    if (continueAfterAuth) outgoing.writeContinue();
+    const upstream = httpRequest(
+      {
+        host: "127.0.0.1",
+        port: config.corePort,
+        method: incoming.method,
+        path: target.target,
+        headers: requestHeaders(incoming.headers, config.corePort),
+      },
+      (response) => {
+        outgoing.writeHead(response.statusCode ?? 502, responseHeaders(response.headers));
+        response.pipe(outgoing);
+      },
+    );
+    upstream.on("error", () => send(outgoing, 503, "CLIProxyAPI is temporarily unavailable"));
+    incoming.on("aborted", () => upstream.destroy());
+    incoming.pipe(upstream);
+  };
+  const server = createServer(handleRequest);
+  server.on("checkContinue", (incoming, outgoing) => {
+    handleRequest(incoming, outgoing, true);
+  });
+  server.on("upgrade", (_request, socket) => {
+    socket.end("HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
+  });
+  server.on("connect", (_request, socket) => {
+    socket.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
+  });
+  return server;
+}
+
+function listen(server) {
+  return new Promise((resolveListen, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        reject(new Error("the loopback gateway did not return a TCP address"));
+        return;
+      }
+      resolveListen(address.port);
+    });
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolveClose) => {
+    server.close(() => resolveClose());
+    server.closeAllConnections?.();
+  });
+}
+
+function childOutcome(child, onOutput) {
+  const { promise: outcome, resolve: resolveOutcome } = Promise.withResolvers();
+  let outputError = null;
+  let childError = null;
+  let killTimer = null;
+  const failOutput = (error) => {
+    if (outputError !== null) return;
+    outputError = error instanceof Error ? error : new Error(String(error));
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGTERM");
+      killTimer = setTimeout(() => child.kill("SIGKILL"), 5_000);
+    }
+  };
+  for (const [stream, output] of [
+    [child.stdout, process.stdout],
+    [child.stderr, process.stderr],
+  ]) {
+    stream?.setEncoding("utf8");
+    stream?.on("data", (chunk) => {
+      output.write(chunk);
+      try {
+        onOutput(String(chunk));
+      } catch (error) {
+        failOutput(error);
+      }
+    });
+  }
+  child.once("error", (error) => {
+    childError = error;
+  });
+  child.once("close", (code, signal) => {
+    if (killTimer !== null) clearTimeout(killTimer);
+    resolveOutcome({ code, signal, error: outputError ?? childError });
+  });
+  return outcome;
+}
+
+async function terminateChild(child, outcome) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    await outcome;
+    return;
+  }
+  child.kill("SIGTERM");
+  const killTimer = setTimeout(() => child.kill("SIGKILL"), 5_000);
+  try {
+    await outcome;
+  } finally {
+    clearTimeout(killTimer);
+  }
+}
+
+async function wait(ms, signal) {
+  try {
+    await delay(ms, undefined, { signal });
+  } catch (error) {
+    if (!signal.aborted) throw error;
+  }
+}
+
+function waitForOutcomeOrAbort(outcome, signal) {
+  if (signal.aborted) return Promise.resolve(null);
+  return new Promise((resolveResult) => {
+    let finished = false;
+    const finish = (value) => {
+      if (finished) return;
+      finished = true;
+      signal.removeEventListener("abort", abort);
+      resolveResult(value);
+    };
+    const abort = () => finish(null);
+    signal.addEventListener("abort", abort, { once: true });
+    outcome.then(finish);
+  });
+}
+
+async function runHelper(configPath, observationPath) {
+  const sessionId = randomUUID();
+  const controller = new AbortController();
+  const stop = () => controller.abort();
+  process.once("SIGTERM", stop);
+  process.once("SIGINT", stop);
+  const gateway = createGateway(configPath);
+  let child = null;
+  let outcome = null;
+  try {
+    const gatewayPort = await listen(gateway);
+    let failures = 0;
+    while (!controller.signal.aborted) {
+      const config = readConfig(configPath);
+      writeAtomic(observationPath, {
+        version: CONFIG_VERSION,
+        phase: "starting",
+        ownerPid: process.pid,
+        sessionId,
+        updatedAt: Date.now(),
+      });
+      child = spawn(
+        config.cloudflaredPath,
+        [
+          "tunnel",
+          "--config",
+          "/dev/null",
+          "--no-autoupdate",
+          "--url",
+          `http://127.0.0.1:${gatewayPort}`,
+        ],
+        { stdio: ["ignore", "pipe", "pipe"] },
+      );
+      const startedAt = Date.now();
+      let outputBuffer = "";
+      let ready = false;
+      outcome = childOutcome(child, (chunk) => {
+        if (ready || child?.pid === undefined) return;
+        outputBuffer = `${outputBuffer}${chunk}`.slice(-16_384);
+        const origin = extractPublicOrigin(outputBuffer);
+        if (origin === null) return;
+        ready = true;
+        writeAtomic(observationPath, {
+          version: CONFIG_VERSION,
+          phase: "ready",
+          ownerPid: process.pid,
+          sessionId,
+          cloudflaredPid: child.pid,
+          publicOrigin: origin,
+          updatedAt: Date.now(),
+        });
+      });
+      const result = await waitForOutcomeOrAbort(outcome, controller.signal);
+      if (controller.signal.aborted) {
+        await terminateChild(child, outcome);
+        break;
+      }
+      const detail =
+        result?.error instanceof Error
+          ? `tunnel attempt failed: ${result.error.message}`
+          : `cloudflared exited with code ${result?.code ?? "null"} and signal ${result?.signal ?? "null"}; retrying`;
+      writeAtomic(observationPath, {
+        version: CONFIG_VERSION,
+        phase: "error",
+        ownerPid: process.pid,
+        sessionId,
+        detail,
+        updatedAt: Date.now(),
+      });
+      child = null;
+      outcome = null;
+      if (ready && Date.now() - startedAt >= STABLE_CHILD_MS) failures = 0;
+      const retryDelay = RETRY_DELAYS_MS[Math.min(failures, RETRY_DELAYS_MS.length - 1)];
+      failures += 1;
+      await wait(retryDelay, controller.signal);
+    }
+  } finally {
+    if (child !== null && outcome !== null) await terminateChild(child, outcome);
+    await closeServer(gateway);
+    rmSync(observationPath, { force: true });
+    process.removeListener("SIGTERM", stop);
+    process.removeListener("SIGINT", stop);
+  }
+}
+
+function selfTest() {
+  const valid = inspectRequestTarget("/v1/models?limit=1");
+  if (!valid.accepted) throw new Error("valid /v1 request target was rejected");
+  for (const target of ["https://example.com/v1", "/v1/%2e%2e/admin", "/v1%2fadmin"]) {
+    if (inspectRequestTarget(target).accepted)
+      throw new Error(`unsafe request target was accepted: ${target}`);
+  }
+  if (publicOrigin("https://example.trycloudflare.com") === null) {
+    throw new Error("valid Quick Tunnel origin was rejected");
+  }
+}
+
+async function main() {
+  const [command, ...args] = process.argv.slice(2);
+  if (command !== "helper")
+    throw new Error("usage: helper [--self-test | --config PATH --observation PATH]");
+  if (args.includes("--self-test")) {
+    selfTest();
+    return;
+  }
+  const configIndex = args.indexOf("--config");
+  const observationIndex = args.indexOf("--observation");
+  const configPath = args[configIndex + 1];
+  const observationPath = args[observationIndex + 1];
+  if (configIndex === -1 || observationIndex === -1 || !configPath || !observationPath) {
+    throw new Error("usage: helper --config PATH --observation PATH");
+  }
+  await runHelper(configPath, observationPath);
+}
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/plugins/agent-proxy/lib/cloudflare-tunnel-runtime.mjs
+++ b/plugins/agent-proxy/lib/cloudflare-tunnel-runtime.mjs
@@ -268,9 +268,7 @@ export function createGateway(configPath, { upstreamIdleTimeoutMs = 5 * 60_000 }
         upstreamResponse = response;
         response.once("aborted", failUpstream);
         response.once("error", failUpstream);
-        response.once("end", () => {
-          terminal = true;
-        });
+        response.once("end", closeUpstream);
         outgoing.writeHead(response.statusCode ?? 502, responseHeaders(response.headers));
         response.pipe(outgoing);
       },

--- a/plugins/agent-proxy/lib/cloudflare-tunnel-runtime.mjs
+++ b/plugins/agent-proxy/lib/cloudflare-tunnel-runtime.mjs
@@ -222,7 +222,7 @@ function send(response, status, detail) {
   response.end(body);
 }
 
-function createGateway(configPath) {
+export function createGateway(configPath, { upstreamIdleTimeoutMs = 5 * 60_000 } = {}) {
   const handleRequest = (incoming, outgoing, continueAfterAuth = false) => {
     const target = inspectRequestTarget(incoming.url);
     if (!target.accepted) {
@@ -261,12 +261,40 @@ function createGateway(configPath) {
         headers: requestHeaders(incoming.headers, config.corePort),
       },
       (response) => {
+        if (terminal) {
+          response.destroy();
+          return;
+        }
+        upstreamResponse = response;
+        response.once("aborted", failUpstream);
+        response.once("error", failUpstream);
+        response.once("end", () => {
+          terminal = true;
+        });
         outgoing.writeHead(response.statusCode ?? 502, responseHeaders(response.headers));
         response.pipe(outgoing);
       },
     );
-    upstream.on("error", () => send(outgoing, 503, "CLIProxyAPI is temporarily unavailable"));
-    incoming.on("aborted", () => upstream.destroy());
+    let upstreamResponse = null;
+    let terminal = false;
+    const terminateUpstream = (sendUnavailable) => {
+      if (terminal) return;
+      terminal = true;
+      upstream.destroy();
+      upstreamResponse?.destroy();
+      if (sendUnavailable) {
+        if (outgoing.headersSent) outgoing.destroy();
+        else send(outgoing, 503, "CLIProxyAPI is temporarily unavailable");
+      }
+    };
+    const failUpstream = () => terminateUpstream(true);
+    const closeUpstream = () => terminateUpstream(false);
+    upstream.setTimeout(upstreamIdleTimeoutMs, failUpstream);
+    upstream.once("error", failUpstream);
+    incoming.once("aborted", closeUpstream);
+    outgoing.once("close", () => {
+      if (!outgoing.writableEnded) closeUpstream();
+    });
     incoming.pipe(upstream);
   };
   const server = createServer(handleRequest);

--- a/plugins/agent-proxy/lib/cloudflare-tunnel.ts
+++ b/plugins/agent-proxy/lib/cloudflare-tunnel.ts
@@ -1,0 +1,494 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import { isExecutable, readTextOr, writeAtomic } from "./fsx.ts";
+import {
+  LaunchdPersistentService,
+  SystemdPersistentService,
+  type CommandResult,
+  type CommandRunner,
+  type PersistentService,
+  type ServiceSnapshot,
+} from "./persistent-service.ts";
+
+export const TUNNEL_CONFIG_VERSION = 1 as const;
+
+export interface TunnelDesiredConfigV1 {
+  version: typeof TUNNEL_CONFIG_VERSION;
+  corePort: number;
+  cloudflaredPath: string;
+  localApiKeyPath: string;
+}
+
+export type TunnelObservationV1 =
+  | {
+      version: typeof TUNNEL_CONFIG_VERSION;
+      phase: "starting";
+      ownerPid: number;
+      sessionId: string;
+      updatedAt: number;
+    }
+  | {
+      version: typeof TUNNEL_CONFIG_VERSION;
+      phase: "ready";
+      ownerPid: number;
+      sessionId: string;
+      cloudflaredPid: number;
+      publicOrigin: string;
+      updatedAt: number;
+    }
+  | {
+      version: typeof TUNNEL_CONFIG_VERSION;
+      phase: "error";
+      ownerPid: number;
+      sessionId: string;
+      detail: string;
+      updatedAt: number;
+    };
+
+export type TunnelStatus =
+  | { state: "disabled" }
+  | { state: "missing-binary"; detail: string }
+  | { state: "stopped"; reason: "core-stopped" | "disabled" }
+  | { state: "stopping"; pid: number | null; detail: string }
+  | { state: "starting"; pid: number | null; detail: string }
+  | { state: "running-without-url"; pid: number; detail: string }
+  | { state: "ready"; pid: number; openaiBaseUrl: string }
+  | { state: "crashed"; lastExit: ServiceSnapshot["lastExit"]; detail: string };
+
+export type CloudflaredDiscovery =
+  | { state: "found"; path: string }
+  | { state: "missing"; detail: string };
+
+const COMMON_CLOUDFLARED_PATHS: Partial<Record<NodeJS.Platform, readonly string[]>> = {
+  darwin: ["/opt/homebrew/bin/cloudflared", "/usr/local/bin/cloudflared"],
+  linux: ["/usr/local/bin/cloudflared", "/usr/bin/cloudflared", "/snap/bin/cloudflared"],
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPort(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 && value < 65_536;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function isTimestamp(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+export function discoverCloudflared(
+  options: {
+    path?: string;
+    platform?: NodeJS.Platform;
+    executable?: (path: string) => boolean;
+    realpath?: (path: string) => string;
+  } = {},
+): CloudflaredDiscovery {
+  const platform = options.platform ?? process.platform;
+  const executable = options.executable ?? isExecutable;
+  const canonicalPath = options.realpath ?? realpathSync;
+  const pathEntries = (options.path ?? process.env.PATH ?? "")
+    .split(delimiter)
+    .filter((entry) => entry.length > 0)
+    .map((entry) => resolve(entry, "cloudflared"));
+  const candidates = [...pathEntries, ...(COMMON_CLOUDFLARED_PATHS[platform] ?? [])];
+  for (const candidate of new Set(candidates)) {
+    if (!isAbsolute(candidate) || !executable(candidate)) continue;
+    try {
+      return { state: "found", path: canonicalPath(candidate) };
+    } catch {
+      return { state: "found", path: candidate };
+    }
+  }
+  const install =
+    platform === "darwin"
+      ? "Install it with `brew install cloudflared`, then disable and re-enable the setting."
+      : "Install cloudflared on this host, then disable and re-enable the setting.";
+  return { state: "missing", detail: `cloudflared was not found. ${install}` };
+}
+
+export function parseTunnelDesiredConfig(value: unknown): TunnelDesiredConfigV1 | null {
+  if (!isRecord(value)) return null;
+  if (value.version !== TUNNEL_CONFIG_VERSION || !isPort(value.corePort)) return null;
+  if (typeof value.cloudflaredPath !== "string" || !isAbsolute(value.cloudflaredPath)) return null;
+  if (typeof value.localApiKeyPath !== "string" || !isAbsolute(value.localApiKeyPath)) return null;
+  return {
+    version: TUNNEL_CONFIG_VERSION,
+    corePort: value.corePort,
+    cloudflaredPath: value.cloudflaredPath,
+    localApiKeyPath: value.localApiKeyPath,
+  };
+}
+
+export function renderTunnelDesiredConfig(config: TunnelDesiredConfigV1): string {
+  return `${JSON.stringify(config, null, 2)}\n`;
+}
+
+export function tryCloudflareOrigin(value: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return null;
+  }
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.port !== "" ||
+    parsed.pathname !== "/" ||
+    parsed.search !== "" ||
+    parsed.hash !== "" ||
+    !/^[a-z0-9-]+\.trycloudflare\.com$/i.test(parsed.hostname)
+  ) {
+    return null;
+  }
+  return parsed.origin;
+}
+
+export function extractTryCloudflareOrigin(output: string): string | null {
+  for (const match of output.matchAll(
+    /https:\/\/[a-z0-9-]+\.trycloudflare\.com\/?(?![a-z0-9.-])/gi,
+  )) {
+    const origin = tryCloudflareOrigin(match[0]);
+    if (origin !== null) return origin;
+  }
+  return null;
+}
+
+export function parseTunnelObservation(value: unknown): TunnelObservationV1 | null {
+  if (!isRecord(value)) return null;
+  if (
+    value.version !== TUNNEL_CONFIG_VERSION ||
+    !isPositiveInteger(value.ownerPid) ||
+    typeof value.sessionId !== "string" ||
+    value.sessionId.length === 0 ||
+    !isTimestamp(value.updatedAt)
+  ) {
+    return null;
+  }
+  const shared = {
+    version: TUNNEL_CONFIG_VERSION,
+    ownerPid: value.ownerPid,
+    sessionId: value.sessionId,
+    updatedAt: value.updatedAt,
+  };
+  if (value.phase === "starting") return { ...shared, phase: "starting" };
+  if (value.phase === "error" && typeof value.detail === "string") {
+    return { ...shared, phase: "error", detail: value.detail };
+  }
+  if (
+    value.phase === "ready" &&
+    isPositiveInteger(value.cloudflaredPid) &&
+    typeof value.publicOrigin === "string"
+  ) {
+    const publicOrigin = tryCloudflareOrigin(value.publicOrigin);
+    if (publicOrigin !== null) {
+      return {
+        ...shared,
+        phase: "ready",
+        cloudflaredPid: value.cloudflaredPid,
+        publicOrigin,
+      };
+    }
+  }
+  return null;
+}
+
+export function readTunnelObservation(path: string): TunnelObservationV1 | null {
+  const raw = readTextOr(path);
+  if (raw === null) return null;
+  try {
+    return parseTunnelObservation(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+export function deriveTunnelStatus(options: {
+  enabled: boolean;
+  coreDesiredRunning: boolean;
+  coreLoaded: boolean;
+  discovery: CloudflaredDiscovery | null;
+  preparationError: string | null;
+  stopError?: string | null;
+  service: ServiceSnapshot;
+  observation: TunnelObservationV1 | null;
+}): TunnelStatus {
+  if (options.stopError) {
+    return { state: "crashed", lastExit: options.service.lastExit, detail: options.stopError };
+  }
+  if (!options.enabled) {
+    if (options.service.loaded || options.service.pid !== null) {
+      return {
+        state: "stopping",
+        pid: options.service.pid,
+        detail: "Waiting for the operating system to stop the public tunnel.",
+      };
+    }
+    return { state: "disabled" };
+  }
+  if (options.discovery?.state === "missing") {
+    return { state: "missing-binary", detail: options.discovery.detail };
+  }
+  if (options.preparationError !== null) {
+    return { state: "crashed", lastExit: null, detail: options.preparationError };
+  }
+  if (!options.coreDesiredRunning || !options.coreLoaded) {
+    return { state: "stopped", reason: "core-stopped" };
+  }
+  if (options.service.state === "crashed") {
+    return {
+      state: "crashed",
+      lastExit: options.service.lastExit,
+      detail: "The Cloudflare tunnel helper keeps exiting. Check the tunnel log.",
+    };
+  }
+  const ownerPid = options.service.pid;
+  if (ownerPid === null || !options.service.loaded) {
+    return { state: "starting", pid: null, detail: "Waiting for the tunnel helper service." };
+  }
+  const observation = options.observation;
+  if (observation === null || observation.ownerPid !== ownerPid) {
+    return {
+      state: "running-without-url",
+      pid: ownerPid,
+      detail: "Waiting for a fresh tunnel helper observation.",
+    };
+  }
+  if (observation.phase === "starting") {
+    return { state: "starting", pid: ownerPid, detail: "Cloudflare is assigning a hostname." };
+  }
+  if (observation.phase === "error") {
+    return { state: "running-without-url", pid: ownerPid, detail: observation.detail };
+  }
+  return {
+    state: "ready",
+    pid: ownerPid,
+    openaiBaseUrl: `${observation.publicOrigin}/v1`,
+  };
+}
+
+export interface BundledTunnelRuntime {
+  sourcePath: string;
+  content: Buffer;
+  sha256: string;
+  targetPath: string;
+}
+
+export interface TunnelHostRuntime {
+  executablePath: string;
+  environment: Readonly<Record<string, string>>;
+}
+
+function canonicalPathOrOriginal(path: string, canonicalPath: (path: string) => string): string {
+  try {
+    return canonicalPath(path);
+  } catch {
+    return path;
+  }
+}
+
+export function resolveTunnelHostRuntime(
+  options: {
+    platform?: NodeJS.Platform;
+    execPath?: string;
+    appImagePath?: string;
+    electronVersion?: string;
+    executable?: (path: string) => boolean;
+    realpath?: (path: string) => string;
+  } = {},
+): TunnelHostRuntime {
+  const platform = options.platform ?? process.platform;
+  const executable = options.executable ?? isExecutable;
+  const canonicalPath = options.realpath ?? realpathSync;
+  const appImagePath = options.appImagePath ?? process.env.APPIMAGE;
+  const preferredPath =
+    platform === "linux" &&
+    appImagePath !== undefined &&
+    isAbsolute(appImagePath) &&
+    executable(appImagePath)
+      ? appImagePath
+      : (options.execPath ?? process.execPath);
+  return {
+    executablePath: canonicalPathOrOriginal(preferredPath, canonicalPath),
+    environment:
+      (options.electronVersion ?? process.versions.electron) === undefined
+        ? {}
+        : { ELECTRON_RUN_AS_NODE: "1" },
+  };
+}
+
+export function loadBundledTunnelRuntime(options: {
+  runtimeDir: string;
+  moduleUrl?: string;
+}): BundledTunnelRuntime {
+  const moduleDir = dirname(fileURLToPath(options.moduleUrl ?? import.meta.url));
+  const sourcePath = [
+    join(moduleDir, "cloudflare-tunnel-runtime.mjs"),
+    join(moduleDir, "..", "lib", "cloudflare-tunnel-runtime.mjs"),
+  ].find(existsSync);
+  if (sourcePath === undefined) {
+    throw new Error("the packaged Cloudflare tunnel helper source is missing");
+  }
+  const content = readFileSync(sourcePath);
+  const sha256 = createHash("sha256").update(content).digest("hex");
+  return {
+    sourcePath,
+    content,
+    sha256,
+    targetPath: join(options.runtimeDir, `cloudflare-tunnel-runtime-${sha256}.mjs`),
+  };
+}
+
+export type RuntimeCommandRunner = (
+  file: string,
+  args: string[],
+  environment: Readonly<Record<string, string>>,
+) => Promise<CommandResult>;
+
+function runCommand(
+  file: string,
+  args: string[],
+  environment: Readonly<Record<string, string>>,
+): Promise<CommandResult> {
+  return new Promise((resolveResult) => {
+    execFile(
+      file,
+      args,
+      {
+        encoding: "utf8",
+        env: { ...process.env, ...environment },
+        timeout: 5_000,
+        killSignal: "SIGKILL",
+      },
+      (error, stdout, stderr) => {
+        const rawCode = (error as NodeJS.ErrnoException | null)?.code;
+        resolveResult({
+          code: typeof rawCode === "number" ? rawCode : error ? 1 : 0,
+          stdout: String(stdout ?? ""),
+          stderr: String(stderr ?? error?.message ?? ""),
+        });
+      },
+    );
+  });
+}
+
+export async function installTunnelRuntime(options: {
+  runtime: BundledTunnelRuntime;
+  hostRuntime: TunnelHostRuntime;
+  commandRunner?: RuntimeCommandRunner;
+}): Promise<{ state: "ready"; runtimePath: string } | { state: "blocked"; detail: string }> {
+  const runtimePath = options.runtime.targetPath;
+  const installed = readTextOr(runtimePath);
+  if (installed === null || !Buffer.from(installed).equals(options.runtime.content)) {
+    writeAtomic(runtimePath, options.runtime.content, 0o700);
+  }
+  const result = await (options.commandRunner ?? runCommand)(
+    options.hostRuntime.executablePath,
+    [runtimePath, "helper", "--self-test"],
+    options.hostRuntime.environment,
+  );
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`;
+    return {
+      state: "blocked",
+      detail: `${options.hostRuntime.executablePath} cannot run the Cloudflare tunnel helper: ${detail}`,
+    };
+  }
+  return { state: "ready", runtimePath };
+}
+
+export function createCloudflareTunnelService(options: {
+  label: string;
+  definitionPath: string;
+  runtimePath: string;
+  hostRuntime: TunnelHostRuntime;
+  configPath: string;
+  observationPath: string;
+  workingDirectory: string;
+  logPath: string;
+  readinessUrl: () => string;
+  platform?: NodeJS.Platform;
+  uid?: number;
+  onChange?: (snapshot: ServiceSnapshot) => void;
+  onError?: (error: unknown) => void;
+  runCommand?: CommandRunner;
+  fetchImpl?: typeof fetch;
+  monitorIntervalMs?: number;
+}): PersistentService {
+  const platform = options.platform ?? process.platform;
+  const program = {
+    command: [
+      options.hostRuntime.executablePath,
+      options.runtimePath,
+      "helper",
+      "--config",
+      options.configPath,
+      "--observation",
+      options.observationPath,
+    ] as const,
+    environment: options.hostRuntime.environment,
+    workingDirectory: options.workingDirectory,
+    logPath: options.logPath,
+    readinessUrl: options.readinessUrl,
+  };
+  const shared = {
+    label: options.label,
+    program,
+    isInstalled: () => existsSync(options.runtimePath) && existsSync(options.configPath),
+    onChange: options.onChange,
+    onError: options.onError,
+    runCommand: options.runCommand,
+    fetchImpl: options.fetchImpl,
+    monitorIntervalMs: options.monitorIntervalMs,
+    platform,
+  };
+  if (platform === "darwin") {
+    if (options.uid === undefined) {
+      throw new Error("Cloudflare tunnel launchd service requires a POSIX user id");
+    }
+    return new LaunchdPersistentService({
+      ...shared,
+      uid: options.uid,
+      plistPath: options.definitionPath,
+    });
+  }
+  if (platform === "linux") {
+    return new SystemdPersistentService({
+      ...shared,
+      unitPath: options.definitionPath,
+    });
+  }
+  throw new Error(`Cloudflare tunnel services are not supported on ${platform}`);
+}
+
+export async function monitorTunnelObservation(options: {
+  path: string;
+  signal: AbortSignal;
+  onChange: () => void;
+  intervalMs?: number;
+}): Promise<void> {
+  let previous = readTextOr(options.path);
+  const intervalMs = options.intervalMs ?? 1_000;
+  while (!options.signal.aborted) {
+    try {
+      await delay(intervalMs, undefined, { signal: options.signal });
+    } catch (error) {
+      if (!options.signal.aborted) throw error;
+    }
+    if (options.signal.aborted) break;
+    const next = readTextOr(options.path);
+    if (next === previous) continue;
+    previous = next;
+    options.onChange();
+  }
+}

--- a/plugins/agent-proxy/lib/core-process.ts
+++ b/plugins/agent-proxy/lib/core-process.ts
@@ -1,50 +1,24 @@
-import { execFile } from "node:child_process";
-import { closeSync, existsSync, fstatSync, openSync, readSync } from "node:fs";
 import { dirname } from "node:path";
-import { ensureDir, readTextOr, writeAtomic } from "./fsx.ts";
+import {
+  LaunchdPersistentService,
+  SystemdPersistentService,
+  parseLaunchctlPrint,
+  parseSystemctlShow,
+  renderLaunchAgentPlist as renderPersistentLaunchAgentPlist,
+  renderSystemdUserUnit as renderPersistentSystemdUserUnit,
+  type CommandResult,
+  type CommandRunner,
+  type PersistentService,
+  type ServiceManager,
+  type ServiceSnapshot,
+  type ServiceState,
+} from "./persistent-service.ts";
 
-export type CoreState =
-  | "not-installed"
-  | "stopped"
-  | "starting"
-  | "running"
-  | "stopping"
-  | "crashed";
-
-export interface ExitInfo {
-  code: number | null;
-  signal: string | null;
-  at: number;
-}
-export interface SupervisorSnapshot {
-  state: CoreState;
-  pid: number | null;
-  loaded: boolean;
-  crashCount: number;
-  lastExit: ExitInfo | null;
-}
-
-export type ServiceManager = "launchd" | "systemd";
-
-export interface CoreSupervisor {
-  readonly manager: ServiceManager;
-  readonly label: string;
-  readonly definitionPath: string;
-  logs(): string[];
-  snapshot(): Promise<SupervisorSnapshot>;
-  start(): Promise<SupervisorSnapshot>;
-  stop(): Promise<SupervisorSnapshot>;
-  restart(): Promise<SupervisorSnapshot>;
-  monitor(signal: AbortSignal): Promise<void>;
-}
-
-export interface CommandResult {
-  code: number;
-  stdout: string;
-  stderr: string;
-}
-
-export type CommandRunner = (file: string, args: string[]) => Promise<CommandResult>;
+export type CoreState = ServiceState;
+export type SupervisorSnapshot = ServiceSnapshot;
+export type CoreSupervisor = PersistentService;
+export type { CommandResult, CommandRunner, ServiceManager };
+export { parseLaunchctlPrint, parseSystemctlShow };
 
 export interface LaunchdSupervisorOptions {
   label: string;
@@ -54,7 +28,6 @@ export interface LaunchdSupervisorOptions {
   configPath: string;
   logPath: string;
   isInstalled: () => boolean;
-  /** Base URL to probe for readiness; any HTTP response counts as listening. */
   probeUrl: () => string;
   onChange?: (snapshot: SupervisorSnapshot) => void;
   onError?: (error: unknown) => void;
@@ -65,409 +38,6 @@ export interface LaunchdSupervisorOptions {
   logLimit?: number;
   platform?: NodeJS.Platform;
   now?: () => number;
-}
-
-interface LaunchdJobInfo {
-  loaded: boolean;
-  state: string | null;
-  pid: number | null;
-  runs: number;
-  lastExitCode: number | null;
-  lastSignal: string | null;
-}
-
-const LAUNCHCTL = "/bin/launchctl";
-const MAX_LOG_BYTES = 256 * 1024;
-
-function defaultCommandRunner(file: string, args: string[]): Promise<CommandResult> {
-  return new Promise((resolve) => {
-    execFile(file, args, { encoding: "utf8" }, (error, stdout, stderr) => {
-      const rawCode = (error as NodeJS.ErrnoException | null)?.code;
-      resolve({
-        code: typeof rawCode === "number" ? rawCode : error ? 1 : 0,
-        stdout: String(stdout ?? ""),
-        stderr: String(stderr ?? error?.message ?? ""),
-      });
-    });
-  });
-}
-
-function xmlEscape(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&apos;");
-}
-
-export function renderLaunchAgentPlist(options: {
-  label: string;
-  binPath: string;
-  configPath: string;
-  logPath: string;
-}): string {
-  const label = xmlEscape(options.label);
-  const binPath = xmlEscape(options.binPath);
-  const configPath = xmlEscape(options.configPath);
-  const logPath = xmlEscape(options.logPath);
-  const workingDirectory = xmlEscape(dirname(options.configPath));
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key>
-  <string>${label}</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>${binPath}</string>
-    <string>--config</string>
-    <string>${configPath}</string>
-  </array>
-  <key>WorkingDirectory</key>
-  <string>${workingDirectory}</string>
-  <key>KeepAlive</key>
-  <true/>
-  <key>Umask</key>
-  <integer>63</integer>
-  <key>StandardOutPath</key>
-  <string>${logPath}</string>
-  <key>StandardErrorPath</key>
-  <string>${logPath}</string>
-</dict>
-</plist>
-`;
-}
-
-export function parseLaunchctlPrint(output: string): Omit<LaunchdJobInfo, "loaded"> {
-  const value = (name: string) =>
-    output.match(new RegExp(`^\\s*${name} = (.+)$`, "m"))?.[1]?.trim() ?? null;
-  const integer = (name: string) => {
-    const raw = value(name);
-    if (raw === null || !/^-?\d+$/.test(raw)) return null;
-    return Number.parseInt(raw, 10);
-  };
-  return {
-    state: value("state"),
-    pid: integer("pid"),
-    runs: integer("runs") ?? 0,
-    lastExitCode: integer("last exit code"),
-    lastSignal: value("last terminating signal"),
-  };
-}
-
-function isMissingService(result: CommandResult): boolean {
-  return (
-    result.code !== 0 &&
-    /could not find service|service cannot be found|no such process|bad request/i.test(
-      `${result.stdout}\n${result.stderr}`,
-    )
-  );
-}
-
-function sameSnapshot(a: SupervisorSnapshot, b: SupervisorSnapshot): boolean {
-  return (
-    a.state === b.state &&
-    a.pid === b.pid &&
-    a.loaded === b.loaded &&
-    a.crashCount === b.crashCount &&
-    a.lastExit?.code === b.lastExit?.code &&
-    a.lastExit?.signal === b.lastExit?.signal &&
-    a.lastExit?.at === b.lastExit?.at
-  );
-}
-
-function wait(ms: number, signal: AbortSignal): Promise<void> {
-  if (signal.aborted) return Promise.resolve();
-  return new Promise((resolve) => {
-    let done = false;
-    const timer = setTimeout(finish, ms);
-    function finish() {
-      if (done) return;
-      done = true;
-      clearTimeout(timer);
-      signal.removeEventListener("abort", finish);
-      // oxlint-disable-next-line promise/no-multiple-resolved
-      resolve();
-    }
-    signal.addEventListener("abort", finish, { once: true });
-  });
-}
-
-function tailLines(path: string, limit: number): string[] {
-  if (!existsSync(path)) return [];
-  const fd = openSync(path, "r");
-  try {
-    const size = fstatSync(fd).size;
-    const length = Math.min(size, MAX_LOG_BYTES);
-    const buffer = Buffer.alloc(length);
-    readSync(fd, buffer, 0, length, size - length);
-    const text = buffer.toString("utf8");
-    const lines = text.split("\n").filter((line) => line.trim().length > 0);
-    return lines.slice(-limit);
-  } finally {
-    closeSync(fd);
-  }
-}
-/**
- * Manages the CLIProxyAPI core as a persistent per-user launchd job. The bb
- * plugin owns the definition and controls it, but does not own the process.
- * Aborting the monitor therefore never stops the core.
- */
-export class LaunchdSupervisor implements CoreSupervisor {
-  readonly manager = "launchd" as const;
-  private readonly options: Required<
-    Pick<
-      LaunchdSupervisorOptions,
-      "monitorIntervalMs" | "probeTimeoutMs" | "logLimit" | "platform" | "now"
-    >
-  > &
-    LaunchdSupervisorOptions;
-
-  private snapshotValue: SupervisorSnapshot = {
-    state: "stopped",
-    pid: null,
-    loaded: false,
-    crashCount: 0,
-    lastExit: null,
-  };
-  private lastExitSignature: string | null = null;
-
-  constructor(options: LaunchdSupervisorOptions) {
-    this.options = {
-      monitorIntervalMs: 2_000,
-      probeTimeoutMs: 500,
-      logLimit: 200,
-      platform: process.platform,
-      now: Date.now,
-      ...options,
-    };
-  }
-
-  get label(): string {
-    return this.options.label;
-  }
-
-  get definitionPath(): string {
-    return this.options.plistPath;
-  }
-
-  get serviceTarget(): string {
-    return `gui/${this.options.uid}/${this.options.label}`;
-  }
-
-  get domainTarget(): string {
-    return `gui/${this.options.uid}`;
-  }
-
-  definition(): string {
-    return renderLaunchAgentPlist(this.options);
-  }
-
-  logs(): string[] {
-    return tailLines(this.options.logPath, this.options.logLimit);
-  }
-
-  async snapshot(): Promise<SupervisorSnapshot> {
-    this.assertSupported();
-    if (!this.options.isInstalled()) {
-      return this.setSnapshot({
-        state: "not-installed",
-        pid: null,
-        loaded: false,
-        crashCount: 0,
-        lastExit: null,
-      });
-    }
-    const job = await this.inspectJob();
-    return this.setSnapshot(await this.snapshotFromJob(job));
-  }
-
-  async start(): Promise<SupervisorSnapshot> {
-    this.assertSupported();
-    if (!this.options.isInstalled()) return this.snapshot();
-
-    const definitionChanged = this.ensureDefinition();
-    await this.runChecked(["enable", this.serviceTarget]);
-    let job = await this.inspectJob();
-    if (job.loaded && definitionChanged) {
-      await this.bootout();
-      job = {
-        loaded: false,
-        state: null,
-        pid: null,
-        runs: 0,
-        lastExitCode: null,
-        lastSignal: null,
-      };
-    }
-    if (!job.loaded) {
-      await this.runChecked(["bootstrap", this.domainTarget, this.options.plistPath]);
-    } else if (job.pid === null || job.state !== "running") {
-      await this.runChecked(["kickstart", this.serviceTarget]);
-    }
-    return this.snapshot();
-  }
-
-  async stop(): Promise<SupervisorSnapshot> {
-    this.assertSupported();
-    this.setSnapshot({ ...this.snapshotValue, state: "stopping" });
-    await this.bootout();
-    await this.runChecked(["disable", this.serviceTarget]);
-    return this.setSnapshot({
-      ...this.snapshotValue,
-      state: this.options.isInstalled() ? "stopped" : "not-installed",
-      pid: null,
-      loaded: false,
-    });
-  }
-
-  async restart(): Promise<SupervisorSnapshot> {
-    this.assertSupported();
-    if (!this.options.isInstalled()) return this.snapshot();
-
-    const definitionChanged = this.ensureDefinition();
-    await this.runChecked(["enable", this.serviceTarget]);
-    const job = await this.inspectJob();
-    if (!job.loaded) {
-      await this.runChecked(["bootstrap", this.domainTarget, this.options.plistPath]);
-    } else if (definitionChanged) {
-      await this.bootout();
-      await this.runChecked(["bootstrap", this.domainTarget, this.options.plistPath]);
-    } else {
-      await this.runChecked(["kickstart", "-k", this.serviceTarget]);
-    }
-    return this.snapshot();
-  }
-
-  async monitor(signal: AbortSignal): Promise<void> {
-    while (!signal.aborted) {
-      try {
-        await this.snapshot();
-      } catch (error) {
-        this.options.onError?.(error);
-      }
-      await wait(this.options.monitorIntervalMs, signal);
-    }
-  }
-
-  private assertSupported(): void {
-    if (this.options.platform !== "darwin") {
-      throw new Error("agent-proxy persistent service requires macOS launchd");
-    }
-  }
-
-  private ensureDefinition(): boolean {
-    const content = this.definition();
-    if (readTextOr(this.options.plistPath) === content) return false;
-    ensureDir(dirname(this.options.plistPath));
-    ensureDir(dirname(this.options.logPath));
-    writeAtomic(this.options.plistPath, content, 0o644);
-    return true;
-  }
-
-  private async inspectJob(): Promise<LaunchdJobInfo> {
-    const result = await this.run(["print", this.serviceTarget]);
-    if (isMissingService(result)) {
-      return {
-        loaded: false,
-        state: null,
-        pid: null,
-        runs: 0,
-        lastExitCode: null,
-        lastSignal: null,
-      };
-    }
-    if (result.code !== 0) {
-      throw new Error(this.commandError(["print", this.serviceTarget], result));
-    }
-    return { loaded: true, ...parseLaunchctlPrint(result.stdout) };
-  }
-
-  private async snapshotFromJob(job: LaunchdJobInfo): Promise<SupervisorSnapshot> {
-    if (!job.loaded) {
-      return {
-        state: "stopped",
-        pid: null,
-        loaded: false,
-        crashCount: this.snapshotValue.crashCount,
-        lastExit: this.snapshotValue.lastExit,
-      };
-    }
-
-    const lastExit = this.exitInfo(job);
-    let state: CoreState;
-    if (job.state === "running" && job.pid !== null) {
-      state = (await this.probe()) ? "running" : "starting";
-    } else if (job.lastExitCode !== null && job.lastExitCode !== 0) {
-      state = "crashed";
-    } else {
-      state = "starting";
-    }
-    return {
-      state,
-      pid: job.pid,
-      loaded: true,
-      crashCount: Math.max(0, job.runs - 1),
-      lastExit,
-    };
-  }
-
-  private exitInfo(job: LaunchdJobInfo): ExitInfo | null {
-    if (job.lastExitCode === null && job.lastSignal === null) return null;
-    const signature = `${job.runs}:${job.lastExitCode ?? "null"}:${job.lastSignal ?? "null"}`;
-    if (signature !== this.lastExitSignature) {
-      this.lastExitSignature = signature;
-      return {
-        code: job.lastExitCode,
-        signal: job.lastSignal,
-        at: this.options.now(),
-      };
-    }
-    return this.snapshotValue.lastExit;
-  }
-
-  private async probe(): Promise<boolean> {
-    const fetchImpl = this.options.fetchImpl ?? fetch;
-    try {
-      await fetchImpl(this.options.probeUrl(), {
-        signal: AbortSignal.timeout(this.options.probeTimeoutMs),
-      });
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  private async bootout(): Promise<void> {
-    const result = await this.run(["bootout", this.serviceTarget]);
-    if (result.code !== 0 && !isMissingService(result)) {
-      throw new Error(this.commandError(["bootout", this.serviceTarget], result));
-    }
-  }
-
-  private async runChecked(args: string[]): Promise<CommandResult> {
-    const result = await this.run(args);
-    if (result.code !== 0) throw new Error(this.commandError(args, result));
-    return result;
-  }
-
-  private run(args: string[]): Promise<CommandResult> {
-    return (this.options.runCommand ?? defaultCommandRunner)(LAUNCHCTL, args);
-  }
-
-  private commandError(args: string[], result: CommandResult): string {
-    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`;
-    return `launchctl ${args.join(" ")} failed: ${detail}`;
-  }
-
-  private setSnapshot(snapshot: SupervisorSnapshot): SupervisorSnapshot {
-    if (!sameSnapshot(snapshot, this.snapshotValue)) {
-      this.snapshotValue = snapshot;
-      this.options.onChange?.(snapshot);
-    }
-    return this.snapshotValue;
-  }
 }
 
 export interface SystemdSupervisorOptions {
@@ -490,26 +60,30 @@ export interface SystemdSupervisorOptions {
   systemctlPath?: string;
 }
 
-interface SystemdJobInfo {
-  enabled: boolean;
-  activeState: string | null;
-  subState: string | null;
-  pid: number | null;
-  restarts: number;
-  exitStatus: number | null;
-  exitCode: number | null;
+function coreProgram(options: {
+  binPath: string;
+  configPath: string;
+  logPath: string;
+  probeUrl: () => string;
+}) {
+  return {
+    command: [options.binPath, "--config", options.configPath] as const,
+    workingDirectory: dirname(options.configPath),
+    logPath: options.logPath,
+    readinessUrl: options.probeUrl,
+  };
 }
 
-function systemdValue(value: string): string {
-  if (/\r|\n|\0/.test(value))
-    throw new Error("systemd service values cannot contain control characters");
-  return value.replaceAll("%", "%%");
-}
-
-// Quoting is only defined for command-line directives such as ExecStart=;
-// plain assignments like WorkingDirectory= take their value literally.
-function systemdQuote(value: string): string {
-  return `"${systemdValue(value).replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+export function renderLaunchAgentPlist(options: {
+  label: string;
+  binPath: string;
+  configPath: string;
+  logPath: string;
+}): string {
+  return renderPersistentLaunchAgentPlist({
+    label: options.label,
+    program: coreProgram({ ...options, probeUrl: () => "" }),
+  });
 }
 
 export function renderSystemdUserUnit(options: {
@@ -518,344 +92,28 @@ export function renderSystemdUserUnit(options: {
   configPath: string;
   logPath: string;
 }): string {
-  const command = [options.binPath, "--config", options.configPath].map(systemdQuote).join(" ");
-  const logTarget = systemdValue(`append:${options.logPath}`);
-  return `[Unit]
-Description=Agent Proxy (${options.label})
-After=network-online.target
-Wants=network-online.target
-
-[Service]
-Type=simple
-ExecStart=${command}
-WorkingDirectory=${systemdValue(dirname(options.configPath))}
-UMask=0077
-Restart=always
-RestartSec=2
-TimeoutStopSec=15
-StandardOutput=${logTarget}
-StandardError=${logTarget}
-
-[Install]
-WantedBy=default.target
-`;
+  return renderPersistentSystemdUserUnit({
+    label: options.label,
+    program: coreProgram({ ...options, probeUrl: () => "" }),
+  });
 }
 
-export function parseSystemctlShow(output: string): {
-  loadState: string | null;
-  activeState: string | null;
-  subState: string | null;
-  pid: number | null;
-  restarts: number;
-  exitStatus: number | null;
-  exitCode: number | null;
-} {
-  const values = new Map<string, string>();
-  for (const line of output.split("\n")) {
-    const separator = line.indexOf("=");
-    if (separator > 0) values.set(line.slice(0, separator), line.slice(separator + 1));
-  }
-  const integer = (name: string, zeroIsNull = false): number | null => {
-    const raw = values.get(name);
-    if (raw === undefined || !/^-?\d+$/.test(raw)) return null;
-    const parsed = Number.parseInt(raw, 10);
-    return zeroIsNull && parsed === 0 ? null : parsed;
-  };
-  return {
-    loadState: values.get("LoadState") ?? null,
-    activeState: values.get("ActiveState") ?? null,
-    subState: values.get("SubState") ?? null,
-    pid: integer("MainPID", true),
-    restarts: integer("NRestarts") ?? 0,
-    exitStatus: integer("ExecMainStatus"),
-    exitCode: integer("ExecMainCode"),
-  };
-}
-
-function isMissingSystemdUnit(result: CommandResult): boolean {
-  return (
-    result.code !== 0 &&
-    /unit .* (?:could not be found|not found|does not exist|not loaded)/i.test(
-      `${result.stdout}\n${result.stderr}`,
-    )
-  );
-}
-
-/** Manages a persistent per-user systemd service. Aborting the monitor leaves
-    the operating-system service running. */
-export class SystemdSupervisor implements CoreSupervisor {
-  readonly manager = "systemd" as const;
-  private readonly options: Required<
-    Pick<
-      SystemdSupervisorOptions,
-      "monitorIntervalMs" | "probeTimeoutMs" | "logLimit" | "platform" | "now" | "systemctlPath"
-    >
-  > &
-    SystemdSupervisorOptions;
-
-  private snapshotValue: SupervisorSnapshot = {
-    state: "stopped",
-    pid: null,
-    loaded: false,
-    crashCount: 0,
-    lastExit: null,
-  };
-  private lastExitSignature: string | null = null;
-
-  constructor(options: SystemdSupervisorOptions) {
-    this.options = {
-      monitorIntervalMs: 2_000,
-      probeTimeoutMs: 500,
-      logLimit: 200,
-      platform: process.platform,
-      now: Date.now,
-      systemctlPath: "systemctl",
-      ...options,
-    };
-  }
-
-  get label(): string {
-    return this.options.label;
-  }
-
-  get definitionPath(): string {
-    return this.options.unitPath;
-  }
-
-  get unitTarget(): string {
-    return `${this.options.label}.service`;
-  }
-
-  definition(): string {
-    return renderSystemdUserUnit(this.options);
-  }
-
-  logs(): string[] {
-    return tailLines(this.options.logPath, this.options.logLimit);
-  }
-
-  async snapshot(): Promise<SupervisorSnapshot> {
-    this.assertSupported();
-    if (!this.options.isInstalled()) {
-      return this.setSnapshot({
-        state: "not-installed",
-        pid: null,
-        loaded: false,
-        crashCount: 0,
-        lastExit: null,
-      });
-    }
-    const job = await this.inspectJob();
-    return this.setSnapshot(await this.snapshotFromJob(job));
-  }
-
-  async start(): Promise<SupervisorSnapshot> {
-    this.assertSupported();
-    if (!this.options.isInstalled()) return this.snapshot();
-
-    const definitionChanged = this.ensureDefinition();
-    await this.runChecked(["--user", "daemon-reload"]);
-    const job = await this.inspectJob();
-    await this.runChecked(["--user", "enable", this.unitTarget]);
-    if (job.activeState === "active") {
-      if (definitionChanged) {
-        await this.runChecked(["--user", "restart", this.unitTarget]);
-      }
-    } else {
-      await this.runChecked(["--user", "start", this.unitTarget]);
-    }
-    return this.snapshot();
-  }
-
-  async stop(): Promise<SupervisorSnapshot> {
-    this.assertSupported();
-    this.setSnapshot({ ...this.snapshotValue, state: "stopping" });
-    const result = await this.run(["--user", "disable", "--now", this.unitTarget]);
-    if (result.code !== 0 && !isMissingSystemdUnit(result)) {
-      throw new Error(this.commandError(["--user", "disable", "--now", this.unitTarget], result));
-    }
-    return this.setSnapshot({
-      ...this.snapshotValue,
-      state: this.options.isInstalled() ? "stopped" : "not-installed",
-      pid: null,
-      loaded: false,
+export class LaunchdSupervisor extends LaunchdPersistentService {
+  constructor(options: LaunchdSupervisorOptions) {
+    const { binPath, configPath, logPath, probeUrl, ...serviceOptions } = options;
+    super({
+      ...serviceOptions,
+      program: coreProgram({ binPath, configPath, logPath, probeUrl }),
     });
   }
+}
 
-  async restart(): Promise<SupervisorSnapshot> {
-    this.assertSupported();
-    if (!this.options.isInstalled()) return this.snapshot();
-
-    this.ensureDefinition();
-    await this.runChecked(["--user", "daemon-reload"]);
-    const job = await this.inspectJob();
-    await this.runChecked(["--user", "enable", this.unitTarget]);
-    await this.runChecked([
-      "--user",
-      job.activeState === "active" ? "restart" : "start",
-      this.unitTarget,
-    ]);
-    return this.snapshot();
-  }
-
-  async monitor(signal: AbortSignal): Promise<void> {
-    while (!signal.aborted) {
-      try {
-        await this.snapshot();
-      } catch (error) {
-        this.options.onError?.(error);
-      }
-      await wait(this.options.monitorIntervalMs, signal);
-    }
-  }
-
-  private assertSupported(): void {
-    if (this.options.platform !== "linux") {
-      throw new Error("agent-proxy systemd service requires Linux");
-    }
-  }
-
-  private ensureDefinition(): boolean {
-    const content = this.definition();
-    if (readTextOr(this.options.unitPath) === content) return false;
-    ensureDir(dirname(this.options.unitPath));
-    ensureDir(dirname(this.options.logPath));
-    writeAtomic(this.options.unitPath, content, 0o644);
-    return true;
-  }
-
-  private async inspectJob(): Promise<SystemdJobInfo> {
-    const properties = [
-      "LoadState",
-      "ActiveState",
-      "SubState",
-      "MainPID",
-      "NRestarts",
-      "ExecMainStatus",
-      "ExecMainCode",
-    ].join(",");
-    const result = await this.run([
-      "--user",
-      "show",
-      this.unitTarget,
-      `--property=${properties}`,
-      "--no-pager",
-    ]);
-    if (isMissingSystemdUnit(result)) return this.emptyJob();
-    if (result.code !== 0) {
-      throw new Error(
-        this.commandError(
-          ["--user", "show", this.unitTarget, `--property=${properties}`, "--no-pager"],
-          result,
-        ),
-      );
-    }
-    const parsed = parseSystemctlShow(result.stdout);
-    if (parsed.loadState === "not-found") return this.emptyJob();
-    const enabledResult = await this.run(["--user", "is-enabled", this.unitTarget]);
-    const enabled =
-      enabledResult.code === 0 &&
-      /^(?:enabled|enabled-runtime|linked)/i.test(enabledResult.stdout.trim());
-    return {
-      enabled,
-      activeState: parsed.activeState,
-      subState: parsed.subState,
-      pid: parsed.pid,
-      restarts: parsed.restarts,
-      exitStatus: parsed.exitStatus,
-      exitCode: parsed.exitCode,
-    };
-  }
-
-  private emptyJob(): SystemdJobInfo {
-    return {
-      enabled: false,
-      activeState: null,
-      subState: null,
-      pid: null,
-      restarts: 0,
-      exitStatus: null,
-      exitCode: null,
-    };
-  }
-
-  private async snapshotFromJob(job: SystemdJobInfo): Promise<SupervisorSnapshot> {
-    const loaded =
-      job.enabled ||
-      job.activeState === "active" ||
-      job.activeState === "activating" ||
-      job.activeState === "deactivating";
-    let state: CoreState;
-    if (job.activeState === "active") {
-      state = (await this.probe()) ? "running" : "starting";
-    } else if (job.activeState === "activating") {
-      state = "starting";
-    } else if (job.activeState === "deactivating") {
-      state = "stopping";
-    } else if (job.activeState === "failed") {
-      state = "crashed";
-    } else {
-      state = "stopped";
-    }
-    return {
-      state,
-      pid: job.pid,
-      loaded,
-      crashCount: Math.max(0, job.restarts),
-      lastExit: this.exitInfo(job),
-    };
-  }
-
-  private exitInfo(job: SystemdJobInfo): ExitInfo | null {
-    const exited = job.exitCode === 1;
-    const killed = job.exitCode === 2 || job.exitCode === 3;
-    if ((job.exitStatus === null || job.exitStatus === 0) && !killed) {
-      return null;
-    }
-    const signature = `${job.restarts}:${job.exitCode ?? "null"}:${job.exitStatus ?? "null"}`;
-    if (signature !== this.lastExitSignature) {
-      this.lastExitSignature = signature;
-      return {
-        code: exited ? job.exitStatus : null,
-        signal: killed ? String(job.exitStatus ?? "unknown") : null,
-        at: this.options.now(),
-      };
-    }
-    return this.snapshotValue.lastExit;
-  }
-
-  private async probe(): Promise<boolean> {
-    const fetchImpl = this.options.fetchImpl ?? fetch;
-    try {
-      await fetchImpl(this.options.probeUrl(), {
-        signal: AbortSignal.timeout(this.options.probeTimeoutMs),
-      });
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  private async runChecked(args: string[]): Promise<CommandResult> {
-    const result = await this.run(args);
-    if (result.code !== 0) throw new Error(this.commandError(args, result));
-    return result;
-  }
-
-  private run(args: string[]): Promise<CommandResult> {
-    return (this.options.runCommand ?? defaultCommandRunner)(this.options.systemctlPath, args);
-  }
-
-  private commandError(args: string[], result: CommandResult): string {
-    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`;
-    return `systemctl ${args.join(" ")} failed: ${detail}`;
-  }
-
-  private setSnapshot(snapshot: SupervisorSnapshot): SupervisorSnapshot {
-    if (!sameSnapshot(snapshot, this.snapshotValue)) {
-      this.snapshotValue = snapshot;
-      this.options.onChange?.(snapshot);
-    }
-    return this.snapshotValue;
+export class SystemdSupervisor extends SystemdPersistentService {
+  constructor(options: SystemdSupervisorOptions) {
+    const { binPath, configPath, logPath, probeUrl, ...serviceOptions } = options;
+    super({
+      ...serviceOptions,
+      program: coreProgram({ binPath, configPath, logPath, probeUrl }),
+    });
   }
 }

--- a/plugins/agent-proxy/lib/keys.ts
+++ b/plugins/agent-proxy/lib/keys.ts
@@ -5,9 +5,7 @@ export function generateKey(): string {
   return randomBytes(32).toString("base64url");
 }
 
-/** Settings have no programmatic write in the plugin SDK, so generated secrets
-    live in 0600 files under the plugin data dir; the secret setting (when set)
-    overrides the file. */
+/** Generated secrets live in 0600 files under the plugin data directory. */
 export function loadOrCreateKey(path: string): string {
   const existing = readTextOr(path)?.trim();
   if (existing) return existing;

--- a/plugins/agent-proxy/lib/paths.ts
+++ b/plugins/agent-proxy/lib/paths.ts
@@ -24,6 +24,7 @@ export interface Paths {
   tunnelRuntimeDir: string;
   secretsDir: string;
   managementKeyPath: string;
+  managementKeyOverridePath: string;
   localApiKeyPath: string;
   backupsDir: string;
   agentsDir: string;
@@ -66,6 +67,7 @@ export function buildPaths(dataDir: string): Paths {
     tunnelRuntimeDir: join(tunnelDir, "runtime"),
     secretsDir,
     managementKeyPath: join(secretsDir, "management-key"),
+    managementKeyOverridePath: join(secretsDir, "management-key-override"),
     localApiKeyPath: join(secretsDir, "local-api-key"),
     backupsDir: join(root, "backups"),
     agentsDir,

--- a/plugins/agent-proxy/lib/paths.ts
+++ b/plugins/agent-proxy/lib/paths.ts
@@ -17,6 +17,11 @@ export interface Paths {
   serviceDir: string;
   serviceLogPath: string;
   runtimeFingerprintPath: string;
+  tunnelDir: string;
+  tunnelConfigPath: string;
+  tunnelObservationPath: string;
+  tunnelLogPath: string;
+  tunnelRuntimeDir: string;
   secretsDir: string;
   managementKeyPath: string;
   localApiKeyPath: string;
@@ -35,6 +40,7 @@ export function buildPaths(dataDir: string): Paths {
   const currentLink = join(binDir, "current");
   const coreExecutable = "cli-proxy-api";
   const serviceDir = join(coreDir, "service");
+  const tunnelDir = join(root, "cloudflare-tunnel");
   const secretsDir = join(coreDir, "secrets");
   const agentsDir = join(root, "agents");
   const codexHomeDir = join(agentsDir, "codex-home");
@@ -53,6 +59,11 @@ export function buildPaths(dataDir: string): Paths {
     serviceDir,
     serviceLogPath: join(serviceDir, "core.log"),
     runtimeFingerprintPath: join(serviceDir, "runtime-fingerprint"),
+    tunnelDir,
+    tunnelConfigPath: join(tunnelDir, "desired.json"),
+    tunnelObservationPath: join(tunnelDir, "observation.json"),
+    tunnelLogPath: join(tunnelDir, "tunnel.log"),
+    tunnelRuntimeDir: join(tunnelDir, "runtime"),
     secretsDir,
     managementKeyPath: join(secretsDir, "management-key"),
     localApiKeyPath: join(secretsDir, "local-api-key"),

--- a/plugins/agent-proxy/lib/persistent-service.ts
+++ b/plugins/agent-proxy/lib/persistent-service.ts
@@ -338,7 +338,7 @@ export class LaunchdPersistentService implements PersistentService {
     return this.commitObservation(token, () => this.snapshotFromJob(job, ready));
   }
 
-  start(): Promise<ServiceSnapshot> {
+  async start(): Promise<ServiceSnapshot> {
     this.assertSupported();
     return this.operations.lifecycle(() => this.startLifecycle());
   }
@@ -368,7 +368,7 @@ export class LaunchdPersistentService implements PersistentService {
     return this.observe(null);
   }
 
-  stop(): Promise<ServiceSnapshot> {
+  async stop(): Promise<ServiceSnapshot> {
     this.assertSupported();
     return this.operations.lifecycle(() => this.stopLifecycle());
   }
@@ -388,7 +388,7 @@ export class LaunchdPersistentService implements PersistentService {
     });
   }
 
-  restart(): Promise<ServiceSnapshot> {
+  async restart(): Promise<ServiceSnapshot> {
     this.assertSupported();
     return this.operations.lifecycle(() => this.restartLifecycle());
   }
@@ -732,7 +732,7 @@ export class SystemdPersistentService implements PersistentService {
     return this.commitObservation(token, () => this.snapshotFromJob(job, ready));
   }
 
-  start(): Promise<ServiceSnapshot> {
+  async start(): Promise<ServiceSnapshot> {
     this.assertSupported();
     return this.operations.lifecycle(() => this.startLifecycle());
   }
@@ -754,7 +754,7 @@ export class SystemdPersistentService implements PersistentService {
     return this.observe(null);
   }
 
-  stop(): Promise<ServiceSnapshot> {
+  async stop(): Promise<ServiceSnapshot> {
     this.assertSupported();
     return this.operations.lifecycle(() => this.stopLifecycle());
   }
@@ -773,7 +773,7 @@ export class SystemdPersistentService implements PersistentService {
     });
   }
 
-  restart(): Promise<ServiceSnapshot> {
+  async restart(): Promise<ServiceSnapshot> {
     this.assertSupported();
     return this.operations.lifecycle(() => this.restartLifecycle());
   }

--- a/plugins/agent-proxy/lib/persistent-service.ts
+++ b/plugins/agent-proxy/lib/persistent-service.ts
@@ -1,0 +1,876 @@
+import { execFile } from "node:child_process";
+import { closeSync, existsSync, fstatSync, openSync, readSync } from "node:fs";
+import { dirname } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { ensureDir, readTextOr, writeAtomic } from "./fsx.ts";
+
+export type ServiceState =
+  | "not-installed"
+  | "stopped"
+  | "starting"
+  | "running"
+  | "stopping"
+  | "crashed";
+
+export interface ExitInfo {
+  code: number | null;
+  signal: string | null;
+  at: number;
+}
+export interface ServiceSnapshot {
+  state: ServiceState;
+  pid: number | null;
+  loaded: boolean;
+  crashCount: number;
+  lastExit: ExitInfo | null;
+}
+
+export type ServiceManager = "launchd" | "systemd";
+
+export interface PersistentService {
+  readonly manager: ServiceManager;
+  readonly label: string;
+  readonly definitionPath: string;
+  logs(): string[];
+  snapshot(): Promise<ServiceSnapshot>;
+  start(): Promise<ServiceSnapshot>;
+  stop(): Promise<ServiceSnapshot>;
+  restart(): Promise<ServiceSnapshot>;
+  monitor(signal: AbortSignal): Promise<void>;
+}
+
+export interface CommandResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type CommandRunner = (file: string, args: string[]) => Promise<CommandResult>;
+
+export interface ManagedProgramSpec {
+  command: readonly [file: string, ...args: string[]];
+  environment?: Readonly<Record<string, string>>;
+  workingDirectory: string;
+  logPath: string;
+  readinessUrl: () => string;
+}
+
+export interface LaunchdServiceOptions {
+  label: string;
+  uid: number;
+  plistPath: string;
+  program: ManagedProgramSpec;
+  isInstalled: () => boolean;
+  onChange?: (snapshot: ServiceSnapshot) => void;
+  onError?: (error: unknown) => void;
+  runCommand?: CommandRunner;
+  fetchImpl?: typeof fetch;
+  monitorIntervalMs?: number;
+  probeTimeoutMs?: number;
+  logLimit?: number;
+  platform?: NodeJS.Platform;
+  now?: () => number;
+}
+
+interface LaunchdJobInfo {
+  loaded: boolean;
+  state: string | null;
+  pid: number | null;
+  runs: number;
+  lastExitCode: number | null;
+  lastSignal: string | null;
+}
+
+const LAUNCHCTL = "/bin/launchctl";
+const MAX_LOG_BYTES = 256 * 1024;
+
+function defaultCommandRunner(file: string, args: string[]): Promise<CommandResult> {
+  return new Promise((resolve) => {
+    execFile(file, args, { encoding: "utf8" }, (error, stdout, stderr) => {
+      const rawCode = (error as NodeJS.ErrnoException | null)?.code;
+      resolve({
+        code: typeof rawCode === "number" ? rawCode : error ? 1 : 0,
+        stdout: String(stdout ?? ""),
+        stderr: String(stderr ?? error?.message ?? ""),
+      });
+    });
+  });
+}
+
+function xmlEscape(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function environmentEntries(program: ManagedProgramSpec): [string, string][] {
+  return Object.entries(program.environment ?? {})
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, value]) => {
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+        throw new Error(`invalid service environment variable name: ${name}`);
+      }
+      return [name, value];
+    });
+}
+
+export function renderLaunchAgentPlist(options: {
+  label: string;
+  program: ManagedProgramSpec;
+}): string {
+  const label = xmlEscape(options.label);
+  const command = options.program.command.map((value) => xmlEscape(value));
+  const environment = environmentEntries(options.program);
+  const logPath = xmlEscape(options.program.logPath);
+  const workingDirectory = xmlEscape(options.program.workingDirectory);
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${label}</string>
+  <key>ProgramArguments</key>
+  <array>
+${command.map((value) => `    <string>${value}</string>`).join("\n")}
+  </array>
+${
+  environment.length === 0
+    ? ""
+    : `  <key>EnvironmentVariables</key>
+  <dict>
+${environment
+  .map(
+    ([name, value]) =>
+      `    <key>${xmlEscape(name)}</key>\n    <string>${xmlEscape(value)}</string>`,
+  )
+  .join("\n")}
+  </dict>
+`
+}  <key>WorkingDirectory</key>
+  <string>${workingDirectory}</string>
+  <key>KeepAlive</key>
+  <true/>
+  <key>Umask</key>
+  <integer>63</integer>
+  <key>StandardOutPath</key>
+  <string>${logPath}</string>
+  <key>StandardErrorPath</key>
+  <string>${logPath}</string>
+</dict>
+</plist>
+`;
+}
+
+export function parseLaunchctlPrint(output: string): Omit<LaunchdJobInfo, "loaded"> {
+  const value = (name: string) =>
+    output.match(new RegExp(`^\\s*${name} = (.+)$`, "m"))?.[1]?.trim() ?? null;
+  const integer = (name: string) => {
+    const raw = value(name);
+    if (raw === null || !/^-?\d+$/.test(raw)) return null;
+    return Number.parseInt(raw, 10);
+  };
+  return {
+    state: value("state"),
+    pid: integer("pid"),
+    runs: integer("runs") ?? 0,
+    lastExitCode: integer("last exit code"),
+    lastSignal: value("last terminating signal"),
+  };
+}
+
+function isMissingService(result: CommandResult): boolean {
+  return (
+    result.code !== 0 &&
+    /could not find service|service cannot be found|no such process|bad request/i.test(
+      `${result.stdout}\n${result.stderr}`,
+    )
+  );
+}
+
+function sameSnapshot(a: ServiceSnapshot, b: ServiceSnapshot): boolean {
+  return (
+    a.state === b.state &&
+    a.pid === b.pid &&
+    a.loaded === b.loaded &&
+    a.crashCount === b.crashCount &&
+    a.lastExit?.code === b.lastExit?.code &&
+    a.lastExit?.signal === b.lastExit?.signal &&
+    a.lastExit?.at === b.lastExit?.at
+  );
+}
+
+async function wait(ms: number, signal: AbortSignal): Promise<void> {
+  try {
+    await delay(ms, undefined, { signal });
+  } catch (error) {
+    if (!signal.aborted) throw error;
+  }
+}
+
+function tailLines(path: string, limit: number): string[] {
+  if (!existsSync(path)) return [];
+  const fd = openSync(path, "r");
+  try {
+    const size = fstatSync(fd).size;
+    const length = Math.min(size, MAX_LOG_BYTES);
+    const buffer = Buffer.alloc(length);
+    readSync(fd, buffer, 0, length, size - length);
+    const text = buffer.toString("utf8");
+    const lines = text.split("\n").filter((line) => line.trim().length > 0);
+    return lines.slice(-limit);
+  } finally {
+    closeSync(fd);
+  }
+}
+/**
+ * Manages a persistent per-user launchd job. The caller owns the definition
+ * and controls the job, but does not own the process. Aborting the monitor
+ * therefore never stops the managed program.
+ */
+export class LaunchdPersistentService implements PersistentService {
+  readonly manager = "launchd" as const;
+  private readonly options: Required<
+    Pick<
+      LaunchdServiceOptions,
+      "monitorIntervalMs" | "probeTimeoutMs" | "logLimit" | "platform" | "now"
+    >
+  > &
+    LaunchdServiceOptions;
+
+  private snapshotValue: ServiceSnapshot = {
+    state: "stopped",
+    pid: null,
+    loaded: false,
+    crashCount: 0,
+    lastExit: null,
+  };
+  private lastExitSignature: string | null = null;
+
+  constructor(options: LaunchdServiceOptions) {
+    this.options = {
+      monitorIntervalMs: 2_000,
+      probeTimeoutMs: 500,
+      logLimit: 200,
+      platform: process.platform,
+      now: Date.now,
+      ...options,
+    };
+  }
+
+  get label(): string {
+    return this.options.label;
+  }
+
+  get definitionPath(): string {
+    return this.options.plistPath;
+  }
+
+  get serviceTarget(): string {
+    return `gui/${this.options.uid}/${this.options.label}`;
+  }
+
+  get domainTarget(): string {
+    return `gui/${this.options.uid}`;
+  }
+
+  definition(): string {
+    return renderLaunchAgentPlist(this.options);
+  }
+
+  logs(): string[] {
+    return tailLines(this.options.program.logPath, this.options.logLimit);
+  }
+
+  async snapshot(): Promise<ServiceSnapshot> {
+    this.assertSupported();
+    if (!this.options.isInstalled()) {
+      return this.setSnapshot({
+        state: "not-installed",
+        pid: null,
+        loaded: false,
+        crashCount: 0,
+        lastExit: null,
+      });
+    }
+    const job = await this.inspectJob();
+    return this.setSnapshot(await this.snapshotFromJob(job));
+  }
+
+  async start(): Promise<ServiceSnapshot> {
+    this.assertSupported();
+    if (!this.options.isInstalled()) return this.snapshot();
+
+    const definitionChanged = this.ensureDefinition();
+    await this.runChecked(["enable", this.serviceTarget]);
+    let job = await this.inspectJob();
+    if (job.loaded && definitionChanged) {
+      await this.bootout();
+      job = {
+        loaded: false,
+        state: null,
+        pid: null,
+        runs: 0,
+        lastExitCode: null,
+        lastSignal: null,
+      };
+    }
+    if (!job.loaded) {
+      await this.runChecked(["bootstrap", this.domainTarget, this.options.plistPath]);
+    } else if (job.pid === null || job.state !== "running") {
+      await this.runChecked(["kickstart", this.serviceTarget]);
+    }
+    return this.snapshot();
+  }
+
+  async stop(): Promise<ServiceSnapshot> {
+    this.assertSupported();
+    this.setSnapshot({ ...this.snapshotValue, state: "stopping" });
+    await this.bootout();
+    await this.runChecked(["disable", this.serviceTarget]);
+    return this.setSnapshot({
+      ...this.snapshotValue,
+      state: this.options.isInstalled() ? "stopped" : "not-installed",
+      pid: null,
+      loaded: false,
+    });
+  }
+
+  async restart(): Promise<ServiceSnapshot> {
+    this.assertSupported();
+    if (!this.options.isInstalled()) return this.snapshot();
+
+    const definitionChanged = this.ensureDefinition();
+    await this.runChecked(["enable", this.serviceTarget]);
+    const job = await this.inspectJob();
+    if (!job.loaded) {
+      await this.runChecked(["bootstrap", this.domainTarget, this.options.plistPath]);
+    } else if (definitionChanged) {
+      await this.bootout();
+      await this.runChecked(["bootstrap", this.domainTarget, this.options.plistPath]);
+    } else {
+      await this.runChecked(["kickstart", "-k", this.serviceTarget]);
+    }
+    return this.snapshot();
+  }
+
+  async monitor(signal: AbortSignal): Promise<void> {
+    while (!signal.aborted) {
+      try {
+        await this.snapshot();
+      } catch (error) {
+        this.options.onError?.(error);
+      }
+      await wait(this.options.monitorIntervalMs, signal);
+    }
+  }
+
+  private assertSupported(): void {
+    if (this.options.platform !== "darwin") {
+      throw new Error("persistent service requires macOS launchd");
+    }
+  }
+
+  private ensureDefinition(): boolean {
+    const content = this.definition();
+    if (readTextOr(this.options.plistPath) === content) return false;
+    ensureDir(dirname(this.options.plistPath));
+    ensureDir(dirname(this.options.program.logPath));
+    writeAtomic(this.options.plistPath, content, 0o644);
+    return true;
+  }
+
+  private async inspectJob(): Promise<LaunchdJobInfo> {
+    const result = await this.run(["print", this.serviceTarget]);
+    if (isMissingService(result)) {
+      return {
+        loaded: false,
+        state: null,
+        pid: null,
+        runs: 0,
+        lastExitCode: null,
+        lastSignal: null,
+      };
+    }
+    if (result.code !== 0) {
+      throw new Error(this.commandError(["print", this.serviceTarget], result));
+    }
+    return { loaded: true, ...parseLaunchctlPrint(result.stdout) };
+  }
+
+  private async snapshotFromJob(job: LaunchdJobInfo): Promise<ServiceSnapshot> {
+    if (!job.loaded) {
+      return {
+        state: "stopped",
+        pid: null,
+        loaded: false,
+        crashCount: this.snapshotValue.crashCount,
+        lastExit: this.snapshotValue.lastExit,
+      };
+    }
+
+    const lastExit = this.exitInfo(job);
+    let state: ServiceState;
+    if (job.state === "running" && job.pid !== null) {
+      state = (await this.probe()) ? "running" : "starting";
+    } else if (job.lastExitCode !== null && job.lastExitCode !== 0) {
+      state = "crashed";
+    } else {
+      state = "starting";
+    }
+    return {
+      state,
+      pid: job.pid,
+      loaded: true,
+      crashCount: Math.max(0, job.runs - 1),
+      lastExit,
+    };
+  }
+
+  private exitInfo(job: LaunchdJobInfo): ExitInfo | null {
+    if (job.lastExitCode === null && job.lastSignal === null) return null;
+    const signature = `${job.runs}:${job.lastExitCode ?? "null"}:${job.lastSignal ?? "null"}`;
+    if (signature !== this.lastExitSignature) {
+      this.lastExitSignature = signature;
+      return {
+        code: job.lastExitCode,
+        signal: job.lastSignal,
+        at: this.options.now(),
+      };
+    }
+    return this.snapshotValue.lastExit;
+  }
+
+  private async probe(): Promise<boolean> {
+    const fetchImpl = this.options.fetchImpl ?? fetch;
+    try {
+      await fetchImpl(this.options.program.readinessUrl(), {
+        signal: AbortSignal.timeout(this.options.probeTimeoutMs),
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async bootout(): Promise<void> {
+    const result = await this.run(["bootout", this.serviceTarget]);
+    if (result.code !== 0 && !isMissingService(result)) {
+      throw new Error(this.commandError(["bootout", this.serviceTarget], result));
+    }
+  }
+
+  private async runChecked(args: string[]): Promise<CommandResult> {
+    const result = await this.run(args);
+    if (result.code !== 0) throw new Error(this.commandError(args, result));
+    return result;
+  }
+
+  private run(args: string[]): Promise<CommandResult> {
+    return (this.options.runCommand ?? defaultCommandRunner)(LAUNCHCTL, args);
+  }
+
+  private commandError(args: string[], result: CommandResult): string {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`;
+    return `launchctl ${args.join(" ")} failed: ${detail}`;
+  }
+
+  private setSnapshot(snapshot: ServiceSnapshot): ServiceSnapshot {
+    if (!sameSnapshot(snapshot, this.snapshotValue)) {
+      this.snapshotValue = snapshot;
+      this.options.onChange?.(snapshot);
+    }
+    return this.snapshotValue;
+  }
+}
+
+export interface SystemdServiceOptions {
+  label: string;
+  unitPath: string;
+  program: ManagedProgramSpec;
+  isInstalled: () => boolean;
+  onChange?: (snapshot: ServiceSnapshot) => void;
+  onError?: (error: unknown) => void;
+  runCommand?: CommandRunner;
+  fetchImpl?: typeof fetch;
+  monitorIntervalMs?: number;
+  probeTimeoutMs?: number;
+  logLimit?: number;
+  platform?: NodeJS.Platform;
+  now?: () => number;
+  systemctlPath?: string;
+}
+
+interface SystemdJobInfo {
+  enabled: boolean;
+  activeState: string | null;
+  subState: string | null;
+  pid: number | null;
+  restarts: number;
+  exitStatus: number | null;
+  exitCode: number | null;
+}
+
+function systemdValue(value: string): string {
+  if (/\r|\n|\0/.test(value))
+    throw new Error("systemd service values cannot contain control characters");
+  return value.replaceAll("%", "%%");
+}
+
+// Quoting is only defined for command-line directives such as ExecStart=;
+// plain assignments like WorkingDirectory= take their value literally.
+function systemdQuote(value: string): string {
+  return `"${systemdValue(value).replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+}
+
+export function renderSystemdUserUnit(options: {
+  label: string;
+  program: ManagedProgramSpec;
+}): string {
+  const command = options.program.command.map(systemdQuote).join(" ");
+  const environment = environmentEntries(options.program)
+    .map(([name, value]) => `Environment=${systemdQuote(`${name}=${value}`)}`)
+    .join("\n");
+  const logTarget = systemdValue(`append:${options.program.logPath}`);
+  return `[Unit]
+Description=Agent Proxy (${options.label})
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+${environment === "" ? "" : `${environment}\n`}
+ExecStart=${command}
+WorkingDirectory=${systemdValue(options.program.workingDirectory)}
+UMask=0077
+Restart=always
+RestartSec=2
+TimeoutStopSec=15
+StandardOutput=${logTarget}
+StandardError=${logTarget}
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+export function parseSystemctlShow(output: string): {
+  loadState: string | null;
+  activeState: string | null;
+  subState: string | null;
+  pid: number | null;
+  restarts: number;
+  exitStatus: number | null;
+  exitCode: number | null;
+} {
+  const values = new Map<string, string>();
+  for (const line of output.split("\n")) {
+    const separator = line.indexOf("=");
+    if (separator > 0) values.set(line.slice(0, separator), line.slice(separator + 1));
+  }
+  const integer = (name: string, zeroIsNull = false): number | null => {
+    const raw = values.get(name);
+    if (raw === undefined || !/^-?\d+$/.test(raw)) return null;
+    const parsed = Number.parseInt(raw, 10);
+    return zeroIsNull && parsed === 0 ? null : parsed;
+  };
+  return {
+    loadState: values.get("LoadState") ?? null,
+    activeState: values.get("ActiveState") ?? null,
+    subState: values.get("SubState") ?? null,
+    pid: integer("MainPID", true),
+    restarts: integer("NRestarts") ?? 0,
+    exitStatus: integer("ExecMainStatus"),
+    exitCode: integer("ExecMainCode"),
+  };
+}
+
+function isMissingSystemdUnit(result: CommandResult): boolean {
+  return (
+    result.code !== 0 &&
+    /unit .* (?:could not be found|not found|does not exist|not loaded)/i.test(
+      `${result.stdout}\n${result.stderr}`,
+    )
+  );
+}
+
+/** Manages a persistent per-user systemd service. Aborting the monitor leaves
+    the operating-system service running. */
+export class SystemdPersistentService implements PersistentService {
+  readonly manager = "systemd" as const;
+  private readonly options: Required<
+    Pick<
+      SystemdServiceOptions,
+      "monitorIntervalMs" | "probeTimeoutMs" | "logLimit" | "platform" | "now" | "systemctlPath"
+    >
+  > &
+    SystemdServiceOptions;
+
+  private snapshotValue: ServiceSnapshot = {
+    state: "stopped",
+    pid: null,
+    loaded: false,
+    crashCount: 0,
+    lastExit: null,
+  };
+  private lastExitSignature: string | null = null;
+
+  constructor(options: SystemdServiceOptions) {
+    this.options = {
+      monitorIntervalMs: 2_000,
+      probeTimeoutMs: 500,
+      logLimit: 200,
+      platform: process.platform,
+      now: Date.now,
+      systemctlPath: "systemctl",
+      ...options,
+    };
+  }
+
+  get label(): string {
+    return this.options.label;
+  }
+
+  get definitionPath(): string {
+    return this.options.unitPath;
+  }
+
+  get unitTarget(): string {
+    return `${this.options.label}.service`;
+  }
+
+  definition(): string {
+    return renderSystemdUserUnit(this.options);
+  }
+
+  logs(): string[] {
+    return tailLines(this.options.program.logPath, this.options.logLimit);
+  }
+
+  async snapshot(): Promise<ServiceSnapshot> {
+    this.assertSupported();
+    if (!this.options.isInstalled()) {
+      return this.setSnapshot({
+        state: "not-installed",
+        pid: null,
+        loaded: false,
+        crashCount: 0,
+        lastExit: null,
+      });
+    }
+    const job = await this.inspectJob();
+    return this.setSnapshot(await this.snapshotFromJob(job));
+  }
+
+  async start(): Promise<ServiceSnapshot> {
+    this.assertSupported();
+    if (!this.options.isInstalled()) return this.snapshot();
+
+    const definitionChanged = this.ensureDefinition();
+    await this.runChecked(["--user", "daemon-reload"]);
+    const job = await this.inspectJob();
+    await this.runChecked(["--user", "enable", this.unitTarget]);
+    if (job.activeState === "active") {
+      if (definitionChanged) {
+        await this.runChecked(["--user", "restart", this.unitTarget]);
+      }
+    } else {
+      await this.runChecked(["--user", "start", this.unitTarget]);
+    }
+    return this.snapshot();
+  }
+
+  async stop(): Promise<ServiceSnapshot> {
+    this.assertSupported();
+    this.setSnapshot({ ...this.snapshotValue, state: "stopping" });
+    const result = await this.run(["--user", "disable", "--now", this.unitTarget]);
+    if (result.code !== 0 && !isMissingSystemdUnit(result)) {
+      throw new Error(this.commandError(["--user", "disable", "--now", this.unitTarget], result));
+    }
+    return this.setSnapshot({
+      ...this.snapshotValue,
+      state: this.options.isInstalled() ? "stopped" : "not-installed",
+      pid: null,
+      loaded: false,
+    });
+  }
+
+  async restart(): Promise<ServiceSnapshot> {
+    this.assertSupported();
+    if (!this.options.isInstalled()) return this.snapshot();
+
+    this.ensureDefinition();
+    await this.runChecked(["--user", "daemon-reload"]);
+    const job = await this.inspectJob();
+    await this.runChecked(["--user", "enable", this.unitTarget]);
+    await this.runChecked([
+      "--user",
+      job.activeState === "active" ? "restart" : "start",
+      this.unitTarget,
+    ]);
+    return this.snapshot();
+  }
+
+  async monitor(signal: AbortSignal): Promise<void> {
+    while (!signal.aborted) {
+      try {
+        await this.snapshot();
+      } catch (error) {
+        this.options.onError?.(error);
+      }
+      await wait(this.options.monitorIntervalMs, signal);
+    }
+  }
+
+  private assertSupported(): void {
+    if (this.options.platform !== "linux") {
+      throw new Error("persistent service requires Linux systemd");
+    }
+  }
+
+  private ensureDefinition(): boolean {
+    const content = this.definition();
+    if (readTextOr(this.options.unitPath) === content) return false;
+    ensureDir(dirname(this.options.unitPath));
+    ensureDir(dirname(this.options.program.logPath));
+    writeAtomic(this.options.unitPath, content, 0o644);
+    return true;
+  }
+
+  private async inspectJob(): Promise<SystemdJobInfo> {
+    const properties = [
+      "LoadState",
+      "ActiveState",
+      "SubState",
+      "MainPID",
+      "NRestarts",
+      "ExecMainStatus",
+      "ExecMainCode",
+    ].join(",");
+    const result = await this.run([
+      "--user",
+      "show",
+      this.unitTarget,
+      `--property=${properties}`,
+      "--no-pager",
+    ]);
+    if (isMissingSystemdUnit(result)) return this.emptyJob();
+    if (result.code !== 0) {
+      throw new Error(
+        this.commandError(
+          ["--user", "show", this.unitTarget, `--property=${properties}`, "--no-pager"],
+          result,
+        ),
+      );
+    }
+    const parsed = parseSystemctlShow(result.stdout);
+    if (parsed.loadState === "not-found") return this.emptyJob();
+    const enabledResult = await this.run(["--user", "is-enabled", this.unitTarget]);
+    const enabled =
+      enabledResult.code === 0 &&
+      /^(?:enabled|enabled-runtime|linked)/i.test(enabledResult.stdout.trim());
+    return {
+      enabled,
+      activeState: parsed.activeState,
+      subState: parsed.subState,
+      pid: parsed.pid,
+      restarts: parsed.restarts,
+      exitStatus: parsed.exitStatus,
+      exitCode: parsed.exitCode,
+    };
+  }
+
+  private emptyJob(): SystemdJobInfo {
+    return {
+      enabled: false,
+      activeState: null,
+      subState: null,
+      pid: null,
+      restarts: 0,
+      exitStatus: null,
+      exitCode: null,
+    };
+  }
+
+  private async snapshotFromJob(job: SystemdJobInfo): Promise<ServiceSnapshot> {
+    const loaded =
+      job.enabled ||
+      job.activeState === "active" ||
+      job.activeState === "activating" ||
+      job.activeState === "deactivating";
+    let state: ServiceState;
+    if (job.activeState === "active") {
+      state = (await this.probe()) ? "running" : "starting";
+    } else if (job.activeState === "activating") {
+      state = "starting";
+    } else if (job.activeState === "deactivating") {
+      state = "stopping";
+    } else if (job.activeState === "failed") {
+      state = "crashed";
+    } else {
+      state = "stopped";
+    }
+    return {
+      state,
+      pid: job.pid,
+      loaded,
+      crashCount: Math.max(0, job.restarts),
+      lastExit: this.exitInfo(job),
+    };
+  }
+
+  private exitInfo(job: SystemdJobInfo): ExitInfo | null {
+    const exited = job.exitCode === 1;
+    const killed = job.exitCode === 2 || job.exitCode === 3;
+    if ((job.exitStatus === null || job.exitStatus === 0) && !killed) {
+      return null;
+    }
+    const signature = `${job.restarts}:${job.exitCode ?? "null"}:${job.exitStatus ?? "null"}`;
+    if (signature !== this.lastExitSignature) {
+      this.lastExitSignature = signature;
+      return {
+        code: exited ? job.exitStatus : null,
+        signal: killed ? String(job.exitStatus ?? "unknown") : null,
+        at: this.options.now(),
+      };
+    }
+    return this.snapshotValue.lastExit;
+  }
+
+  private async probe(): Promise<boolean> {
+    const fetchImpl = this.options.fetchImpl ?? fetch;
+    try {
+      await fetchImpl(this.options.program.readinessUrl(), {
+        signal: AbortSignal.timeout(this.options.probeTimeoutMs),
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async runChecked(args: string[]): Promise<CommandResult> {
+    const result = await this.run(args);
+    if (result.code !== 0) throw new Error(this.commandError(args, result));
+    return result;
+  }
+
+  private run(args: string[]): Promise<CommandResult> {
+    return (this.options.runCommand ?? defaultCommandRunner)(this.options.systemctlPath, args);
+  }
+
+  private commandError(args: string[], result: CommandResult): string {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`;
+    return `systemctl ${args.join(" ")} failed: ${detail}`;
+  }
+
+  private setSnapshot(snapshot: ServiceSnapshot): ServiceSnapshot {
+    if (!sameSnapshot(snapshot, this.snapshotValue)) {
+      this.snapshotValue = snapshot;
+      this.options.onChange?.(snapshot);
+    }
+    return this.snapshotValue;
+  }
+}

--- a/plugins/agent-proxy/lib/persistent-service.ts
+++ b/plugins/agent-proxy/lib/persistent-service.ts
@@ -202,6 +202,38 @@ function sameSnapshot(a: ServiceSnapshot, b: ServiceSnapshot): boolean {
   );
 }
 
+class ServiceOperationFence {
+  private epoch = 0;
+  private lifecycleActive = false;
+  private lifecycleTail: Promise<void> = Promise.resolve();
+
+  observationToken(): number {
+    return this.epoch;
+  }
+
+  canCommit(token: number): boolean {
+    return !this.lifecycleActive && token === this.epoch;
+  }
+
+  lifecycle<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.lifecycleTail.then(async () => {
+      this.epoch += 1;
+      this.lifecycleActive = true;
+      try {
+        return await operation();
+      } finally {
+        this.epoch += 1;
+        this.lifecycleActive = false;
+      }
+    });
+    this.lifecycleTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+}
+
 async function wait(ms: number, signal: AbortSignal): Promise<void> {
   try {
     await delay(ms, undefined, { signal });
@@ -248,6 +280,7 @@ export class LaunchdPersistentService implements PersistentService {
     lastExit: null,
   };
   private lastExitSignature: string | null = null;
+  private readonly operations = new ServiceOperationFence();
 
   constructor(options: LaunchdServiceOptions) {
     this.options = {
@@ -286,22 +319,32 @@ export class LaunchdPersistentService implements PersistentService {
 
   async snapshot(): Promise<ServiceSnapshot> {
     this.assertSupported();
+    return this.observe(this.operations.observationToken());
+  }
+
+  private async observe(token: number | null): Promise<ServiceSnapshot> {
     if (!this.options.isInstalled()) {
-      return this.setSnapshot({
-        state: "not-installed",
+      return this.commitObservation(token, () => ({
+        state: "not-installed" as const,
         pid: null,
         loaded: false,
         crashCount: 0,
         lastExit: null,
-      });
+      }));
     }
     const job = await this.inspectJob();
-    return this.setSnapshot(await this.snapshotFromJob(job));
+    const ready =
+      job.loaded && job.state === "running" && job.pid !== null ? await this.probe() : false;
+    return this.commitObservation(token, () => this.snapshotFromJob(job, ready));
   }
 
-  async start(): Promise<ServiceSnapshot> {
+  start(): Promise<ServiceSnapshot> {
     this.assertSupported();
-    if (!this.options.isInstalled()) return this.snapshot();
+    return this.operations.lifecycle(() => this.startLifecycle());
+  }
+
+  private async startLifecycle(): Promise<ServiceSnapshot> {
+    if (!this.options.isInstalled()) return this.observe(null);
 
     const definitionChanged = this.ensureDefinition();
     await this.runChecked(["enable", this.serviceTarget]);
@@ -322,14 +365,21 @@ export class LaunchdPersistentService implements PersistentService {
     } else if (job.pid === null || job.state !== "running") {
       await this.runChecked(["kickstart", this.serviceTarget]);
     }
-    return this.snapshot();
+    return this.observe(null);
   }
 
-  async stop(): Promise<ServiceSnapshot> {
+  stop(): Promise<ServiceSnapshot> {
     this.assertSupported();
+    return this.operations.lifecycle(() => this.stopLifecycle());
+  }
+
+  private async stopLifecycle(): Promise<ServiceSnapshot> {
     this.setSnapshot({ ...this.snapshotValue, state: "stopping" });
     await this.bootout();
-    await this.runChecked(["disable", this.serviceTarget]);
+    const result = await this.run(["disable", this.serviceTarget]);
+    if (result.code !== 0 && !isMissingService(result)) {
+      throw new Error(this.commandError(["disable", this.serviceTarget], result));
+    }
     return this.setSnapshot({
       ...this.snapshotValue,
       state: this.options.isInstalled() ? "stopped" : "not-installed",
@@ -338,9 +388,13 @@ export class LaunchdPersistentService implements PersistentService {
     });
   }
 
-  async restart(): Promise<ServiceSnapshot> {
+  restart(): Promise<ServiceSnapshot> {
     this.assertSupported();
-    if (!this.options.isInstalled()) return this.snapshot();
+    return this.operations.lifecycle(() => this.restartLifecycle());
+  }
+
+  private async restartLifecycle(): Promise<ServiceSnapshot> {
+    if (!this.options.isInstalled()) return this.observe(null);
 
     const definitionChanged = this.ensureDefinition();
     await this.runChecked(["enable", this.serviceTarget]);
@@ -353,7 +407,7 @@ export class LaunchdPersistentService implements PersistentService {
     } else {
       await this.runChecked(["kickstart", "-k", this.serviceTarget]);
     }
-    return this.snapshot();
+    return this.observe(null);
   }
 
   async monitor(signal: AbortSignal): Promise<void> {
@@ -400,7 +454,7 @@ export class LaunchdPersistentService implements PersistentService {
     return { loaded: true, ...parseLaunchctlPrint(result.stdout) };
   }
 
-  private async snapshotFromJob(job: LaunchdJobInfo): Promise<ServiceSnapshot> {
+  private snapshotFromJob(job: LaunchdJobInfo, ready: boolean): ServiceSnapshot {
     if (!job.loaded) {
       return {
         state: "stopped",
@@ -414,8 +468,8 @@ export class LaunchdPersistentService implements PersistentService {
     const lastExit = this.exitInfo(job);
     let state: ServiceState;
     if (job.state === "running" && job.pid !== null) {
-      state = (await this.probe()) ? "running" : "starting";
-    } else if (job.lastExitCode !== null && job.lastExitCode !== 0) {
+      state = ready ? "running" : "starting";
+    } else if (job.lastSignal !== null || (job.lastExitCode !== null && job.lastExitCode !== 0)) {
       state = "crashed";
     } else {
       state = "starting";
@@ -483,6 +537,14 @@ export class LaunchdPersistentService implements PersistentService {
       this.options.onChange?.(snapshot);
     }
     return this.snapshotValue;
+  }
+
+  private commitObservation(
+    token: number | null,
+    makeSnapshot: () => ServiceSnapshot,
+  ): ServiceSnapshot {
+    if (token !== null && !this.operations.canCommit(token)) return this.snapshotValue;
+    return this.setSnapshot(makeSnapshot());
   }
 }
 
@@ -616,6 +678,7 @@ export class SystemdPersistentService implements PersistentService {
     lastExit: null,
   };
   private lastExitSignature: string | null = null;
+  private readonly operations = new ServiceOperationFence();
 
   constructor(options: SystemdServiceOptions) {
     this.options = {
@@ -651,22 +714,31 @@ export class SystemdPersistentService implements PersistentService {
 
   async snapshot(): Promise<ServiceSnapshot> {
     this.assertSupported();
+    return this.observe(this.operations.observationToken());
+  }
+
+  private async observe(token: number | null): Promise<ServiceSnapshot> {
     if (!this.options.isInstalled()) {
-      return this.setSnapshot({
-        state: "not-installed",
+      return this.commitObservation(token, () => ({
+        state: "not-installed" as const,
         pid: null,
         loaded: false,
         crashCount: 0,
         lastExit: null,
-      });
+      }));
     }
     const job = await this.inspectJob();
-    return this.setSnapshot(await this.snapshotFromJob(job));
+    const ready = job.activeState === "active" ? await this.probe() : false;
+    return this.commitObservation(token, () => this.snapshotFromJob(job, ready));
   }
 
-  async start(): Promise<ServiceSnapshot> {
+  start(): Promise<ServiceSnapshot> {
     this.assertSupported();
-    if (!this.options.isInstalled()) return this.snapshot();
+    return this.operations.lifecycle(() => this.startLifecycle());
+  }
+
+  private async startLifecycle(): Promise<ServiceSnapshot> {
+    if (!this.options.isInstalled()) return this.observe(null);
 
     const definitionChanged = this.ensureDefinition();
     await this.runChecked(["--user", "daemon-reload"]);
@@ -679,11 +751,15 @@ export class SystemdPersistentService implements PersistentService {
     } else {
       await this.runChecked(["--user", "start", this.unitTarget]);
     }
-    return this.snapshot();
+    return this.observe(null);
   }
 
-  async stop(): Promise<ServiceSnapshot> {
+  stop(): Promise<ServiceSnapshot> {
     this.assertSupported();
+    return this.operations.lifecycle(() => this.stopLifecycle());
+  }
+
+  private async stopLifecycle(): Promise<ServiceSnapshot> {
     this.setSnapshot({ ...this.snapshotValue, state: "stopping" });
     const result = await this.run(["--user", "disable", "--now", this.unitTarget]);
     if (result.code !== 0 && !isMissingSystemdUnit(result)) {
@@ -697,9 +773,13 @@ export class SystemdPersistentService implements PersistentService {
     });
   }
 
-  async restart(): Promise<ServiceSnapshot> {
+  restart(): Promise<ServiceSnapshot> {
     this.assertSupported();
-    if (!this.options.isInstalled()) return this.snapshot();
+    return this.operations.lifecycle(() => this.restartLifecycle());
+  }
+
+  private async restartLifecycle(): Promise<ServiceSnapshot> {
+    if (!this.options.isInstalled()) return this.observe(null);
 
     this.ensureDefinition();
     await this.runChecked(["--user", "daemon-reload"]);
@@ -710,7 +790,7 @@ export class SystemdPersistentService implements PersistentService {
       job.activeState === "active" ? "restart" : "start",
       this.unitTarget,
     ]);
-    return this.snapshot();
+    return this.observe(null);
   }
 
   async monitor(signal: AbortSignal): Promise<void> {
@@ -794,7 +874,7 @@ export class SystemdPersistentService implements PersistentService {
     };
   }
 
-  private async snapshotFromJob(job: SystemdJobInfo): Promise<ServiceSnapshot> {
+  private snapshotFromJob(job: SystemdJobInfo, ready: boolean): ServiceSnapshot {
     const loaded =
       job.enabled ||
       job.activeState === "active" ||
@@ -802,7 +882,7 @@ export class SystemdPersistentService implements PersistentService {
       job.activeState === "deactivating";
     let state: ServiceState;
     if (job.activeState === "active") {
-      state = (await this.probe()) ? "running" : "starting";
+      state = ready ? "running" : "starting";
     } else if (job.activeState === "activating") {
       state = "starting";
     } else if (job.activeState === "deactivating") {
@@ -872,5 +952,13 @@ export class SystemdPersistentService implements PersistentService {
       this.options.onChange?.(snapshot);
     }
     return this.snapshotValue;
+  }
+
+  private commitObservation(
+    token: number | null,
+    makeSnapshot: () => ServiceSnapshot,
+  ): ServiceSnapshot {
+    if (token !== null && !this.operations.canCommit(token)) return this.snapshotValue;
+    return this.setSnapshot(makeSnapshot());
   }
 }

--- a/plugins/agent-proxy/lib/plugin-settings.ts
+++ b/plugins/agent-proxy/lib/plugin-settings.ts
@@ -1,0 +1,70 @@
+export const ROUTING_STRATEGIES = ["round-robin", "fill-first", "weighted-round-robin"] as const;
+
+export type RoutingStrategy = (typeof ROUTING_STRATEGIES)[number];
+
+export interface AgentProxySettings {
+  autostart: boolean;
+  cloudflareQuickTunnelForCursor: boolean;
+  port: number;
+  sourceRepository: string;
+  sourceBranch: string;
+  routingStrategy: RoutingStrategy;
+}
+
+export const DEFAULT_AGENT_PROXY_SETTINGS: AgentProxySettings = {
+  autostart: true,
+  cloudflareQuickTunnelForCursor: false,
+  port: 8317,
+  sourceRepository: "router-for-me/CLIProxyAPI",
+  sourceBranch: "latest",
+  routingStrategy: "round-robin",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function booleanOr(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function stringOr(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : fallback;
+}
+
+function portOr(value: unknown, fallback: number): number {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string"
+        ? Number.parseInt(value, 10)
+        : Number.NaN;
+  return Number.isInteger(parsed) && parsed > 0 && parsed < 65_536 ? parsed : fallback;
+}
+
+function routingStrategyOr(value: unknown, fallback: RoutingStrategy): RoutingStrategy {
+  return typeof value === "string" && ROUTING_STRATEGIES.includes(value as RoutingStrategy)
+    ? (value as RoutingStrategy)
+    : fallback;
+}
+
+export function normalizeAgentProxySettings(value: unknown): AgentProxySettings {
+  const source = isRecord(value) ? value : {};
+  return {
+    autostart: booleanOr(source.autostart, DEFAULT_AGENT_PROXY_SETTINGS.autostart),
+    cloudflareQuickTunnelForCursor: booleanOr(
+      source.cloudflareQuickTunnelForCursor,
+      DEFAULT_AGENT_PROXY_SETTINGS.cloudflareQuickTunnelForCursor,
+    ),
+    port: portOr(source.port, DEFAULT_AGENT_PROXY_SETTINGS.port),
+    sourceRepository: stringOr(
+      source.sourceRepository,
+      DEFAULT_AGENT_PROXY_SETTINGS.sourceRepository,
+    ),
+    sourceBranch: stringOr(source.sourceBranch, DEFAULT_AGENT_PROXY_SETTINGS.sourceBranch),
+    routingStrategy: routingStrategyOr(
+      source.routingStrategy,
+      DEFAULT_AGENT_PROXY_SETTINGS.routingStrategy,
+    ),
+  };
+}

--- a/plugins/agent-proxy/lib/plugin-settings.ts
+++ b/plugins/agent-proxy/lib/plugin-settings.ts
@@ -34,11 +34,7 @@ function stringOr(value: unknown, fallback: string): string {
 
 function portOr(value: unknown, fallback: number): number {
   const parsed =
-    typeof value === "number"
-      ? value
-      : typeof value === "string"
-        ? Number.parseInt(value, 10)
-        : Number.NaN;
+    typeof value === "number" ? value : typeof value === "string" ? Number(value) : Number.NaN;
   return Number.isInteger(parsed) && parsed > 0 && parsed < 65_536 ? parsed : fallback;
 }
 

--- a/plugins/agent-proxy/server.ts
+++ b/plugins/agent-proxy/server.ts
@@ -46,6 +46,12 @@ import {
 import type { PersistentService } from "./lib/persistent-service.ts";
 import { planRuntimeReconciliation, runtimeConfigFingerprint } from "./lib/runtime-state.ts";
 import {
+  DEFAULT_AGENT_PROXY_SETTINGS,
+  normalizeAgentProxySettings,
+  ROUTING_STRATEGIES,
+  type AgentProxySettings,
+} from "./lib/plugin-settings.ts";
+import {
   ManagementClient,
   ManagementError,
   RESOURCES,
@@ -61,8 +67,9 @@ import {
   type ClaudeEnvState,
 } from "./lib/agents-config.ts";
 
-const DEFAULT_PORT = 8317;
+const DEFAULT_PORT = DEFAULT_AGENT_PROXY_SETTINGS.port;
 const LATEST_CACHE_KEY = "latest-source-revision-v1";
+const SETTINGS_STORAGE_KEY = "configuration-v1";
 const LATEST_CACHE_TTL_MS = 3_600_000;
 const CLAUDE_BACKUP_BASE = "claude-settings.json";
 const SERVICE_LABEL = "com.bb.plugin.agent-proxy";
@@ -123,10 +130,27 @@ const sourceSchema = z.object({
   error: z.string().nullable(),
 });
 
-const sourceSettingsSchema = sourceSchema.extend({
-  defaultRepository: z.string(),
-  defaultBranch: z.string(),
+const configurationValuesSchema = z.object({
+  autostart: z.boolean(),
+  cloudflareQuickTunnelForCursor: z.boolean(),
+  port: z.number().int().min(1).max(65_535),
+  sourceRepository: z.string(),
+  sourceBranch: z.string(),
+  routingStrategy: z.enum(ROUTING_STRATEGIES),
 });
+
+const configurationViewSchema = z.object({
+  values: configurationValuesSchema,
+  defaults: configurationValuesSchema,
+  managementKeyConfigured: z.boolean(),
+  sourceError: z.string().nullable(),
+});
+
+const managementKeyUpdateSchema = z.discriminatedUnion("action", [
+  z.object({ action: z.literal("keep") }).strict(),
+  z.object({ action: z.literal("clear") }).strict(),
+  z.object({ action: z.literal("set"), value: z.string().min(1) }).strict(),
+]);
 
 const statusSchema = z.object({
   state: stateSchema,
@@ -207,10 +231,10 @@ export const rpcContract = defineRpcContract({
     input: z.null(),
     output: endpointsSchema.extend({ apiKey: z.string(), publicOpenai: z.string().nullable() }),
   },
-  sourceSettings: { input: z.null(), output: sourceSettingsSchema },
-  sourceSettingsUpdate: {
-    input: z.object({ repository: z.string(), branch: z.string() }).strict(),
-    output: sourceSettingsSchema,
+  configuration: { input: z.null(), output: configurationViewSchema },
+  configurationUpdate: {
+    input: configurationValuesSchema.extend({ managementKey: managementKeyUpdateSchema }).strict(),
+    output: configurationViewSchema,
   },
 
   oauthStart: {
@@ -285,49 +309,6 @@ export const rpcContract = defineRpcContract({
 // ---------------------------------------------------------------------------
 
 export default async function plugin(bb: BbPluginApi) {
-  const settings = bb.settings.define({
-    autostart: {
-      type: "boolean",
-      label: "Keep the proxy running as a login service",
-      description:
-        "The operating system starts it at login and keeps it running when bb is closed.",
-      default: true,
-    },
-    cloudflareQuickTunnelForCursor: {
-      type: "boolean",
-      label: "Cloudflare Quick Tunnel for Cursor",
-      description:
-        "Development only. The hostname changes after helper restarts, and Cloudflare Quick Tunnels do not support SSE.",
-      default: false,
-    },
-    port: { type: "string", label: "Proxy listen port", default: String(DEFAULT_PORT) },
-    sourceRepository: {
-      type: "string",
-      label: "Advanced: core source repository",
-      description:
-        "Public GitHub repository in owner/name form. A github.com URL is also accepted.",
-      default: CORE_REPO,
-    },
-    sourceBranch: {
-      type: "string",
-      label: "Advanced: core source branch or ref",
-      description: "Branch, tag, or commit used for update checks and source builds.",
-      default: CORE_REF,
-    },
-    managementKey: {
-      type: "string",
-      label: "Management API key override (leave empty to auto-generate)",
-      secret: true,
-    },
-    routingStrategy: {
-      type: "string",
-      label: "Credential routing strategy",
-      description:
-        "How the core selects between multiple matching credentials. round-robin rotates per request (trashes upstream prompt caches); fill-first sticks to one until it cools down; weighted-round-robin uses per-credential weights.",
-      default: "round-robin",
-    },
-  });
-
   async function resolveDataDir(): Promise<string> {
     try {
       const config = await bb.sdk.system.config();
@@ -361,6 +342,50 @@ export default async function plugin(bb: BbPluginApi) {
   const generatedManagementKey = loadOrCreateKey(paths.managementKeyPath);
   const localApiKey = loadOrCreateKey(paths.localApiKeyPath);
 
+  let migratedLegacySettings = false;
+  const storedConfiguration = await bb.storage.kv.get<unknown>(SETTINGS_STORAGE_KEY);
+  let configuration: AgentProxySettings;
+  if (storedConfiguration === undefined) {
+    const legacySettings = bb.settings.define({
+      autostart: { type: "boolean", label: "Autostart", default: true },
+      cloudflareQuickTunnelForCursor: {
+        type: "boolean",
+        label: "Cloudflare Quick Tunnel for Cursor",
+        default: false,
+      },
+      port: { type: "string", label: "Proxy listen port", default: String(DEFAULT_PORT) },
+      sourceRepository: {
+        type: "string",
+        label: "Core source repository",
+        default: CORE_REPO,
+      },
+      sourceBranch: { type: "string", label: "Core source branch", default: CORE_REF },
+      managementKey: { type: "string", label: "Management API key", secret: true },
+      routingStrategy: {
+        type: "string",
+        label: "Credential routing strategy",
+        default: "round-robin",
+      },
+    });
+    const legacyValues = await legacySettings.get();
+    configuration = normalizeAgentProxySettings(legacyValues);
+    const legacyManagementKey = legacyValues.managementKey?.trim();
+    if (legacyManagementKey) {
+      writeAtomic(paths.managementKeyOverridePath, `${legacyManagementKey}\n`, 0o600);
+    }
+    await bb.storage.kv.set(SETTINGS_STORAGE_KEY, configuration);
+    migratedLegacySettings = true;
+  } else {
+    configuration = normalizeAgentProxySettings(storedConfiguration);
+    if (JSON.stringify(configuration) !== JSON.stringify(storedConfiguration)) {
+      await bb.storage.kv.set(SETTINGS_STORAGE_KEY, configuration);
+    }
+  }
+
+  function managementKeyOverride(): string | null {
+    return readTextOr(paths.managementKeyOverridePath)?.trim() || null;
+  }
+
   async function effectiveSettings(): Promise<{
     port: number;
     managementKey: string;
@@ -368,45 +393,46 @@ export default async function plugin(bb: BbPluginApi) {
     cloudflareQuickTunnelForCursor: boolean;
     routingStrategy: string;
   }> {
-    const values = await settings.get();
-    const port = Number.parseInt(values.port, 10);
-    const strategy = values.routingStrategy?.trim() || "round-robin";
     return {
-      port: Number.isFinite(port) && port > 0 && port < 65_536 ? port : DEFAULT_PORT,
-      managementKey: values.managementKey?.trim() || generatedManagementKey,
-      autostart: values.autostart,
-      cloudflareQuickTunnelForCursor: values.cloudflareQuickTunnelForCursor,
-      routingStrategy: strategy,
+      port: configuration.port,
+      managementKey: managementKeyOverride() ?? generatedManagementKey,
+      autostart: configuration.autostart,
+      cloudflareQuickTunnelForCursor: configuration.cloudflareQuickTunnelForCursor,
+      routingStrategy: configuration.routingStrategy,
     };
   }
 
   async function sourceSettingsView() {
-    const values = await settings.get();
-    const repository = values.sourceRepository.trim();
-    const branch = values.sourceBranch.trim();
+    const repository = configuration.sourceRepository;
+    const branch = configuration.sourceBranch;
     try {
       const source = normalizeCoreSource(repository, branch);
       return {
         repository: source.repo,
         branch: source.ref,
         error: null,
-        defaultRepository: CORE_REPO,
-        defaultBranch: CORE_REF,
       };
     } catch (error) {
       return {
         repository,
         branch,
         error: String(error instanceof Error ? error.message : error),
-        defaultRepository: CORE_REPO,
-        defaultBranch: CORE_REF,
       };
     }
   }
 
   async function configuredSource(): Promise<CoreSource> {
-    const values = await settings.get();
-    return normalizeCoreSource(values.sourceRepository, values.sourceBranch);
+    return normalizeCoreSource(configuration.sourceRepository, configuration.sourceBranch);
+  }
+
+  async function configurationView() {
+    const source = await sourceSettingsView();
+    return {
+      values: configuration,
+      defaults: DEFAULT_AGENT_PROXY_SETTINGS,
+      managementKeyConfigured: managementKeyOverride() !== null,
+      sourceError: source.error,
+    };
   }
 
   const initial = await effectiveSettings();
@@ -898,39 +924,73 @@ export default async function plugin(bb: BbPluginApi) {
     });
   }
 
-  settings.onChange((next, previous) => {
-    const sourceChanged =
-      next.sourceRepository !== previous.sourceRepository ||
-      next.sourceBranch !== previous.sourceBranch;
-    if (sourceChanged) {
-      void bb.storage.kv
-        .delete(LATEST_CACHE_KEY)
-        .then(() => bb.realtime.publish("status", { sourceChanged: true }))
-        .catch((error: unknown) => {
-          bb.log.error(`failed to clear the source update cache: ${String(error)}`);
-        });
+  async function updateConfiguration(
+    requested: AgentProxySettings,
+    managementKeyUpdate:
+      | { action: "keep" }
+      | { action: "clear" }
+      | { action: "set"; value: string },
+  ) {
+    const source = normalizeCoreSource(requested.sourceRepository, requested.sourceBranch);
+    const next: AgentProxySettings = {
+      ...requested,
+      sourceRepository: source.repo,
+      sourceBranch: source.ref,
+    };
+    const nextManagementKey =
+      managementKeyUpdate.action === "set" ? managementKeyUpdate.value.trim() : null;
+    if (managementKeyUpdate.action === "set" && !nextManagementKey) {
+      throw new Error("Management API key cannot be empty");
     }
-    const runtimeChanged =
-      next.port !== previous.port ||
-      next.managementKey !== previous.managementKey ||
-      next.routingStrategy !== previous.routingStrategy;
-    const autostartChanged = next.autostart !== previous.autostart;
-    const tunnelChanged =
-      next.cloudflareQuickTunnelForCursor !== previous.cloudflareQuickTunnelForCursor;
-    if (autostartChanged || tunnelChanged) {
-      tunnelEnabled = next.cloudflareQuickTunnelForCursor;
-      desiredRunning = next.autostart || tunnelEnabled;
-    }
-    if (!runtimeChanged && !autostartChanged && !tunnelChanged) return;
-    void initialize()
-      .then(() =>
-        enqueue(async () => {
-          const tunnelStopFailure =
-            !tunnelEnabled || !desiredRunning ? await tryStopTunnel() : null;
-          if (!tunnelEnabled && tunnelStopFailure !== null) {
-            await supervisor.stop();
-            return;
-          }
+
+    await initialize();
+    return enqueue(async () => {
+      const previous = configuration;
+      const previousManagementKey = managementKeyOverride();
+      const resolvedManagementKey =
+        managementKeyUpdate.action === "keep"
+          ? previousManagementKey
+          : managementKeyUpdate.action === "clear"
+            ? null
+            : nextManagementKey;
+      const managementKeyChanged = resolvedManagementKey !== previousManagementKey;
+
+      await bb.storage.kv.set(SETTINGS_STORAGE_KEY, next);
+      try {
+        if (resolvedManagementKey === null) {
+          rmSync(paths.managementKeyOverridePath, { force: true });
+        } else if (managementKeyChanged) {
+          writeAtomic(paths.managementKeyOverridePath, `${resolvedManagementKey}\n`, 0o600);
+        }
+      } catch (error) {
+        await bb.storage.kv.set(SETTINGS_STORAGE_KEY, previous);
+        throw error;
+      }
+      configuration = next;
+
+      const sourceChanged =
+        next.sourceRepository !== previous.sourceRepository ||
+        next.sourceBranch !== previous.sourceBranch;
+      if (sourceChanged) {
+        await bb.storage.kv.delete(LATEST_CACHE_KEY);
+        bb.realtime.publish("status", { sourceChanged: true });
+      }
+      const runtimeChanged =
+        next.port !== previous.port ||
+        managementKeyChanged ||
+        next.routingStrategy !== previous.routingStrategy;
+      const autostartChanged = next.autostart !== previous.autostart;
+      const tunnelChanged =
+        next.cloudflareQuickTunnelForCursor !== previous.cloudflareQuickTunnelForCursor;
+      if (autostartChanged || tunnelChanged) {
+        tunnelEnabled = next.cloudflareQuickTunnelForCursor;
+        desiredRunning = next.autostart || tunnelEnabled;
+      }
+      if (runtimeChanged || autostartChanged || tunnelChanged) {
+        const tunnelStopFailure = !tunnelEnabled || !desiredRunning ? await tryStopTunnel() : null;
+        if (!tunnelEnabled && tunnelStopFailure !== null) {
+          await supervisor.stop();
+        } else {
           if (runtimeChanged) {
             const effective = await effectiveSettings();
             await supervisor.stop();
@@ -952,12 +1012,13 @@ export default async function plugin(bb: BbPluginApi) {
             const snapshot = await supervisor.snapshot();
             await reconcileTunnelForCore(snapshot);
           }
-        }),
-      )
-      .catch((error: unknown) => {
-        bb.log.error(`failed to apply settings to core config: ${String(error)}`);
-      });
-  });
+        }
+      }
+
+      bb.realtime.publish("status", { configurationChanged: true });
+      return configurationView();
+    });
+  }
 
   // -------------------------------------------------------------------------
   // Agents wiring helpers
@@ -1087,19 +1148,9 @@ export default async function plugin(bb: BbPluginApi) {
         publicOpenai: status.tunnel.state === "ready" ? status.tunnel.openaiBaseUrl : null,
       };
     },
-    sourceSettings: () => sourceSettingsView(),
-    async sourceSettingsUpdate({ repository, branch }) {
-      const source = normalizeCoreSource(repository, branch);
-      await bb.sdk.plugins.updateSettings({
-        pluginId: bb.pluginId,
-        values: {
-          sourceRepository: source.repo,
-          sourceBranch: source.ref,
-        },
-      });
-      await bb.storage.kv.delete(LATEST_CACHE_KEY);
-      bb.realtime.publish("status", { sourceChanged: true });
-      return sourceSettingsView();
+    configuration: () => configurationView(),
+    async configurationUpdate({ managementKey, ...values }) {
+      return updateConfiguration(values, managementKey);
     },
 
     async oauthStart({ provider }) {
@@ -1423,6 +1474,15 @@ export default async function plugin(bb: BbPluginApi) {
       }
     },
   });
+
+  if (migratedLegacySettings) {
+    const migrationReload = setTimeout(() => {
+      void bb.sdk.plugins.reload({ pluginId: bb.pluginId }).catch((error: unknown) => {
+        bb.log.error(`failed to finish the settings migration reload: ${String(error)}`);
+      });
+    }, 0);
+    bb.onDispose(() => clearTimeout(migrationReload));
+  }
 
   bb.log.info(
     `loaded (core ${installedVersion(paths) ?? "not installed"}, source ${initialSource.repository}#${initialSource.branch}, port ${initial.port}, routing ${initial.routingStrategy}, autostart ${String(initial.autostart)}, Cloudflare tunnel ${String(initial.cloudflareQuickTunnelForCursor)})`,

--- a/plugins/agent-proxy/server.ts
+++ b/plugins/agent-proxy/server.ts
@@ -28,6 +28,22 @@ import {
   type CoreSupervisor,
   type SupervisorSnapshot,
 } from "./lib/core-process.ts";
+import {
+  createCloudflareTunnelService,
+  deriveTunnelStatus,
+  discoverCloudflared,
+  installTunnelRuntime,
+  loadBundledTunnelRuntime,
+  monitorTunnelObservation,
+  readTunnelObservation,
+  renderTunnelDesiredConfig,
+  resolveTunnelHostRuntime,
+  type BundledTunnelRuntime,
+  type CloudflaredDiscovery,
+  type TunnelHostRuntime,
+  type TunnelStatus,
+} from "./lib/cloudflare-tunnel.ts";
+import type { PersistentService } from "./lib/persistent-service.ts";
 import { planRuntimeReconciliation, runtimeConfigFingerprint } from "./lib/runtime-state.ts";
 import {
   ManagementClient,
@@ -50,6 +66,7 @@ const LATEST_CACHE_KEY = "latest-source-revision-v1";
 const LATEST_CACHE_TTL_MS = 3_600_000;
 const CLAUDE_BACKUP_BASE = "claude-settings.json";
 const SERVICE_LABEL = "com.bb.plugin.agent-proxy";
+const TUNNEL_SERVICE_LABEL = "com.bb.plugin.agent-proxy.cloudflare-tunnel";
 /** Labels earlier versions installed. Retired once on initialize so an upgraded
     install keeps exactly one login service. Never derive this from the plugin
     id: a rename or reinstall would orphan the service already on disk. */
@@ -129,6 +146,37 @@ const statusSchema = z.object({
   }),
   source: sourceSchema,
   latest: z.object({ version: z.string(), checkedAt: z.number() }).nullable(),
+  tunnel: z.discriminatedUnion("state", [
+    z.object({ state: z.literal("disabled") }),
+    z.object({ state: z.literal("missing-binary"), detail: z.string() }),
+    z.object({
+      state: z.literal("stopped"),
+      reason: z.enum(["core-stopped", "disabled"]),
+    }),
+    z.object({
+      state: z.literal("stopping"),
+      pid: z.number().nullable(),
+      detail: z.string(),
+    }),
+    z.object({
+      state: z.literal("starting"),
+      pid: z.number().nullable(),
+      detail: z.string(),
+    }),
+    z.object({
+      state: z.literal("running-without-url"),
+      pid: z.number(),
+      detail: z.string(),
+    }),
+    z.object({ state: z.literal("ready"), pid: z.number(), openaiBaseUrl: z.string() }),
+    z.object({
+      state: z.literal("crashed"),
+      lastExit: z
+        .object({ code: z.number().nullable(), signal: z.string().nullable(), at: z.number() })
+        .nullable(),
+      detail: z.string(),
+    }),
+  ]),
 });
 
 export type CoreStatus = z.infer<typeof statusSchema>;
@@ -157,7 +205,7 @@ export const rpcContract = defineRpcContract({
   restart: { input: z.null(), output: statusSchema },
   endpoints: {
     input: z.null(),
-    output: endpointsSchema.extend({ apiKey: z.string() }),
+    output: endpointsSchema.extend({ apiKey: z.string(), publicOpenai: z.string().nullable() }),
   },
   sourceSettings: { input: z.null(), output: sourceSettingsSchema },
   sourceSettingsUpdate: {
@@ -245,6 +293,13 @@ export default async function plugin(bb: BbPluginApi) {
         "The operating system starts it at login and keeps it running when bb is closed.",
       default: true,
     },
+    cloudflareQuickTunnelForCursor: {
+      type: "boolean",
+      label: "Cloudflare Quick Tunnel for Cursor",
+      description:
+        "Development only. The hostname changes after helper restarts, and Cloudflare Quick Tunnels do not support SSE.",
+      default: false,
+    },
     port: { type: "string", label: "Proxy listen port", default: String(DEFAULT_PORT) },
     sourceRepository: {
       type: "string",
@@ -310,6 +365,7 @@ export default async function plugin(bb: BbPluginApi) {
     port: number;
     managementKey: string;
     autostart: boolean;
+    cloudflareQuickTunnelForCursor: boolean;
     routingStrategy: string;
   }> {
     const values = await settings.get();
@@ -319,6 +375,7 @@ export default async function plugin(bb: BbPluginApi) {
       port: Number.isFinite(port) && port > 0 && port < 65_536 ? port : DEFAULT_PORT,
       managementKey: values.managementKey?.trim() || generatedManagementKey,
       autostart: values.autostart,
+      cloudflareQuickTunnelForCursor: values.cloudflareQuickTunnelForCursor,
       routingStrategy: strategy,
     };
   }
@@ -354,15 +411,29 @@ export default async function plugin(bb: BbPluginApi) {
 
   const initial = await effectiveSettings();
   const initialSource = await sourceSettingsView();
+  const tunnelHostRuntime: TunnelHostRuntime = resolveTunnelHostRuntime();
+  let bundledTunnelRuntime: BundledTunnelRuntime | null = null;
+  let bundledTunnelRuntimeError: string | null = null;
+  try {
+    bundledTunnelRuntime = loadBundledTunnelRuntime({ runtimeDir: paths.tunnelRuntimeDir });
+  } catch (error) {
+    bundledTunnelRuntimeError = String(error instanceof Error ? error.message : error);
+  }
   let currentPort = initial.port;
   let currentManagementKey = initial.managementKey;
-  let desiredRunning = initial.autostart;
+  let tunnelEnabled = initial.cloudflareQuickTunnelForCursor;
+  let desiredRunning = initial.autostart || tunnelEnabled;
+  let tunnelDiscovery: CloudflaredDiscovery | null = null;
+  let tunnelPreparationError: string | null = bundledTunnelRuntimeError;
+  let tunnelStopError: string | null = null;
+  let tunnelRuntimeValidated = false;
   let acceptingOperations = true;
   let initialized = false;
   let operationTail: Promise<void> = Promise.resolve();
   let initializationTask: Promise<void> | null = null;
   let currentRuntimeFingerprint = runtimeConfigFingerprint(initial);
   let supervisor: CoreSupervisor;
+  let tunnelSupervisor: PersistentService;
   const pluginAbort = new AbortController();
 
   function enqueue<T>(operation: () => Promise<T> | T): Promise<T> {
@@ -427,6 +498,101 @@ export default async function plugin(bb: BbPluginApi) {
     return snapshot;
   }
 
+  function persistTunnelConfig(cloudflaredPath: string): void {
+    writeAtomic(
+      paths.tunnelConfigPath,
+      renderTunnelDesiredConfig({
+        version: 1,
+        corePort: currentPort,
+        cloudflaredPath,
+        localApiKeyPath: paths.localApiKeyPath,
+      }),
+      0o600,
+    );
+  }
+
+  async function tryStopTunnel(): Promise<unknown | null> {
+    try {
+      await tunnelSupervisor.stop();
+      tunnelStopError = null;
+      return null;
+    } catch (error) {
+      tunnelStopError = `Could not stop the public tunnel: ${String(
+        error instanceof Error ? error.message : error,
+      )}`;
+      bb.realtime.publish("status", { tunnelChanged: true });
+      return error;
+    }
+  }
+
+  async function startTunnel(): Promise<void> {
+    await tunnelSupervisor.start();
+    tunnelStopError = null;
+  }
+
+  async function prepareTunnel(): Promise<boolean> {
+    if (!tunnelEnabled) return false;
+    tunnelDiscovery = discoverCloudflared();
+    if (tunnelDiscovery.state === "missing") {
+      tunnelPreparationError = null;
+      await tryStopTunnel();
+      return false;
+    }
+    if (bundledTunnelRuntime === null) {
+      tunnelPreparationError =
+        bundledTunnelRuntimeError ?? "the packaged Cloudflare tunnel helper source is missing";
+      await tryStopTunnel();
+      return false;
+    }
+    if (!tunnelRuntimeValidated) {
+      const installed = await installTunnelRuntime({
+        runtime: bundledTunnelRuntime,
+        hostRuntime: tunnelHostRuntime,
+      });
+      if (installed.state === "blocked") {
+        tunnelPreparationError = installed.detail;
+        await tryStopTunnel();
+        return false;
+      }
+      tunnelRuntimeValidated = true;
+    }
+    tunnelPreparationError = null;
+    persistTunnelConfig(tunnelDiscovery.path);
+    return true;
+  }
+
+  async function reconcileTunnelForCore(snapshot: SupervisorSnapshot): Promise<void> {
+    if (!tunnelEnabled || !snapshot.loaded) return;
+    if (await prepareTunnel()) {
+      await startTunnel();
+      return;
+    }
+    if (tunnelStopError !== null) {
+      await supervisor.stop();
+      throw new Error(tunnelStopError);
+    }
+  }
+
+  async function startManagedStack(): Promise<SupervisorSnapshot> {
+    if (!tunnelEnabled && tunnelStopError !== null) {
+      const stopError = await tryStopTunnel();
+      if (stopError !== null) {
+        await supervisor.stop();
+        throw stopError;
+      }
+    }
+    const snapshot = await startManagedService();
+    await reconcileTunnelForCore(snapshot);
+    return snapshot;
+  }
+
+  async function stopManagedStack(): Promise<SupervisorSnapshot> {
+    const tunnelError = await tryStopTunnel();
+    const snapshot = await supervisor.stop();
+    if (tunnelError !== null) throw tunnelError;
+    return snapshot;
+  }
+
   /** One-time retirement of login services installed under an older label. Stops
       each one through the same supervisor that installed it, then deletes its
       definition so reconciliation installs only the current label. Idempotent:
@@ -460,6 +626,7 @@ export default async function plugin(bb: BbPluginApi) {
       cleanStaleStaging(paths.coreDir);
       migrateLegacyInstall(paths);
       const retiredLegacyService = await retireLegacyServices();
+      if (!tunnelEnabled && (await tryStopTunnel()) !== null) await supervisor.stop();
       secureAuthDirectory();
       const effective = await effectiveSettings();
       const desiredFingerprint = runtimeConfigFingerprint(effective);
@@ -473,11 +640,16 @@ export default async function plugin(bb: BbPluginApi) {
       if (plan.stopBeforeWrite) await supervisor.stop();
       if (plan.writeConfig) persistCoreConfig(effective);
       else adoptCoreSettings(effective);
+      if (tunnelEnabled) await prepareTunnel();
       // The planner starts only a service it found loaded, which is right for a
       // fresh install and wrong straight after a retirement: the core WAS
       // running, under the old label. Re-adopt it under the new one.
       const replaceRetiredService = retiredLegacyService && desiredRunning && !snapshot.loaded;
-      if (plan.startAfterWrite || replaceRetiredService) await startManagedService();
+      if (plan.startAfterWrite || replaceRetiredService) {
+        await startManagedStack();
+      } else if (tunnelEnabled && desiredRunning) {
+        await reconcileTunnelForCore(snapshot);
+      }
       initialized = true;
     });
     return initializationTask;
@@ -521,6 +693,28 @@ export default async function plugin(bb: BbPluginApi) {
     }
   }
 
+  function createTunnelSupervisor(
+    hooks: {
+      onChange?: (snapshot: SupervisorSnapshot) => void;
+      onError?: (error: unknown) => void;
+    } = {},
+  ): PersistentService {
+    return createCloudflareTunnelService({
+      label: TUNNEL_SERVICE_LABEL,
+      definitionPath: serviceDefinitionPath(TUNNEL_SERVICE_LABEL),
+      runtimePath:
+        bundledTunnelRuntime?.targetPath ?? join(paths.tunnelRuntimeDir, "unavailable-runtime.mjs"),
+      hostRuntime: tunnelHostRuntime,
+      configPath: paths.tunnelConfigPath,
+      observationPath: paths.tunnelObservationPath,
+      workingDirectory: paths.tunnelDir,
+      logPath: paths.tunnelLogPath,
+      readinessUrl: () => `http://127.0.0.1:${currentPort}/`,
+      uid: process.getuid?.(),
+      ...hooks,
+    });
+  }
+
   supervisor = createSupervisor(SERVICE_LABEL, {
     onChange: (snapshot: SupervisorSnapshot) => {
       bb.realtime.publish("status", snapshot);
@@ -529,13 +723,29 @@ export default async function plugin(bb: BbPluginApi) {
       bb.log.error(`service monitor failed: ${String(error)}`);
     },
   });
+  tunnelSupervisor = createTunnelSupervisor({
+    onChange: () => {
+      bb.realtime.publish("status", { tunnelChanged: true });
+    },
+    onError: (error: unknown) => {
+      bb.log.error(`Cloudflare tunnel service monitor failed: ${String(error)}`);
+    },
+  });
 
   bb.background.service("core", {
     async start(signal) {
       await initialize();
-      if (desiredRunning) await startManagedService();
-      else if (installedVersion(paths) !== null) await supervisor.stop();
-      await supervisor.monitor(signal);
+      if (desiredRunning) await startManagedStack();
+      else if (installedVersion(paths) !== null) await stopManagedStack();
+      await Promise.all([
+        supervisor.monitor(signal),
+        tunnelSupervisor.monitor(signal),
+        monitorTunnelObservation({
+          path: paths.tunnelObservationPath,
+          signal,
+          onChange: () => bb.realtime.publish("status", { tunnelChanged: true }),
+        }),
+      ]);
     },
   });
   bb.onDispose(async () => {
@@ -572,6 +782,30 @@ export default async function plugin(bb: BbPluginApi) {
   async function computeStatus(): Promise<CoreStatus> {
     await initialize();
     const snapshot = await supervisor.snapshot();
+    let tunnel: TunnelStatus;
+    try {
+      const tunnelSnapshot = await tunnelSupervisor.snapshot();
+      tunnel = deriveTunnelStatus({
+        enabled: tunnelEnabled,
+        coreDesiredRunning: desiredRunning,
+        coreLoaded: snapshot.loaded,
+        discovery: tunnelDiscovery,
+        preparationError: tunnelPreparationError,
+        stopError: tunnelStopError,
+        service: tunnelSnapshot,
+        observation: readTunnelObservation(paths.tunnelObservationPath),
+      });
+    } catch (error) {
+      tunnel = {
+        state: "crashed",
+        lastExit: null,
+        detail:
+          tunnelStopError ??
+          `Could not inspect the public tunnel service: ${String(
+            error instanceof Error ? error.message : error,
+          )}`,
+      };
+    }
     const sourceView = await sourceSettingsView();
     const latest =
       sourceView.error === null
@@ -597,6 +831,7 @@ export default async function plugin(bb: BbPluginApi) {
         error: sourceView.error,
       },
       latest,
+      tunnel,
     };
   }
 
@@ -625,7 +860,7 @@ export default async function plugin(bb: BbPluginApi) {
       bb.log.info(`installed CLIProxyAPI ${installed}`);
       return installed;
     } finally {
-      if (stoppedForSwap && desiredRunning) await startManagedService();
+      if (stoppedForSwap && desiredRunning) await startManagedStack();
       else await supervisor.snapshot();
     }
   }
@@ -639,7 +874,7 @@ export default async function plugin(bb: BbPluginApi) {
     desiredRunning = true;
     await initialize();
     return enqueue(async () => {
-      await startManagedService();
+      await startManagedStack();
       return computeStatus();
     });
   }
@@ -648,7 +883,7 @@ export default async function plugin(bb: BbPluginApi) {
     desiredRunning = false;
     await initialize();
     return enqueue(async () => {
-      await supervisor.stop();
+      await stopManagedStack();
       return computeStatus();
     });
   }
@@ -657,7 +892,8 @@ export default async function plugin(bb: BbPluginApi) {
     desiredRunning = true;
     await initialize();
     return enqueue(async () => {
-      await restartManagedService();
+      const snapshot = await restartManagedService();
+      await reconcileTunnelForCore(snapshot);
       return computeStatus();
     });
   }
@@ -679,24 +915,42 @@ export default async function plugin(bb: BbPluginApi) {
       next.managementKey !== previous.managementKey ||
       next.routingStrategy !== previous.routingStrategy;
     const autostartChanged = next.autostart !== previous.autostart;
-    if (autostartChanged) desiredRunning = next.autostart;
-    if (!runtimeChanged && !autostartChanged) return;
+    const tunnelChanged =
+      next.cloudflareQuickTunnelForCursor !== previous.cloudflareQuickTunnelForCursor;
+    if (autostartChanged || tunnelChanged) {
+      tunnelEnabled = next.cloudflareQuickTunnelForCursor;
+      desiredRunning = next.autostart || tunnelEnabled;
+    }
+    if (!runtimeChanged && !autostartChanged && !tunnelChanged) return;
     void initialize()
       .then(() =>
         enqueue(async () => {
+          const tunnelStopFailure =
+            !tunnelEnabled || !desiredRunning ? await tryStopTunnel() : null;
+          if (!tunnelEnabled && tunnelStopFailure !== null) {
+            await supervisor.stop();
+            return;
+          }
           if (runtimeChanged) {
             const effective = await effectiveSettings();
             await supervisor.stop();
             try {
               persistCoreConfig(effective);
+              if (tunnelEnabled && tunnelDiscovery?.state === "found") {
+                persistTunnelConfig(tunnelDiscovery.path);
+              }
               bb.log.info(`core settings reconciled on port ${effective.port}`);
             } finally {
               if (desiredRunning) await startManagedService();
             }
           } else if (desiredRunning) {
             await startManagedService();
-          } else {
-            await supervisor.stop();
+          }
+          if (!desiredRunning) {
+            await stopManagedStack();
+          } else if (tunnelEnabled) {
+            const snapshot = await supervisor.snapshot();
+            await reconcileTunnelForCore(snapshot);
           }
         }),
       )
@@ -826,8 +1080,12 @@ export default async function plugin(bb: BbPluginApi) {
       return requestRestart();
     },
     async endpoints() {
-      await initialize();
-      return { ...endpointsFor(currentPort), apiKey: localApiKey };
+      const status = await computeStatus();
+      return {
+        ...endpointsFor(currentPort),
+        apiKey: localApiKey,
+        publicOpenai: status.tunnel.state === "ready" ? status.tunnel.openaiBaseUrl : null,
+      };
     },
     sourceSettings: () => sourceSettingsView(),
     async sourceSettingsUpdate({ repository, branch }) {
@@ -1007,7 +1265,7 @@ export default async function plugin(bb: BbPluginApi) {
     commands: [
       {
         name: "status",
-        summary: "Core state, versions, and endpoints",
+        summary: "Core and tunnel state, versions, and endpoints",
         usage: "bb agent-proxy status",
       },
       { name: "start", summary: "Start the proxy core", usage: "bb agent-proxy start" },
@@ -1015,7 +1273,7 @@ export default async function plugin(bb: BbPluginApi) {
       { name: "restart", summary: "Restart the proxy core", usage: "bb agent-proxy restart" },
       {
         name: "endpoints",
-        summary: "Print local endpoint URLs and the local API key",
+        summary: "Print local endpoints, the API key, and the ready public endpoint",
         usage: "bb agent-proxy endpoints",
       },
       {
@@ -1057,7 +1315,12 @@ export default async function plugin(bb: BbPluginApi) {
               `openai: ${status.endpoints.openai}`,
               `anthropic: ${status.endpoints.anthropic}`,
               `gemini: ${status.endpoints.gemini}`,
+              `tunnel: ${status.tunnel.state}`,
             ];
+            if ("detail" in status.tunnel) lines.push(`tunnel detail: ${status.tunnel.detail}`);
+            if (status.tunnel.state === "ready") {
+              lines.push(`public openai: ${status.tunnel.openaiBaseUrl}`);
+            }
             if (status.lastExit) {
               lines.push(
                 `last exit: code ${status.lastExit.code ?? "null"} signal ${status.lastExit.signal ?? "null"} (${new Date(status.lastExit.at).toISOString()})`,
@@ -1079,17 +1342,19 @@ export default async function plugin(bb: BbPluginApi) {
             return { exitCode: 0, stdout: "restart requested" };
           }
           case "endpoints": {
-            await initialize();
+            const status = await computeStatus();
             const endpoints = endpointsFor(currentPort);
-            return {
-              exitCode: 0,
-              stdout: [
-                `openai: ${endpoints.openai}`,
-                `anthropic: ${endpoints.anthropic}`,
-                `gemini: ${endpoints.gemini}`,
-                `api key: ${localApiKey}`,
-              ].join("\n"),
-            };
+            const lines = [
+              `openai: ${endpoints.openai}`,
+              `anthropic: ${endpoints.anthropic}`,
+              `gemini: ${endpoints.gemini}`,
+              `api key: ${localApiKey}`,
+              `tunnel: ${status.tunnel.state}`,
+            ];
+            if (status.tunnel.state === "ready") {
+              lines.push(`public openai: ${status.tunnel.openaiBaseUrl}`);
+            }
+            return { exitCode: 0, stdout: lines.join("\n") };
           }
           case "install": {
             const version = await requestInstall(rest[0]);
@@ -1144,9 +1409,9 @@ export default async function plugin(bb: BbPluginApi) {
               exitCode: 2,
               stderr:
                 "usage: bb agent-proxy <status|start|stop|restart|endpoints|install|oauth|providers|usage>\n" +
-                "  status              core state, versions, endpoints\n" +
+                "  status              core and tunnel state, versions, endpoints\n" +
                 "  start|stop|restart  control the proxy core\n" +
-                "  endpoints           local endpoint URLs + API key\n" +
+                "  endpoints           local endpoints, API key, tunnel state, and public endpoint\n" +
                 "  install [ref]       build and install the configured GitHub source\n" +
                 "  oauth <claude|codex> run a browser OAuth flow\n" +
                 "  providers           configured credentials + auth files\n" +
@@ -1160,6 +1425,6 @@ export default async function plugin(bb: BbPluginApi) {
   });
 
   bb.log.info(
-    `loaded (core ${installedVersion(paths) ?? "not installed"}, source ${initialSource.repository}#${initialSource.branch}, port ${initial.port}, routing ${initial.routingStrategy}, autostart ${String(initial.autostart)})`,
+    `loaded (core ${installedVersion(paths) ?? "not installed"}, source ${initialSource.repository}#${initialSource.branch}, port ${initial.port}, routing ${initial.routingStrategy}, autostart ${String(initial.autostart)}, Cloudflare tunnel ${String(initial.cloudflareQuickTunnelForCursor)})`,
   );
 }

--- a/plugins/agent-proxy/skills/agent-proxy/SKILL.md
+++ b/plugins/agent-proxy/skills/agent-proxy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-proxy
-description: Route Claude Code, Codex, and OpenAI-compatible agents through the local CLIProxyAPI proxy managed by the agent-proxy plugin. Use when the user asks to route model traffic through the proxy, needs local proxy endpoints/keys, or wants to manage the proxy core.
+description: Route Claude Code, Codex, Cursor BYOK, and OpenAI-compatible agents through the CLIProxyAPI proxy. Use for local endpoints and keys, the public Cursor Quick Tunnel, or proxy lifecycle work.
 ---
 
 # Agent Proxy (CLIProxyAPI)
@@ -30,6 +30,36 @@ bb agent-proxy endpoints
 
 Auth: pass the local API key as the bearer token / `x-api-key`.
 
+## Cursor BYOK quick tunnel
+
+Enable **Cloudflare Quick Tunnel for Cursor** in Agent Proxy settings. Then run:
+
+```
+bb agent-proxy endpoints
+```
+
+Use these values in Cursor BYOK:
+
+- OpenAI base URL: the `public openai` value. It already ends in `/v1`.
+- OpenAI API key: the `api key` value.
+
+The setting is off by default. When it is off, Agent Proxy does not search for
+`cloudflared`. When it is on, Agent Proxy keeps the core running and starts the
+tunnel helper after the core.
+
+The helper survives bb closing. Stop shuts down the helper before the core. A
+core port change keeps the helper PID and public hostname. A helper restart gets
+a new random hostname.
+
+Quick Tunnels are for development. They do not support SSE. Some Cursor
+requests may fail. This plugin release has not verified a live Cursor request.
+
+Use `bb agent-proxy status` for the tunnel state. If `cloudflared` is missing,
+install it and toggle the setting off and on. If the public endpoint returns
+503, start the core or resolve its port conflict. The helper keeps the current
+hostname during a temporary core outage. If the host runtime cannot run the
+helper, update or reinstall bb, then toggle the setting off and on.
+
 ## Env recipes
 
 - Claude Code: `ANTHROPIC_BASE_URL=<anthropic url> ANTHROPIC_AUTH_TOKEN=<key>`
@@ -40,9 +70,9 @@ Auth: pass the local API key as the bearer token / `x-api-key`.
 ## CLI
 
 ```
-bb agent-proxy status                 # core state, versions, endpoints
+bb agent-proxy status                 # core and tunnel state, versions, endpoints
 bb agent-proxy start|stop|restart     # lifecycle
-bb agent-proxy endpoints              # URLs + local API key
+bb agent-proxy endpoints              # local and public URLs + local API key
 bb agent-proxy install [ref]          # install configured source (release archive, else source build); ref temporarily overrides branch
 bb agent-proxy oauth <claude|codex>   # browser OAuth flow (prints URL, waits)
 bb agent-proxy providers              # configured credentials + auth files
@@ -60,6 +90,8 @@ enables and loads it again.
   the plugin and the core co-own that file.
 - Never edit or load the generated service definition by hand. The plugin owns
   the macOS LaunchAgent or Linux user unit and reloads it when needed.
+- Never start `cloudflared` directly for this feature. The helper restricts the
+  public gateway to `/v1` and checks the local bearer key before proxying.
 - The proxy listens on 127.0.0.1 of the bb server machine only.
 - Save custom GitHub repository and branch values on the Advanced page. A save
   does not replace the running binary; run Install core after the change.

--- a/plugins/agent-proxy/test/app-settings.test.ts
+++ b/plugins/agent-proxy/test/app-settings.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { installDom } from "@bb-kit/core/testing";
+import { fireEvent } from "@testing-library/react";
+
+installDom();
+const { loadPluginApp, renderSlot } = await import("@get-bb/plugin-sdk/testing/app");
+
+const configuration = {
+  values: {
+    autostart: true,
+    cloudflareQuickTunnelForCursor: false,
+    port: 8317,
+    sourceRepository: "router-for-me/CLIProxyAPI",
+    sourceBranch: "latest",
+    routingStrategy: "fill-first" as const,
+  },
+  defaults: {
+    autostart: true,
+    cloudflareQuickTunnelForCursor: false,
+    port: 8317,
+    sourceRepository: "router-for-me/CLIProxyAPI",
+    sourceBranch: "latest",
+    routingStrategy: "round-robin" as const,
+  },
+  managementKeyConfigured: false,
+  sourceError: null,
+};
+
+test("bb Settings contains one button that opens Agent Proxy Advanced", async () => {
+  const app = await loadPluginApp(() => import("../app.tsx"));
+  assert.equal(app.settingsSections.length, 1);
+  const shortcut = app.settingsSections[0];
+  assert.ok(shortcut);
+  assert.equal(shortcut.title, undefined);
+  assert.equal(shortcut.description, undefined);
+
+  const slot = renderSlot(shortcut, {});
+  fireEvent.click(slot.getByRole("button", { name: "Open Agent Proxy settings" }));
+  assert.deepEqual(slot.inspection.navigateCalls, [
+    {
+      method: "toPluginPanel",
+      path: "agent-proxy",
+      options: { subPath: "advanced" },
+    },
+  ]);
+  slot.unmount();
+});
+
+test("Agent Proxy Advanced owns every configuration field", async () => {
+  const app = await loadPluginApp(() => import("../app.tsx"));
+  const panel = app.navPanels[0];
+  assert.ok(panel);
+  const slot = renderSlot(
+    panel,
+    { subPath: "advanced" },
+    {
+      rpc: {
+        configuration: async () => configuration,
+        configurationUpdate: async () => configuration,
+      },
+    },
+  );
+
+  await slot.findByText("Service");
+  slot.getByRole("checkbox", { name: /Keep the proxy running as a login service/ });
+  slot.getByLabelText("Proxy listen port");
+  slot.getByRole("combobox", { name: /Credential routing/ });
+  slot.getByRole("checkbox", { name: /Cloudflare Quick Tunnel/ });
+  slot.getByLabelText("Management key override");
+  slot.getByRole("textbox", { name: /Repository/ });
+  slot.getByRole("textbox", { name: /Branch or ref/ });
+  slot.unmount();
+});

--- a/plugins/agent-proxy/test/app-settings.test.ts
+++ b/plugins/agent-proxy/test/app-settings.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { installDom } from "@bb-kit/core/testing";
-import { fireEvent } from "@testing-library/react";
 
 installDom();
+const { fireEvent, waitFor } = await import("@testing-library/react");
 const { loadPluginApp, renderSlot } = await import("@get-bb/plugin-sdk/testing/app");
 
 const configuration = {
@@ -70,5 +70,47 @@ test("Agent Proxy Advanced owns every configuration field", async () => {
   slot.getByLabelText("Management key override");
   slot.getByRole("textbox", { name: /Repository/ });
   slot.getByRole("textbox", { name: /Branch or ref/ });
+  slot.unmount();
+});
+
+test("Agent Proxy Advanced keeps an empty port draft and validates before saving", async () => {
+  const app = await loadPluginApp(() => import("../app.tsx"));
+  const panel = app.navPanels[0];
+  assert.ok(panel);
+  const updateCalls: unknown[] = [];
+  const slot = renderSlot(
+    panel,
+    { subPath: "advanced" },
+    {
+      rpc: {
+        configuration: async () => configuration,
+        configurationUpdate: async (input) => {
+          updateCalls.push(input);
+          const port = (input as { port: number }).port;
+          return {
+            ...configuration,
+            values: { ...configuration.values, port },
+          };
+        },
+      },
+    },
+  );
+
+  await slot.findByText("Service");
+  const port = slot.getByLabelText("Proxy listen port") as HTMLInputElement;
+  await waitFor(() => assert.equal(port.disabled, false));
+  fireEvent.input(port, { target: { value: "" } });
+  assert.equal(port.value, "");
+
+  const save = slot.getByRole("button", { name: "Save settings" }) as HTMLButtonElement;
+  await waitFor(() => assert.equal(save.disabled, false));
+  fireEvent.click(save);
+  await slot.findByText("Proxy listen port must be an integer from 1 to 65535.");
+  assert.equal(updateCalls.length, 0);
+
+  fireEvent.input(port, { target: { value: "9417" } });
+  fireEvent.click(save);
+  await waitFor(() => assert.equal(updateCalls.length, 1));
+  assert.equal((updateCalls[0] as { port: unknown }).port, 9417);
   slot.unmount();
 });

--- a/plugins/agent-proxy/test/cloudflare-tunnel-runtime.test.ts
+++ b/plugins/agent-proxy/test/cloudflare-tunnel-runtime.test.ts
@@ -234,6 +234,66 @@ test("the gateway destroys upstream work when the downstream disconnects", async
   }
 });
 
+test("an early core response closes the upstream request while the upload remains open", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "agent-proxy-gateway-early-response-"));
+  let closeUpstream!: () => void;
+  const upstreamClosed = new Promise<void>((resolveClosed) => {
+    closeUpstream = resolveClosed;
+  });
+  const core = createServer((request, response) => {
+    request.socket.once("close", closeUpstream);
+    response.writeHead(200, {
+      "content-length": 5,
+      connection: "keep-alive",
+    });
+    response.end("early");
+  });
+  const corePort = await listen(core);
+  const { configPath, key } = gatewayFixture(dir, corePort);
+  const gateway = createGateway(configPath, { upstreamIdleTimeoutMs: 5_000 });
+  const gatewayPort = await listen(gateway);
+  let downstream!: ReturnType<typeof httpRequest>;
+  const earlyResponse = new Promise<GatewayResponse>((resolveResponse, reject) => {
+    downstream = httpRequest(
+      {
+        host: "127.0.0.1",
+        port: gatewayPort,
+        path: "/v1/chat/completions",
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${key}`,
+          "content-length": 1_000_000,
+        },
+      },
+      (response) => {
+        response.setEncoding("utf8");
+        let body = "";
+        response.on("data", (chunk) => {
+          body += chunk;
+        });
+        response.on("end", () =>
+          resolveResponse({ status: response.statusCode ?? 0, body, headers: response.headers }),
+        );
+      },
+    );
+    downstream.once("error", reject);
+  });
+  downstream.write(Buffer.alloc(64 * 1024, "a"));
+
+  try {
+    const response = await eventWithin(earlyResponse, "early core response");
+    assert.equal(response.status, 200);
+    assert.equal(response.body, "early");
+    await eventWithin(upstreamClosed, "early-response upstream cleanup", 250);
+  } finally {
+    downstream.destroy();
+    gateway.closeAllConnections?.();
+    core.closeAllConnections?.();
+    await Promise.all([close(gateway), close(core)]);
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test(
   "the helper retries cloudflared and enforces the loopback gateway boundary",
   { timeout: 20_000 },

--- a/plugins/agent-proxy/test/cloudflare-tunnel-runtime.test.ts
+++ b/plugins/agent-proxy/test/cloudflare-tunnel-runtime.test.ts
@@ -1,0 +1,500 @@
+import assert from "node:assert/strict";
+import { spawn, type ChildProcess } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer, request as httpRequest, type IncomingHttpHeaders } from "node:http";
+import { connect } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+interface CoreRequest {
+  method: string;
+  url: string;
+  headers: IncomingHttpHeaders;
+  body: string;
+}
+
+interface GatewayResponse {
+  status: number;
+  body: string;
+  headers: IncomingHttpHeaders;
+}
+
+function listen(server: ReturnType<typeof createServer>): Promise<number> {
+  return new Promise((resolvePort, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        reject(new Error("test server did not return a TCP address"));
+      } else {
+        resolvePort(address.port);
+      }
+    });
+  });
+}
+
+function close(server: ReturnType<typeof createServer>): Promise<void> {
+  return new Promise((done) => server.close(() => done()));
+}
+
+function requestGateway(options: {
+  port: number;
+  path: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: readonly string[];
+}): Promise<GatewayResponse> {
+  return new Promise((resolveResponse, reject) => {
+    const request = httpRequest(
+      {
+        host: "127.0.0.1",
+        port: options.port,
+        path: options.path,
+        method: options.method ?? "GET",
+        headers: options.headers,
+      },
+      (response) => {
+        response.setEncoding("utf8");
+        let body = "";
+        response.on("data", (chunk) => {
+          body += chunk;
+        });
+        response.on("end", () =>
+          resolveResponse({ status: response.statusCode ?? 0, body, headers: response.headers }),
+        );
+      },
+    );
+    request.once("error", reject);
+    for (const chunk of options.body ?? []) request.write(chunk);
+    request.end();
+  });
+}
+
+function rawRequest(port: number, request: string): Promise<string> {
+  return new Promise((resolveResponse, reject) => {
+    const socket = connect(port, "127.0.0.1");
+    let response = "";
+    socket.setEncoding("utf8");
+    socket.once("connect", () => socket.end(request));
+    socket.on("data", (chunk) => {
+      response += chunk;
+    });
+    socket.once("end", () => resolveResponse(response));
+    socket.once("error", reject);
+  });
+}
+
+async function waitFor<T>(read: () => T | null, detail: string, timeoutMs = 8_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = read();
+    if (value !== null) return value;
+    await new Promise((done) => setTimeout(done, 20));
+  }
+  throw new Error(`timed out waiting for ${detail}`);
+}
+
+function waitForExit(child: ChildProcess): Promise<number | null> {
+  if (child.exitCode !== null) return Promise.resolve(child.exitCode);
+  return new Promise((resolveExit, reject) => {
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error("the tunnel helper did not exit after SIGTERM"));
+    }, 5_000);
+    child.once("exit", (code) => {
+      clearTimeout(timeout);
+      resolveExit(code);
+    });
+  });
+}
+
+test(
+  "the helper retries cloudflared and enforces the loopback gateway boundary",
+  { timeout: 20_000 },
+  async () => {
+    const dir = mkdtempSync(join(tmpdir(), "agent-proxy-tunnel-integration-"));
+    const keyPath = join(dir, "local-api-key");
+    const configPath = join(dir, "desired.json");
+    const observationPath = join(dir, "observation.json");
+    const fakeStatePath = join(dir, "fake-cloudflared.json");
+    const terminatedPath = join(dir, "cloudflared-terminated");
+    const cloudflaredPath = join(dir, "cloudflared.mjs");
+    const fakeHome = join(dir, "home");
+    const runtimePath = fileURLToPath(
+      new URL("../lib/cloudflare-tunnel-runtime.mjs", import.meta.url),
+    );
+    const localApiKey = "unit-test-local-key";
+    writeFileSync(keyPath, `${localApiKey}\n`, { mode: 0o600 });
+    mkdirSync(join(fakeHome, ".cloudflared"), { recursive: true });
+    writeFileSync(join(fakeHome, ".cloudflared", "config.yaml"), "tunnel: user-config\n");
+    writeFileSync(
+      cloudflaredPath,
+      `#!${process.execPath}
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+const statePath = process.env.FAKE_CLOUDFLARED_STATE;
+const terminatedPath = process.env.FAKE_CLOUDFLARED_TERMINATED;
+const previous = statePath && existsSync(statePath) ? JSON.parse(readFileSync(statePath, "utf8")) : { attempts: 0 };
+const state = { attempts: previous.attempts + 1, gatewayUrl: process.argv.at(-1), args: process.argv.slice(2) };
+writeFileSync(statePath, JSON.stringify(state));
+if (state.attempts === 1) process.exit(7);
+process.stderr.write("Quick Tunnel: https://unit-test.trycloudflare.com\\n");
+if (state.attempts === 2) setTimeout(() => process.exit(8), 25);
+process.on("SIGTERM", () => {
+  writeFileSync(terminatedPath, "terminated\\n");
+  process.exit(0);
+});
+setInterval(() => {}, 10_000);
+`,
+      { mode: 0o700 },
+    );
+    chmodSync(cloudflaredPath, 0o700);
+
+    const coreRequests: CoreRequest[] = [];
+    const core = createServer((request, response) => {
+      request.setEncoding("utf8");
+      let body = "";
+      request.on("data", (chunk) => {
+        body += chunk;
+      });
+      request.on("end", () => {
+        coreRequests.push({
+          method: request.method ?? "",
+          url: request.url ?? "",
+          headers: request.headers,
+          body,
+        });
+        response.writeHead(200, {
+          "content-type": "text/plain",
+          connection: "x-upstream-private",
+          "x-upstream-private": "remove-me",
+        });
+        response.write("core:");
+        setImmediate(() => response.end(`${request.method}:${request.url}:${body}`));
+      });
+    });
+    const corePort = await listen(core);
+    const writeConfig = (port: number) => {
+      const temporary = `${configPath}.tmp`;
+      writeFileSync(
+        temporary,
+        `${JSON.stringify({
+          version: 1,
+          corePort: port,
+          cloudflaredPath,
+          localApiKeyPath: keyPath,
+        })}\n`,
+        { mode: 0o600 },
+      );
+      renameSync(temporary, configPath);
+    };
+    writeConfig(corePort);
+
+    let helperError = "";
+    const helperStartedAt = Date.now();
+    const helper = spawn(
+      process.execPath,
+      [runtimePath, "helper", "--config", configPath, "--observation", observationPath],
+      {
+        env: {
+          ...process.env,
+          HOME: fakeHome,
+          FAKE_CLOUDFLARED_STATE: fakeStatePath,
+          FAKE_CLOUDFLARED_TERMINATED: terminatedPath,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    helper.stderr.setEncoding("utf8");
+    helper.stderr.on("data", (chunk) => {
+      helperError += chunk;
+    });
+
+    let secondCore: ReturnType<typeof createServer> | null = null;
+    try {
+      const observation = await waitFor(() => {
+        if (!existsSync(observationPath) || !existsSync(fakeStatePath)) return null;
+        const state = JSON.parse(readFileSync(fakeStatePath, "utf8")) as { attempts?: number };
+        if ((state.attempts ?? 0) < 3) return null;
+        const value = JSON.parse(readFileSync(observationPath, "utf8")) as {
+          phase?: string;
+          ownerPid?: number;
+          publicOrigin?: string;
+        };
+        return value.phase === "ready" ? value : null;
+      }, "a ready tunnel observation");
+      const fakeState = JSON.parse(readFileSync(fakeStatePath, "utf8")) as {
+        attempts: number;
+        gatewayUrl: string;
+        args: string[];
+      };
+      assert.equal(fakeState.attempts, 3);
+      assert.ok(Date.now() - helperStartedAt >= 2_700);
+      assert.deepEqual(fakeState.args.slice(0, 5), [
+        "tunnel",
+        "--config",
+        "/dev/null",
+        "--no-autoupdate",
+        "--url",
+      ]);
+      assert.equal(observation.ownerPid, helper.pid);
+      assert.equal(observation.publicOrigin, "https://unit-test.trycloudflare.com");
+      const gatewayPort = Number.parseInt(new URL(fakeState.gatewayUrl).port, 10);
+
+      const headers = {
+        authorization: `Bearer ${localApiKey}`,
+        host: "public.example.test",
+        forwarded: "for=203.0.113.10",
+        "x-forwarded-for": "203.0.113.10",
+        "cf-connecting-ip": "203.0.113.10",
+        "cf-connecting-ipv6": "2001:db8::1",
+        "cf-pseudo-ipv4": "192.0.2.1",
+        "cf-ew-via": "cloudflare",
+        "cf-connecting-o2o": "1",
+        "cf-worker": "worker.example",
+        via: "1.1 proxy.example",
+        connection: "keep-alive, x-remove, authorization",
+        "x-remove": "private",
+      };
+      const models = await requestGateway({
+        port: gatewayPort,
+        path: "/v1/models?limit=1",
+        headers,
+      });
+      assert.equal(models.status, 200);
+      assert.equal(models.body, "core:GET:/v1/models?limit=1:");
+      assert.equal(models.headers["x-upstream-private"], undefined);
+      assert.equal(coreRequests[0]?.headers.host, `127.0.0.1:${corePort}`);
+      assert.equal(coreRequests[0]?.headers.authorization, `Bearer ${localApiKey}`);
+      assert.equal(coreRequests[0]?.headers.forwarded, undefined);
+      assert.equal(coreRequests[0]?.headers["x-forwarded-for"], undefined);
+      assert.equal(coreRequests[0]?.headers["cf-connecting-ip"], undefined);
+      for (const name of [
+        "cf-connecting-ipv6",
+        "cf-pseudo-ipv4",
+        "cf-ew-via",
+        "cf-connecting-o2o",
+        "cf-worker",
+        "via",
+      ]) {
+        assert.equal(coreRequests[0]?.headers[name], undefined, name);
+      }
+      assert.equal(coreRequests[0]?.headers["x-remove"], undefined);
+
+      const chat = await requestGateway({
+        port: gatewayPort,
+        path: "/v1/chat/completions",
+        method: "POST",
+        headers: { authorization: `Bearer ${localApiKey}` },
+        body: ["hello", " world"],
+      });
+      assert.equal(chat.status, 200);
+      assert.equal(coreRequests.at(-1)?.body, "hello world");
+      const responses = await requestGateway({
+        port: gatewayPort,
+        path: "/v1/responses",
+        method: "POST",
+        headers: { authorization: `Bearer ${localApiKey}` },
+        body: ["response body"],
+      });
+      assert.equal(responses.status, 200);
+
+      for (const [path, expectedStatus] of [
+        ["/", 404],
+        ["/management", 404],
+        ["/v1/%2e%2e/admin", 400],
+        ["/v1%2fadmin", 400],
+        ["/v1/%2525252fadmin", 400],
+        ["http://example.test/v1/models", 400],
+        ["//example.test/v1/models", 400],
+      ] as const) {
+        const before = coreRequests.length;
+        const rejected = await requestGateway({
+          port: gatewayPort,
+          path,
+          headers: { authorization: `Bearer ${localApiKey}` },
+        });
+        assert.equal(rejected.status, expectedStatus, path);
+        assert.equal(coreRequests.length, before, path);
+      }
+
+      const beforeUnauthorized = coreRequests.length;
+      const unauthorized = await requestGateway({
+        port: gatewayPort,
+        path: "/v1/chat/completions",
+        method: "POST",
+        headers: { authorization: "Bearer wrong-key" },
+        body: ["must not reach the core"],
+      });
+      assert.equal(unauthorized.status, 401);
+      assert.equal(coreRequests.length, beforeUnauthorized);
+
+      const beforeContinue = coreRequests.length;
+      const refusedContinue = await rawRequest(
+        gatewayPort,
+        "POST /v1/responses HTTP/1.1\r\n" +
+          "Host: public.example.test\r\n" +
+          "Authorization: Bearer wrong-key\r\n" +
+          "Expect: 100-continue\r\n" +
+          "Content-Length: 10\r\n\r\n",
+      );
+      assert.match(refusedContinue, /^HTTP\/1\.1 401 /);
+      assert.doesNotMatch(refusedContinue, /HTTP\/1\.1 100 Continue/);
+      assert.equal(coreRequests.length, beforeContinue);
+
+      const beforeMissingKey = coreRequests.length;
+      const hiddenKeyPath = `${keyPath}.hidden`;
+      renameSync(keyPath, hiddenKeyPath);
+      const missingKey = await requestGateway({
+        port: gatewayPort,
+        path: "/v1/models",
+        headers: { authorization: `Bearer ${localApiKey}` },
+      });
+      renameSync(hiddenKeyPath, keyPath);
+      assert.equal(missingKey.status, 503);
+      assert.equal(coreRequests.length, beforeMissingKey);
+
+      const upgrade = await requestGateway({
+        port: gatewayPort,
+        path: "/v1/models",
+        headers: {
+          authorization: `Bearer ${localApiKey}`,
+          connection: "upgrade",
+          upgrade: "websocket",
+        },
+      });
+      assert.equal(upgrade.status, 426);
+
+      const secondCoreRequests: CoreRequest[] = [];
+      secondCore = createServer((request, response) => {
+        request.resume();
+        request.on("end", () => {
+          secondCoreRequests.push({
+            method: request.method ?? "",
+            url: request.url ?? "",
+            headers: request.headers,
+            body: "",
+          });
+          response.end("second core");
+        });
+      });
+      const secondCorePort = await listen(secondCore);
+      writeConfig(secondCorePort);
+      const afterPortChange = await requestGateway({
+        port: gatewayPort,
+        path: "/v1/models",
+        headers: { authorization: `Bearer ${localApiKey}` },
+      });
+      assert.equal(afterPortChange.body, "second core");
+      assert.equal(secondCoreRequests.length, 1);
+      const sameObservation = JSON.parse(readFileSync(observationPath, "utf8")) as {
+        ownerPid: number;
+        publicOrigin: string;
+      };
+      assert.equal(sameObservation.ownerPid, observation.ownerPid);
+      assert.equal(sameObservation.publicOrigin, observation.publicOrigin);
+
+      await close(secondCore);
+      secondCore = null;
+      const unavailable = await requestGateway({
+        port: gatewayPort,
+        path: "/v1/models",
+        headers: { authorization: `Bearer ${localApiKey}` },
+      });
+      assert.equal(unavailable.status, 503);
+    } finally {
+      if (secondCore !== null) await close(secondCore);
+      await close(core);
+      const exit = waitForExit(helper);
+      helper.kill("SIGTERM");
+      const exitCode = await exit;
+      assert.equal(exitCode, 0, helperError);
+    }
+
+    await waitFor(() => (existsSync(terminatedPath) ? true : null), "cloudflared cleanup");
+    assert.equal(existsSync(observationPath), false);
+    rmSync(dir, { recursive: true, force: true });
+  },
+);
+
+test(
+  "a ready-observation write failure still terminates cloudflared",
+  { timeout: 10_000 },
+  async () => {
+    const dir = mkdtempSync(join(tmpdir(), "agent-proxy-tunnel-observation-failure-"));
+    const keyPath = join(dir, "local-api-key");
+    const configPath = join(dir, "desired.json");
+    const observationDir = join(dir, "observation-dir");
+    const observationPath = join(observationDir, "observation.json");
+    const terminatedPath = join(dir, "cloudflared-terminated");
+    const cloudflaredPath = join(dir, "cloudflared.mjs");
+    const runtimePath = fileURLToPath(
+      new URL("../lib/cloudflare-tunnel-runtime.mjs", import.meta.url),
+    );
+    writeFileSync(keyPath, "unit-test-local-key\n", { mode: 0o600 });
+    writeFileSync(
+      cloudflaredPath,
+      `#!${process.execPath}
+import { rmSync, writeFileSync } from "node:fs";
+process.on("SIGTERM", () => {
+  writeFileSync(process.env.FAKE_CLOUDFLARED_TERMINATED, "terminated\\n");
+  process.exit(0);
+});
+rmSync(process.env.FAKE_OBSERVATION_DIR, { recursive: true, force: true });
+writeFileSync(process.env.FAKE_OBSERVATION_DIR, "not a directory");
+process.stderr.write("Quick Tunnel: https://unit-test.trycloudflare.com\\n");
+setInterval(() => {}, 10_000);
+`,
+      { mode: 0o700 },
+    );
+    chmodSync(cloudflaredPath, 0o700);
+    writeFileSync(
+      configPath,
+      `${JSON.stringify({
+        version: 1,
+        corePort: 8317,
+        cloudflaredPath,
+        localApiKeyPath: keyPath,
+      })}\n`,
+      { mode: 0o600 },
+    );
+
+    const helper = spawn(
+      process.execPath,
+      [runtimePath, "helper", "--config", configPath, "--observation", observationPath],
+      {
+        env: {
+          ...process.env,
+          FAKE_CLOUDFLARED_TERMINATED: terminatedPath,
+          FAKE_OBSERVATION_DIR: observationDir,
+        },
+        stdio: ["ignore", "ignore", "pipe"],
+      },
+    );
+    let helperError = "";
+    helper.stderr.setEncoding("utf8");
+    helper.stderr.on("data", (chunk) => {
+      helperError += chunk;
+    });
+
+    try {
+      await waitFor(() => (existsSync(terminatedPath) ? true : null), "cloudflared termination");
+      const exitCode = await waitForExit(helper);
+      assert.notEqual(exitCode, 0, helperError);
+    } finally {
+      if (helper.exitCode === null) helper.kill("SIGKILL");
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);

--- a/plugins/agent-proxy/test/cloudflare-tunnel-runtime.test.ts
+++ b/plugins/agent-proxy/test/cloudflare-tunnel-runtime.test.ts
@@ -16,6 +16,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
+import { createGateway } from "../lib/cloudflare-tunnel-runtime.mjs";
 
 interface CoreRequest {
   method: string;
@@ -119,6 +120,119 @@ function waitForExit(child: ChildProcess): Promise<number | null> {
     });
   });
 }
+
+function eventWithin<T>(promise: Promise<T>, detail: string, timeoutMs = 1_000): Promise<T> {
+  return new Promise((resolveEvent, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error(`timed out waiting for ${detail}`)),
+      timeoutMs,
+    );
+    promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        return resolveEvent(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timeout);
+        return reject(error);
+      },
+    );
+  });
+}
+
+function gatewayFixture(dir: string, corePort: number) {
+  const key = "unit-test-local-key";
+  const keyPath = join(dir, "local-api-key");
+  const configPath = join(dir, "desired.json");
+  writeFileSync(keyPath, `${key}\n`, { mode: 0o600 });
+  writeFileSync(
+    configPath,
+    `${JSON.stringify({
+      version: 1,
+      corePort,
+      cloudflaredPath: join(dir, "cloudflared"),
+      localApiKeyPath: keyPath,
+    })}\n`,
+    { mode: 0o600 },
+  );
+  return { configPath, key };
+}
+
+test("the gateway returns 503 and closes an idle upstream before headers", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "agent-proxy-gateway-idle-"));
+  let closeUpstream!: () => void;
+  const upstreamClosed = new Promise<void>((resolveClosed) => {
+    closeUpstream = resolveClosed;
+  });
+  const core = createServer((request) => {
+    request.resume();
+    request.socket.once("close", closeUpstream);
+  });
+  const corePort = await listen(core);
+  const { configPath, key } = gatewayFixture(dir, corePort);
+  const gateway = createGateway(configPath, { upstreamIdleTimeoutMs: 25 });
+  const gatewayPort = await listen(gateway);
+
+  try {
+    const response = await eventWithin(
+      requestGateway({
+        port: gatewayPort,
+        path: "/v1/models",
+        headers: { authorization: `Bearer ${key}` },
+      }),
+      "gateway idle timeout",
+    );
+    assert.equal(response.status, 503);
+    assert.equal(response.body, "CLIProxyAPI is temporarily unavailable\n");
+    await eventWithin(upstreamClosed, "idle upstream cleanup");
+  } finally {
+    gateway.closeAllConnections?.();
+    core.closeAllConnections?.();
+    await Promise.all([close(gateway), close(core)]);
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("the gateway destroys upstream work when the downstream disconnects", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "agent-proxy-gateway-downstream-close-"));
+  let acceptUpstream!: () => void;
+  const upstreamAccepted = new Promise<void>((resolveAccepted) => {
+    acceptUpstream = resolveAccepted;
+  });
+  let closeUpstream!: () => void;
+  const upstreamClosed = new Promise<void>((resolveClosed) => {
+    closeUpstream = resolveClosed;
+  });
+  const core = createServer((request) => {
+    request.resume();
+    request.socket.once("close", closeUpstream);
+    acceptUpstream();
+  });
+  const corePort = await listen(core);
+  const { configPath, key } = gatewayFixture(dir, corePort);
+  const gateway = createGateway(configPath, { upstreamIdleTimeoutMs: 5_000 });
+  const gatewayPort = await listen(gateway);
+  const downstream = httpRequest({
+    host: "127.0.0.1",
+    port: gatewayPort,
+    path: "/v1/models",
+    headers: { authorization: `Bearer ${key}` },
+  });
+  downstream.on("error", () => {});
+  downstream.end();
+
+  try {
+    await eventWithin(upstreamAccepted, "upstream request acceptance");
+    downstream.destroy();
+    await eventWithin(upstreamClosed, "downstream-close upstream cleanup");
+  } finally {
+    downstream.destroy();
+    gateway.closeAllConnections?.();
+    core.closeAllConnections?.();
+    await Promise.all([close(gateway), close(core)]);
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 test(
   "the helper retries cloudflared and enforces the loopback gateway boundary",

--- a/plugins/agent-proxy/test/cloudflare-tunnel.test.ts
+++ b/plugins/agent-proxy/test/cloudflare-tunnel.test.ts
@@ -1,0 +1,303 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import {
+  deriveTunnelStatus,
+  discoverCloudflared,
+  extractTryCloudflareOrigin,
+  installTunnelRuntime,
+  parseTunnelDesiredConfig,
+  parseTunnelObservation,
+  renderTunnelDesiredConfig,
+  resolveTunnelHostRuntime,
+  type BundledTunnelRuntime,
+} from "../lib/cloudflare-tunnel.ts";
+import type { ServiceSnapshot } from "../lib/persistent-service.ts";
+
+const runningService: ServiceSnapshot = {
+  state: "running",
+  pid: 4100,
+  loaded: true,
+  crashCount: 0,
+  lastExit: null,
+};
+
+test("discovers an executable cloudflared as an absolute canonical path", () => {
+  const executablePaths = new Set(["/custom/bin/cloudflared", "/opt/homebrew/bin/cloudflared"]);
+  assert.deepEqual(
+    discoverCloudflared({
+      path: "/missing:/custom/bin",
+      platform: "darwin",
+      executable: (path) => executablePaths.has(path),
+      realpath: (path) => `/canonical${path}`,
+    }),
+    { state: "found", path: "/canonical/custom/bin/cloudflared" },
+  );
+  const fallback = discoverCloudflared({
+    path: "",
+    platform: "darwin",
+    executable: (path) => executablePaths.has(path),
+    realpath: (path) => path,
+  });
+  assert.deepEqual(fallback, { state: "found", path: "/opt/homebrew/bin/cloudflared" });
+});
+
+test("missing cloudflared is an actionable state", () => {
+  const result = discoverCloudflared({
+    path: "/missing",
+    platform: "darwin",
+    executable: () => false,
+  });
+  assert.equal(result.state, "missing");
+  if (result.state === "missing") assert.match(result.detail, /brew install cloudflared/);
+});
+
+test("resolves one stable host runtime and its required service environment", () => {
+  assert.deepEqual(
+    resolveTunnelHostRuntime({
+      platform: "darwin",
+      execPath: "/Applications/bb.app/Contents/MacOS/bb",
+      electronVersion: "40.0.0",
+      realpath: (path) => path,
+    }),
+    {
+      executablePath: "/Applications/bb.app/Contents/MacOS/bb",
+      environment: { ELECTRON_RUN_AS_NODE: "1" },
+    },
+  );
+  assert.deepEqual(
+    resolveTunnelHostRuntime({
+      platform: "linux",
+      execPath: "/tmp/.mount_bb/bb",
+      appImagePath: "/opt/bb.AppImage",
+      executable: (path) => path === "/opt/bb.AppImage",
+      realpath: (path) => path,
+    }),
+    { executablePath: "/opt/bb.AppImage", environment: {} },
+  );
+});
+
+test("parses desired config and rejects relative executable or key paths", () => {
+  const config = {
+    version: 1,
+    corePort: 8317,
+    cloudflaredPath: "/usr/local/bin/cloudflared",
+    localApiKeyPath: "/tmp/local-api-key",
+  } as const;
+  assert.deepEqual(parseTunnelDesiredConfig(config), config);
+  assert.deepEqual(JSON.parse(renderTunnelDesiredConfig(config)), config);
+  assert.equal(parseTunnelDesiredConfig({ ...config, corePort: 0 }), null);
+  assert.equal(parseTunnelDesiredConfig({ ...config, cloudflaredPath: "cloudflared" }), null);
+  assert.equal(parseTunnelDesiredConfig({ ...config, localApiKeyPath: "local-api-key" }), null);
+});
+
+test("extracts only a valid Quick Tunnel origin", () => {
+  assert.equal(
+    extractTryCloudflareOrigin(
+      "INF Your quick Tunnel has been created! Visit it at https://swift-river.trycloudflare.com",
+    ),
+    "https://swift-river.trycloudflare.com",
+  );
+  assert.equal(extractTryCloudflareOrigin("https://trycloudflare.com.example.test"), null);
+  assert.equal(extractTryCloudflareOrigin("https://swift-river.trycloudflare.com.evil.test"), null);
+});
+
+test("parses observation variants without accepting invalid origins", () => {
+  const shared = { version: 1, ownerPid: 4100, sessionId: "session", updatedAt: 123 } as const;
+  assert.deepEqual(parseTunnelObservation({ ...shared, phase: "starting" }), {
+    ...shared,
+    phase: "starting",
+  });
+  assert.deepEqual(
+    parseTunnelObservation({
+      ...shared,
+      phase: "ready",
+      cloudflaredPid: 4200,
+      publicOrigin: "https://swift-river.trycloudflare.com",
+    }),
+    {
+      ...shared,
+      phase: "ready",
+      cloudflaredPid: 4200,
+      publicOrigin: "https://swift-river.trycloudflare.com",
+    },
+  );
+  assert.equal(
+    parseTunnelObservation({
+      ...shared,
+      phase: "ready",
+      cloudflaredPid: 4200,
+      publicOrigin: "https://example.com",
+    }),
+    null,
+  );
+});
+
+test("derives ready only from an observation owned by the live service", () => {
+  const observation = {
+    version: 1,
+    phase: "ready",
+    ownerPid: 4100,
+    sessionId: "session",
+    cloudflaredPid: 4200,
+    publicOrigin: "https://swift-river.trycloudflare.com",
+    updatedAt: 123,
+  } as const;
+  const ready = deriveTunnelStatus({
+    enabled: true,
+    coreDesiredRunning: true,
+    coreLoaded: true,
+    discovery: { state: "found", path: "/usr/local/bin/cloudflared" },
+    preparationError: null,
+    service: runningService,
+    observation,
+  });
+  assert.deepEqual(ready, {
+    state: "ready",
+    pid: 4100,
+    openaiBaseUrl: "https://swift-river.trycloudflare.com/v1",
+  });
+
+  const stale = deriveTunnelStatus({
+    enabled: true,
+    coreDesiredRunning: true,
+    coreLoaded: true,
+    discovery: { state: "found", path: "/usr/local/bin/cloudflared" },
+    preparationError: null,
+    service: { ...runningService, pid: 5000 },
+    observation,
+  });
+  assert.equal(stale.state, "running-without-url");
+  assert.equal("openaiBaseUrl" in stale, false);
+});
+
+test("disabled status wins before cloudflared discovery", () => {
+  assert.deepEqual(
+    deriveTunnelStatus({
+      enabled: false,
+      coreDesiredRunning: false,
+      coreLoaded: false,
+      discovery: null,
+      preparationError: null,
+      service: { ...runningService, loaded: false, pid: null, state: "stopped" },
+      observation: null,
+    }),
+    { state: "disabled" },
+  );
+});
+
+test("disabled status waits for the service to stop and reports stop failures", () => {
+  const shared = {
+    enabled: false,
+    coreDesiredRunning: false,
+    coreLoaded: false,
+    discovery: null,
+    preparationError: null,
+    observation: null,
+  } as const;
+  assert.deepEqual(deriveTunnelStatus({ ...shared, service: runningService }), {
+    state: "stopping",
+    pid: 4100,
+    detail: "Waiting for the operating system to stop the public tunnel.",
+  });
+  assert.deepEqual(
+    deriveTunnelStatus({
+      ...shared,
+      stopError: "Could not stop the public tunnel: launchctl failed",
+      service: runningService,
+    }),
+    {
+      state: "crashed",
+      lastExit: null,
+      detail: "Could not stop the public tunnel: launchctl failed",
+    },
+  );
+});
+
+test("derives actionable missing-binary and stopped states", () => {
+  const missing = deriveTunnelStatus({
+    enabled: true,
+    coreDesiredRunning: true,
+    coreLoaded: true,
+    discovery: { state: "missing", detail: "install cloudflared" },
+    preparationError: null,
+    service: { ...runningService, loaded: false, pid: null, state: "stopped" },
+    observation: null,
+  });
+  assert.deepEqual(missing, { state: "missing-binary", detail: "install cloudflared" });
+
+  const stopped = deriveTunnelStatus({
+    enabled: true,
+    coreDesiredRunning: true,
+    coreLoaded: false,
+    discovery: { state: "found", path: "/usr/local/bin/cloudflared" },
+    preparationError: null,
+    service: { ...runningService, loaded: false, pid: null, state: "stopped" },
+    observation: null,
+  });
+  assert.deepEqual(stopped, { state: "stopped", reason: "core-stopped" });
+});
+
+test("installs a content-addressed runtime and validates it with the host executable", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "agent-proxy-tunnel-runtime-"));
+  const content = Buffer.from("export const value = 1;\n");
+  const sha256 = createHash("sha256").update(content).digest("hex");
+  const runtime: BundledTunnelRuntime = {
+    sourcePath: "/source/cloudflare-tunnel-runtime.mjs",
+    content,
+    sha256,
+    targetPath: join(dir, `cloudflare-tunnel-runtime-${sha256}.mjs`),
+  };
+  const calls: {
+    file: string;
+    args: string[];
+    environment: Readonly<Record<string, string>>;
+  }[] = [];
+  const result = await installTunnelRuntime({
+    runtime,
+    hostRuntime: {
+      executablePath: "/host/runtime",
+      environment: { ELECTRON_RUN_AS_NODE: "1" },
+    },
+    commandRunner: async (file, args, environment) => {
+      calls.push({ file, args, environment });
+      return { code: 0, stdout: "", stderr: "" };
+    },
+  });
+  assert.deepEqual(result, { state: "ready", runtimePath: runtime.targetPath });
+  assert.equal(existsSync(runtime.targetPath), true);
+  assert.deepEqual(readFileSync(runtime.targetPath), content);
+  assert.deepEqual(calls, [
+    {
+      file: "/host/runtime",
+      args: [runtime.targetPath, "helper", "--self-test"],
+      environment: { ELECTRON_RUN_AS_NODE: "1" },
+    },
+  ]);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("reports a host runtime self-test failure as a blocked state", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "agent-proxy-tunnel-runtime-blocked-"));
+  const content = Buffer.from("invalid for this host\n");
+  const sha256 = createHash("sha256").update(content).digest("hex");
+  const runtime: BundledTunnelRuntime = {
+    sourcePath: "/source/cloudflare-tunnel-runtime.mjs",
+    content,
+    sha256,
+    targetPath: join(dir, `cloudflare-tunnel-runtime-${sha256}.mjs`),
+  };
+  const result = await installTunnelRuntime({
+    runtime,
+    hostRuntime: { executablePath: "/host/runtime", environment: {} },
+    commandRunner: async () => ({ code: 1, stdout: "", stderr: "unsupported syntax" }),
+  });
+  assert.deepEqual(result, {
+    state: "blocked",
+    detail: "/host/runtime cannot run the Cloudflare tunnel helper: unsupported syntax",
+  });
+  rmSync(dir, { recursive: true, force: true });
+});

--- a/plugins/agent-proxy/test/core-process.test.ts
+++ b/plugins/agent-proxy/test/core-process.test.ts
@@ -31,6 +31,16 @@ function successful(stdout = ""): CommandResult {
   return { code: 0, stdout, stderr: "" };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 function launchctlOutput(job: FakeJob): string {
   return `gui/501/${TEST_LABEL} = {
 \tstate = ${job.state}
@@ -94,7 +104,9 @@ function makeFakeLaunchctl(initial: Partial<FakeJob> = {}) {
 function makeSupervisor(options: {
   installed?: () => boolean;
   launchctl?: ReturnType<typeof makeFakeLaunchctl>;
+  fetchImpl?: typeof fetch;
   logLimit?: number;
+  now?: () => number;
 }) {
   const dir = mkdtempSync(join(tmpdir(), "agent-proxy-launchd-"));
   const launchctl = options.launchctl ?? makeFakeLaunchctl();
@@ -111,11 +123,11 @@ function makeSupervisor(options: {
     isInstalled: options.installed ?? (() => true),
     probeUrl: () => "http://127.0.0.1:8317/",
     runCommand: launchctl.runner,
-    fetchImpl: (() => Promise.resolve(new Response("ok"))) as typeof fetch,
+    fetchImpl: options.fetchImpl ?? ((() => Promise.resolve(new Response("ok"))) as typeof fetch),
     monitorIntervalMs: 10,
     ...(options.logLimit === undefined ? {} : { logLimit: options.logLimit }),
     platform: "darwin",
-    now: () => 1_700_000_000_000,
+    now: options.now ?? (() => 1_700_000_000_000),
     onChange: (snapshot) => transitions.push(snapshot.state),
   });
   return { supervisor, transitions, launchctl, plistPath, logPath };
@@ -235,6 +247,120 @@ test("reports a launchd crash and its last exit", async () => {
   });
 });
 
+test("reports a signal-only launchd exit as crashed", async () => {
+  const launchctl = makeFakeLaunchctl({
+    loaded: true,
+    state: "waiting",
+    runs: 2,
+    lastExitCode: 0,
+    lastSignal: "Terminated: 15",
+  });
+  const { supervisor } = makeSupervisor({ launchctl });
+  const snapshot = await supervisor.snapshot();
+  assert.equal(snapshot.state, "crashed");
+  assert.deepEqual(snapshot.lastExit, {
+    code: 0,
+    signal: "Terminated: 15",
+    at: 1_700_000_000_000,
+  });
+});
+
+test("launchd stop tolerates only missing-service disable errors", async () => {
+  const missingLaunchctl = makeFakeLaunchctl();
+  const missingRunner = missingLaunchctl.runner;
+  missingLaunchctl.runner = async (file, args) =>
+    args[0] === "disable"
+      ? { code: 113, stdout: "", stderr: "Could not find service" }
+      : missingRunner(file, args);
+  const missing = makeSupervisor({ launchctl: missingLaunchctl });
+  assert.equal((await missing.supervisor.stop()).state, "stopped");
+
+  const rejectedLaunchctl = makeFakeLaunchctl();
+  const rejectedRunner = rejectedLaunchctl.runner;
+  rejectedLaunchctl.runner = async (file, args) =>
+    args[0] === "disable"
+      ? { code: 77, stdout: "", stderr: "permission denied" }
+      : rejectedRunner(file, args);
+  const rejected = makeSupervisor({ launchctl: rejectedLaunchctl });
+  await assert.rejects(rejected.supervisor.stop(), /permission denied/);
+});
+
+test("launchd stop overtakes and discards a stale observation", { timeout: 2_000 }, async () => {
+  const probeStarted = deferred<void>();
+  const probeResponse = deferred<Response>();
+  let nowCalls = 0;
+  const launchctl = makeFakeLaunchctl({
+    loaded: true,
+    state: "running",
+    pid: 9_001,
+    runs: 2,
+    lastExitCode: 7,
+  });
+  const { supervisor, transitions } = makeSupervisor({
+    launchctl,
+    fetchImpl: (() => {
+      probeStarted.resolve();
+      return probeResponse.promise;
+    }) as typeof fetch,
+    now: () => 1_700_000_000_000 + ++nowCalls,
+  });
+
+  const staleObservation = supervisor.snapshot();
+  await probeStarted.promise;
+  const stopped = await supervisor.stop();
+  assert.equal(stopped.state, "stopped");
+  probeResponse.resolve(new Response("ok"));
+
+  assert.deepEqual(await staleObservation, stopped);
+  assert.deepEqual(transitions, ["stopping", "stopped"]);
+  assert.equal(nowCalls, 0);
+});
+
+test("launchd lifecycle operations are serialized", { timeout: 2_000 }, async () => {
+  const enableStarted = deferred<void>();
+  const releaseEnable = deferred<void>();
+  const launchctl = makeFakeLaunchctl();
+  const baseRunner = launchctl.runner;
+  launchctl.runner = async (file, args) => {
+    if (args[0] === "enable") {
+      enableStarted.resolve();
+      await releaseEnable.promise;
+    }
+    return baseRunner(file, args);
+  };
+  const { supervisor } = makeSupervisor({ launchctl });
+
+  const starting = supervisor.start();
+  await enableStarted.promise;
+  const stopping = supervisor.stop();
+  assert.equal(
+    launchctl.calls.some((args) => args[0] === "bootout" || args[0] === "disable"),
+    false,
+  );
+
+  releaseEnable.resolve();
+  const [started, stopped] = await Promise.all([starting, stopping]);
+  assert.equal(started.state, "running");
+  assert.equal(stopped.state, "stopped");
+});
+
+test("a rejected launchd lifecycle operation does not poison later work", async () => {
+  const launchctl = makeFakeLaunchctl({ loaded: true, state: "running", pid: 9_001 });
+  const baseRunner = launchctl.runner;
+  let rejectDisable = true;
+  launchctl.runner = async (file, args) => {
+    if (args[0] === "disable" && rejectDisable) {
+      rejectDisable = false;
+      return { code: 77, stdout: "", stderr: "permission denied" };
+    }
+    return baseRunner(file, args);
+  };
+  const { supervisor } = makeSupervisor({ launchctl });
+
+  await assert.rejects(supervisor.stop(), /permission denied/);
+  assert.equal((await supervisor.stop()).state, "stopped");
+});
+
 test("aborting the monitor does not stop the external service", async () => {
   const { supervisor, launchctl } = makeSupervisor({});
   await supervisor.start();
@@ -327,11 +453,15 @@ function makeFakeSystemctl(initial: Partial<FakeSystemdJob> = {}) {
   return { calls, job, runner };
 }
 
-function makeSystemdSupervisor(initial: Partial<FakeSystemdJob> = {}) {
+function makeSystemdSupervisor(
+  initial: Partial<FakeSystemdJob> = {},
+  options: { fetchImpl?: typeof fetch; now?: () => number } = {},
+) {
   const dir = mkdtempSync(join(tmpdir(), "agent-proxy-systemd-"));
   const systemctl = makeFakeSystemctl(initial);
   const unitPath = join(dir, ".config", "systemd", "user", "agent-proxy.service");
   const logPath = join(dir, "core", "service", "core.log");
+  const transitions: string[] = [];
   const supervisor = new SystemdSupervisor({
     label: TEST_LABEL,
     unitPath,
@@ -341,12 +471,13 @@ function makeSystemdSupervisor(initial: Partial<FakeSystemdJob> = {}) {
     isInstalled: () => true,
     probeUrl: () => "http://127.0.0.1:8317/",
     runCommand: systemctl.runner,
-    fetchImpl: (() => Promise.resolve(new Response("ok"))) as typeof fetch,
+    fetchImpl: options.fetchImpl ?? ((() => Promise.resolve(new Response("ok"))) as typeof fetch),
     monitorIntervalMs: 10,
     platform: "linux",
-    now: () => 1_700_000_000_000,
+    now: options.now ?? (() => 1_700_000_000_000),
+    onChange: (snapshot) => transitions.push(snapshot.state),
   });
-  return { supervisor, systemctl, unitPath, logPath };
+  return { supervisor, transitions, systemctl, unitPath, logPath };
 }
 
 test("renders and parses a persistent user systemd service", () => {
@@ -459,4 +590,37 @@ test("systemd maps numeric CLD_KILLED exit metadata to a signal", async () => {
   const snapshot = await killed.supervisor.snapshot();
   assert.equal(snapshot.lastExit?.code, null);
   assert.equal(snapshot.lastExit?.signal, "15");
+});
+
+test("systemd stop overtakes and discards a stale observation", { timeout: 2_000 }, async () => {
+  const probeStarted = deferred<void>();
+  const probeResponse = deferred<Response>();
+  let nowCalls = 0;
+  const { supervisor, transitions } = makeSystemdSupervisor(
+    {
+      enabled: true,
+      activeState: "active",
+      pid: 10_001,
+      restarts: 2,
+      exitStatus: 7,
+      exitCode: 1,
+    },
+    {
+      fetchImpl: (() => {
+        probeStarted.resolve();
+        return probeResponse.promise;
+      }) as typeof fetch,
+      now: () => 1_700_000_000_000 + ++nowCalls,
+    },
+  );
+
+  const staleObservation = supervisor.snapshot();
+  await probeStarted.promise;
+  const stopped = await supervisor.stop();
+  assert.equal(stopped.state, "stopped");
+  probeResponse.resolve(new Response("ok"));
+
+  assert.deepEqual(await staleObservation, stopped);
+  assert.deepEqual(transitions, ["stopping", "stopped"]);
+  assert.equal(nowCalls, 0);
 });

--- a/plugins/agent-proxy/test/core-process.test.ts
+++ b/plugins/agent-proxy/test/core-process.test.ts
@@ -107,6 +107,7 @@ function makeSupervisor(options: {
   fetchImpl?: typeof fetch;
   logLimit?: number;
   now?: () => number;
+  platform?: NodeJS.Platform;
 }) {
   const dir = mkdtempSync(join(tmpdir(), "agent-proxy-launchd-"));
   const launchctl = options.launchctl ?? makeFakeLaunchctl();
@@ -126,12 +127,25 @@ function makeSupervisor(options: {
     fetchImpl: options.fetchImpl ?? ((() => Promise.resolve(new Response("ok"))) as typeof fetch),
     monitorIntervalMs: 10,
     ...(options.logLimit === undefined ? {} : { logLimit: options.logLimit }),
-    platform: "darwin",
+    platform: options.platform ?? "darwin",
     now: options.now ?? (() => 1_700_000_000_000),
     onChange: (snapshot) => transitions.push(snapshot.state),
   });
   return { supervisor, transitions, launchctl, plistPath, logPath };
 }
+
+test("unsupported launchd lifecycle calls return rejected promises", async () => {
+  const { supervisor } = makeSupervisor({ platform: "linux" });
+
+  for (const operation of ["start", "stop", "restart"] as const) {
+    let outcome: Promise<unknown> | undefined;
+    assert.doesNotThrow(() => {
+      outcome = supervisor[operation]();
+    });
+    assert.ok(outcome instanceof Promise);
+    await assert.rejects(outcome, /persistent service requires macOS launchd/);
+  }
+});
 
 test("renders a private, persistent launch agent definition", () => {
   const plist = renderLaunchAgentPlist({
@@ -455,7 +469,7 @@ function makeFakeSystemctl(initial: Partial<FakeSystemdJob> = {}) {
 
 function makeSystemdSupervisor(
   initial: Partial<FakeSystemdJob> = {},
-  options: { fetchImpl?: typeof fetch; now?: () => number } = {},
+  options: { fetchImpl?: typeof fetch; now?: () => number; platform?: NodeJS.Platform } = {},
 ) {
   const dir = mkdtempSync(join(tmpdir(), "agent-proxy-systemd-"));
   const systemctl = makeFakeSystemctl(initial);
@@ -473,12 +487,25 @@ function makeSystemdSupervisor(
     runCommand: systemctl.runner,
     fetchImpl: options.fetchImpl ?? ((() => Promise.resolve(new Response("ok"))) as typeof fetch),
     monitorIntervalMs: 10,
-    platform: "linux",
+    platform: options.platform ?? "linux",
     now: options.now ?? (() => 1_700_000_000_000),
     onChange: (snapshot) => transitions.push(snapshot.state),
   });
   return { supervisor, transitions, systemctl, unitPath, logPath };
 }
+
+test("unsupported systemd lifecycle calls return rejected promises", async () => {
+  const { supervisor } = makeSystemdSupervisor({}, { platform: "darwin" });
+
+  for (const operation of ["start", "stop", "restart"] as const) {
+    let outcome: Promise<unknown> | undefined;
+    assert.doesNotThrow(() => {
+      outcome = supervisor[operation]();
+    });
+    assert.ok(outcome instanceof Promise);
+    await assert.rejects(outcome, /persistent service requires Linux systemd/);
+  }
+});
 
 test("renders and parses a persistent user systemd service", () => {
   const unit = renderSystemdUserUnit({

--- a/plugins/agent-proxy/test/persistent-service.test.ts
+++ b/plugins/agent-proxy/test/persistent-service.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  renderLaunchAgentPlist,
+  renderSystemdUserUnit,
+  type ManagedProgramSpec,
+} from "../lib/persistent-service.ts";
+
+const program: ManagedProgramSpec = {
+  command: ["/usr/bin/example", "serve", "--config", "/tmp/Agent Proxy/config.json"],
+  environment: { ELECTRON_RUN_AS_NODE: "1" },
+  workingDirectory: "/tmp/Agent Proxy",
+  logPath: "/tmp/Agent Proxy/service.log",
+  readinessUrl: () => "http://127.0.0.1:8123/",
+};
+
+test("renders any managed command in launchd and systemd definitions", () => {
+  const launchd = renderLaunchAgentPlist({ label: "com.example.service", program });
+  assert.match(launchd, /<string>\/usr\/bin\/example<\/string>/);
+  assert.match(launchd, /<string>serve<\/string>/);
+  assert.match(launchd, /<string>--config<\/string>/);
+  assert.match(launchd, /<string>\/tmp\/Agent Proxy\/config\.json<\/string>/);
+  assert.match(launchd, /<string>\/tmp\/Agent Proxy<\/string>/);
+  assert.match(launchd, /<key>ELECTRON_RUN_AS_NODE<\/key>\s*<string>1<\/string>/);
+
+  const systemd = renderSystemdUserUnit({ label: "com.example.service", program });
+  assert.match(
+    systemd,
+    /ExecStart="\/usr\/bin\/example" "serve" "--config" "\/tmp\/Agent Proxy\/config\.json"/,
+  );
+  assert.match(systemd, /^WorkingDirectory=\/tmp\/Agent Proxy$/m);
+  assert.match(systemd, /^Environment="ELECTRON_RUN_AS_NODE=1"$/m);
+});

--- a/plugins/agent-proxy/test/plugin-settings.test.ts
+++ b/plugins/agent-proxy/test/plugin-settings.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  DEFAULT_AGENT_PROXY_SETTINGS,
+  normalizeAgentProxySettings,
+} from "../lib/plugin-settings.ts";
+
+test("normalizes legacy declarative settings into plugin-owned settings", () => {
+  assert.deepEqual(
+    normalizeAgentProxySettings({
+      autostart: false,
+      cloudflareQuickTunnelForCursor: true,
+      port: "9417",
+      sourceRepository: " example/proxy ",
+      sourceBranch: " feature/settings ",
+      routingStrategy: "fill-first",
+      managementKey: "never persisted with non-secret settings",
+    }),
+    {
+      autostart: false,
+      cloudflareQuickTunnelForCursor: true,
+      port: 9417,
+      sourceRepository: "example/proxy",
+      sourceBranch: "feature/settings",
+      routingStrategy: "fill-first",
+    },
+  );
+});
+
+test("invalid stored values fall back to safe defaults", () => {
+  assert.deepEqual(
+    normalizeAgentProxySettings({
+      autostart: "yes",
+      cloudflareQuickTunnelForCursor: null,
+      port: 70_000,
+      sourceRepository: " ",
+      sourceBranch: "",
+      routingStrategy: "random",
+    }),
+    DEFAULT_AGENT_PROXY_SETTINGS,
+  );
+});

--- a/plugins/agent-proxy/test/plugin-settings.test.ts
+++ b/plugins/agent-proxy/test/plugin-settings.test.ts
@@ -40,3 +40,10 @@ test("invalid stored values fall back to safe defaults", () => {
     DEFAULT_AGENT_PROXY_SETTINGS,
   );
 });
+
+test("a persisted port with a numeric prefix falls back to the default", () => {
+  assert.equal(
+    normalizeAgentProxySettings({ port: "9417garbage" }).port,
+    DEFAULT_AGENT_PROXY_SETTINGS.port,
+  );
+});


### PR DESCRIPTION
## Summary

- Add an opt-in Cloudflare Quick Tunnel for the CLIProxyAPI OpenAI-compatible endpoint.
- Show the public endpoint in Agent Proxy for Cursor BYOK setup.
- Move all Agent Proxy configuration to its Advanced page.
- Leave one navigation button in bb Settings and migrate existing values automatically.

## Verification

- Agent Proxy test suite: 88 passed
- Root typecheck, test, lint, and build passed
- Pinned bb UI flow verified for the Settings shortcut and dedicated form

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in Cloudflare Quick Tunnel that exposes the Agent Proxy OpenAI-compatible `/v1` endpoint publicly for Cursor BYOK, and moves all Agent Proxy configuration to the Advanced page.

**New Features**
- The home page shows tunnel state plus the public URL and API key for Cursor BYOK.
- bb Settings now shows one button that opens the Advanced page.

**Refactors**
- Extracted launchd/systemd supervision into a shared `persistent-service` used by both the proxy core and the tunnel runtime.
- Settings are now plugin-owned and migrate from legacy declarative values automatically; invalid values fall back to defaults.
- Added a `routingStrategy` setting with `round-robin` as the default.

<sup>Written for commit f7c3fc8d151fecaa38d0f5b4c726369a9b96dcd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/smsunarto/bb-plugins/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

