### PR TITLE
Fix Amp WebSocket disconnect recovery

### DIFF
--- a/plugins/amp/src/bridge/events.ts
+++ b/plugins/amp/src/bridge/events.ts
@@ -46,6 +46,7 @@ export type AmpErrorSubtype =
   | "error_max_turns"
   | "unsupported_option"
   | "auth_required"
+  | "stream_disconnected"
   | "unknown";
 
 /** Token usage as Amp reports it on the execute wire. Provider-owned:
@@ -375,6 +376,8 @@ function normalizeImageMimeType(value: string): string | null {
 // Error classification
 // ---------------------------------------------------------------------------
 
+const OPENAI_WEBSOCKET_CLOSED_1006 = /^OpenAI WebSocket closed:\s*1006(?:\s|\.|$)/;
+
 /** Amp CLI auth failures, matched on the error text Amp actually emits. */
 export function isAuthError(message: string): boolean {
   const lower = message.toLowerCase();
@@ -396,6 +399,7 @@ export function isAuthError(message: string): boolean {
  */
 export function classifyAmpError(subtype: string | undefined, message: string): AmpErrorSubtype {
   if (subtype === "error_max_turns") return "error_max_turns";
+  if (OPENAI_WEBSOCKET_CLOSED_1006.test(message)) return "stream_disconnected";
   if (subtype === "error_during_execution") {
     return isAuthError(message) ? "auth_required" : "error_during_execution";
   }

--- a/plugins/amp/src/bridge/project.ts
+++ b/plugins/amp/src/bridge/project.ts
@@ -155,6 +155,7 @@ export function projectAmpEvent(event: AmpEvent, ctx: ProjectionContext): void {
         message: event.message,
         settlesTurn: true,
         category: categoryFor(event.subtype),
+        ...(event.subtype === "stream_disconnected" ? { willRetry: false } : {}),
       });
       return;
     case "raw":
@@ -263,6 +264,8 @@ function categoryFor(subtype: AmpErrorSubtype): ProviderErrorCategory {
       return "bad-request";
     case "error_during_execution":
       return "internal";
+    case "stream_disconnected":
+      return "stream-disconnected";
     case "unknown":
       return "unknown";
   }

--- a/plugins/amp/src/bridge/session.ts
+++ b/plugins/amp/src/bridge/session.ts
@@ -16,14 +16,17 @@
  * truthfully declare `steerMode: "inject"`.
  */
 import { createHash } from "node:crypto";
-import type { BridgeExecutionOptions } from "@get-bb/plugin-sdk/provider-bridge";
+import type {
+  BridgeExecutionOptions,
+  ProviderRecoveryHint,
+} from "@get-bb/plugin-sdk/provider-bridge";
 import {
   shapesEqual,
   type AmpConversation,
   type OrbRun,
   type SessionShape,
 } from "./conversation.ts";
-import type { AmpEventBatch } from "./events.ts";
+import type { AmpEvent, AmpEventBatch } from "./events.ts";
 import { toSessionShape } from "./options.ts";
 import { projectAmpEvent, type OracleReports, type ProjectionContext } from "./project.ts";
 import { AMP_THREAD_LINK_KIND } from "./shapes.ts";
@@ -163,7 +166,6 @@ interface ActiveTurn {
   /** Set while the pump sits in the post-terminal idle window; calling it
    * cancels the timer and keeps the pump reading. */
   steerWake: (() => void) | null;
-  authRequired: boolean;
 }
 
 interface LiveLocal {
@@ -172,6 +174,16 @@ interface LiveLocal {
   /** Held manually across turns: a for-await `break` would close the
    * generator, and `batches()` is one continuous stream per CLI process. */
   iterator: AsyncIterator<AmpEventBatch>;
+}
+
+interface PumpOutcome {
+  readonly disposition: "keep-warm" | "retire";
+  readonly recovery?: ProviderRecoveryHint;
+}
+
+interface PendingLocalReplacement {
+  readonly reason: string;
+  readonly contextLost: boolean;
 }
 
 function promptText(input: readonly unknown[]): string {
@@ -188,6 +200,27 @@ function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function recoveryFor(events: readonly AmpEvent[]): ProviderRecoveryHint | undefined {
+  for (const event of events) {
+    if (event.kind !== "resultError") continue;
+    if (event.subtype === "auth_required") {
+      return {
+        kind: "authRequired",
+        message: "Amp is not signed in. Run `amp login` in a terminal, then retry.",
+        retryable: true,
+      };
+    }
+    if (event.subtype === "stream_disconnected") {
+      return {
+        kind: "restartRecommended",
+        message: "Amp disconnected from OpenAI. Retry to continue this thread in a fresh process.",
+        retryable: true,
+      };
+    }
+  }
+  return undefined;
+}
+
 export function createAmpSession(args: AmpSessionArgs): AmpSession {
   const { threadId, providerThreadId, cwd, record, writer, store, deps } = args;
 
@@ -195,6 +228,7 @@ export function createAmpSession(args: AmpSessionArgs): AmpSession {
   let orbRun: OrbRun | null = null;
   let active: ActiveTurn | null = null;
   let stopping: "interrupt" | "release" | null = null;
+  let pendingLocalReplacement: PendingLocalReplacement | null = null;
 
   const shapeFor = (options: BridgeExecutionOptions): SessionShape =>
     toSessionShape({
@@ -244,12 +278,19 @@ export function createAmpSession(args: AmpSessionArgs): AmpSession {
     ]);
   };
 
-  const persistAmpThreadId = (ampThreadId: string): void => {
-    if (record.ampThreadId !== null) return;
-    record.ampThreadId = ampThreadId;
-    // Write-through so a crash right now still resumes into the Amp thread.
-    void store.write(providerThreadId, { ...record }).catch(() => {});
-    announceThreadLink();
+  let ampThreadIdPersistenceAttempted = record.ampThreadId !== null;
+  const persistAmpThreadId = async (ampThreadId: string): Promise<void> => {
+    if (record.ampThreadId === null) {
+      record.ampThreadId = ampThreadId;
+      announceThreadLink();
+    }
+    if (ampThreadIdPersistenceAttempted) return;
+    ampThreadIdPersistenceAttempted = true;
+    try {
+      await store.write(providerThreadId, { ...record });
+    } catch {
+      return;
+    }
   };
 
   const idleWindow = (turn: ActiveTurn): Promise<boolean> =>
@@ -292,7 +333,7 @@ export function createAmpSession(args: AmpSessionArgs): AmpSession {
     ctx: ProjectionContext,
     iterator: AsyncIterator<AmpEventBatch>,
     steerable: boolean,
-  ): Promise<void> => {
+  ): Promise<PumpOutcome> => {
     const scribe = turn.scribe;
     try {
       while (true) {
@@ -301,30 +342,36 @@ export function createAmpSession(args: AmpSessionArgs): AmpSession {
           result = await iterator.next();
         } catch (error) {
           settleAfterStreamEnd(scribe, error);
-          return;
+          return { disposition: "retire" };
         }
         if (result.done === true) {
           settleAfterStreamEnd(scribe, undefined);
-          return;
+          return { disposition: "retire" };
         }
         const batch = result.value;
-        if (batch.ampThreadId !== null) persistAmpThreadId(batch.ampThreadId);
+        if (batch.ampThreadId !== null) await persistAmpThreadId(batch.ampThreadId);
+        if (stopping !== null) {
+          settleAfterStreamEnd(scribe, undefined);
+          return { disposition: "retire" };
+        }
         for (const event of batch.events) {
-          if (event.kind === "resultError" && event.subtype === "auth_required") {
-            turn.authRequired = true;
-          }
           projectAmpEvent(event, ctx);
+        }
+        const recovery = recoveryFor(batch.events);
+        if (batch.terminal || scribe.settled) {
+          if (!scribe.settled) scribe.settle("completed");
+          return {
+            disposition: "retire",
+            ...(recovery === undefined ? {} : { recovery }),
+          };
         }
         // Live evidence (U5 smoke): in interactive stream-json mode the CLI
         // ends a turn with stop_reason on the assistant message and sends no
         // result line, so assistantStop is the primary turn-end signal —
         // exactly the signal bridge-core keyed on. Result lines still count:
         // that is how zero-work and error turns terminate.
-        const turnEnded =
-          batch.terminal || batch.events.some((event) => event.kind === "assistantStop");
+        const turnEnded = batch.events.some((event) => event.kind === "assistantStop");
         if (!turnEnded) continue;
-        // A resultError already settled the turn through scribe.fail.
-        if (scribe.settled) return;
         if (steerable) {
           const steered = await idleWindow(turn);
           // A stop arrived inside the window: one more next() surfaces the
@@ -333,38 +380,54 @@ export function createAmpSession(args: AmpSessionArgs): AmpSession {
           if (steered) continue;
         }
         scribe.settle("completed");
-        return;
+        return { disposition: "keep-warm" };
       }
     } finally {
       turn.steerWake = null;
       writer.flush();
-      if (active === turn) active = null;
     }
   };
 
-  const reportAuthRequired = (turn: ActiveTurn): void => {
-    if (!turn.authRequired) return;
-    writer.recovery({
-      kind: "authRequired",
-      message: "Amp is not signed in. Run `amp login` in a terminal, then retry.",
-      retryable: true,
-    });
+  const closeIterator = async (iterator: AsyncIterator<AmpEventBatch>): Promise<void> => {
+    try {
+      await iterator.return?.();
+    } catch {
+      return;
+    }
+  };
+
+  const retireLocal = (
+    live: LiveLocal,
+    replacement: PendingLocalReplacement | null,
+  ): Promise<void> => {
+    if (local === live) {
+      local = null;
+      if (replacement !== null) pendingLocalReplacement = replacement;
+    }
+    if (!live.conversation.aborted) live.conversation.abort("restart");
+    return closeIterator(live.iterator);
   };
 
   const ensureLocal = (options: BridgeExecutionOptions): LiveLocal => {
     const next = shapeFor(options);
     // A CLI that exited or was interrupted just respawns with --continue;
-    // that is not a shape restart and gets no session.replaced notice.
+    // announce that rebuild when the next turn creates its replacement.
     if (local !== null && (local.conversation.closed || local.conversation.aborted)) {
-      local = null;
+      void retireLocal(local, {
+        reason: "the Amp process ended",
+        contextLost: record.ampThreadId === null,
+      });
     }
     if (local !== null && !shapesEqual(local.shape, next)) {
       const plan = planRestart({ current: local.shape, next, ampThreadId: record.ampThreadId });
       writer.replaced({ providerThreadId, reason: plan.reason, contextLost: plan.contextLost });
-      local.conversation.abort("restart");
-      local = null;
+      void retireLocal(local, null);
     }
     if (local === null) {
+      if (pendingLocalReplacement !== null) {
+        writer.replaced({ providerThreadId, ...pendingLocalReplacement });
+        pendingLocalReplacement = null;
+      }
       const conversation = deps.createConversation({
         shape: next,
         continueFrom: record.ampThreadId,
@@ -403,8 +466,14 @@ export function createAmpSession(args: AmpSessionArgs): AmpSession {
         writer.flush();
       }
     });
-    await pump(turn, ctx, live.iterator, true);
-    reportAuthRequired(turn);
+    const outcome = await pump(turn, ctx, live.iterator, true);
+    if (outcome.disposition === "retire") {
+      await retireLocal(live, {
+        reason: "the Amp process ended",
+        contextLost: record.ampThreadId === null,
+      });
+    }
+    if (outcome.recovery !== undefined) writer.recovery(outcome.recovery);
   };
 
   const runOrbTurn = async (
@@ -422,12 +491,15 @@ export function createAmpSession(args: AmpSessionArgs): AmpSession {
     // Orb prompts are one-shot strings with no delivery signal; starting the
     // execution is the acceptance.
     if (turnArgs.clientRequestId !== null) turn.scribe.accept(turnArgs.clientRequestId);
+    const iterator = run.batches()[Symbol.asyncIterator]();
     try {
-      await pump(turn, ctx, run.batches()[Symbol.asyncIterator](), false);
+      const outcome = await pump(turn, ctx, iterator, false);
+      if (outcome.recovery !== undefined) writer.recovery(outcome.recovery);
     } finally {
+      run.abort();
+      await closeIterator(iterator);
       orbRun = null;
     }
-    reportAuthRequired(turn);
   };
 
   return {
@@ -453,13 +525,15 @@ export function createAmpSession(args: AmpSessionArgs): AmpSession {
         scribe,
         done: Promise.resolve(),
         steerWake: null,
-        authRequired: false,
       };
       active = turn;
-      turn.done =
+      const run =
         record.executionTarget === "orb"
           ? runOrbTurn(turn, ctx, text, turnArgs)
           : runLocalTurn(turn, ctx, ensureLocal(turnArgs.options), text, turnArgs.clientRequestId);
+      turn.done = run.finally(() => {
+        if (active === turn) active = null;
+      });
       await turn.done;
     },
 

--- a/plugins/amp/src/bridge/timeline.ts
+++ b/plugins/amp/src/bridge/timeline.ts
@@ -27,6 +27,7 @@ import {
   type DeltaPresentation,
   type JsonValue,
   type ProviderErrorCategory,
+  type ProviderRecoveryHint,
   type ThreadDelta,
   type ThreadEventItemStatus,
   type ThreadEventTokenUsageBreakdown,
@@ -84,15 +85,6 @@ export type ItemOutcome =
 // ---------------------------------------------------------------------------
 // ThreadWriter — session scope
 // ---------------------------------------------------------------------------
-
-/** An unsolicited recovery hint. `message` is required by the runtime's
- *  `providerRecoveryNotificationSchema` (deviation from the sketch, which had
- *  it optional). */
-export interface ProviderRecoveryHint {
-  readonly kind: "authRequired" | "sessionArchived" | "staleTurn" | "rateLimited";
-  readonly retryable: boolean;
-  readonly message: string;
-}
 
 export interface ThreadWriter {
   /**
@@ -311,6 +303,7 @@ export interface TurnScribe {
     detail?: string;
     settlesTurn: boolean;
     category?: ProviderErrorCategory;
+    willRetry?: boolean;
   }): void;
 
   /**
@@ -495,6 +488,7 @@ export function createTurnScribe(writer: ThreadWriter, turnKeyPrefix: string): T
           message: e.message,
           ...(e.detail === undefined ? {} : { detail: e.detail }),
           ...(e.category === undefined ? {} : { category: e.category }),
+          ...(e.willRetry === undefined ? {} : { willRetry: e.willRetry }),
           ...(settles ? { settlesTurn: true } : {}),
         },
       ]);

--- a/plugins/amp/test/bridge-stream.test.ts
+++ b/plugins/amp/test/bridge-stream.test.ts
@@ -306,6 +306,34 @@ describe("bridge stream (U2)", () => {
     assert.equal(last.status, "failed");
   });
 
+  it("marks a stream disconnect as a non-retrying provider error", () => {
+    const { messages, writer } = makeHarness();
+    const scribe = writer.scribe();
+    const { oracle } = makeOracle();
+    const ctx = makeContext(writer, scribe, oracle);
+    projectAmpEvent(
+      {
+        kind: "resultError",
+        subtype: "stream_disconnected",
+        message: "OpenAI WebSocket closed: 1006",
+        denials: [],
+      },
+      ctx,
+    );
+
+    const deltaMessage = messages.find((message) => message.method === "thread/delta");
+    assert.ok(deltaMessage);
+    const params = deltaMessage.params as { deltas?: Array<Record<string, unknown>> };
+    const providerError = params.deltas?.find((delta) => delta.kind === "provider.error");
+    assert.deepEqual(providerError, {
+      kind: "provider.error",
+      message: "OpenAI WebSocket closed: 1006",
+      category: "stream-disconnected",
+      willRetry: false,
+      settlesTurn: true,
+    });
+  });
+
   it("claims a zero-work turn", () => {
     const { messages, writer } = makeHarness();
     const scribe = writer.scribe();

--- a/plugins/amp/test/events.test.ts
+++ b/plugins/amp/test/events.test.ts
@@ -355,6 +355,10 @@ describe("result messages", () => {
 describe("classifyAmpError", () => {
   it("keeps error_max_turns even when the text looks auth-shaped", () => {
     assert.equal(classifyAmpError("error_max_turns", "run 'amp login'"), "error_max_turns");
+    assert.equal(
+      classifyAmpError("error_max_turns", "OpenAI WebSocket closed: 1006"),
+      "error_max_turns",
+    );
   });
 
   it("splits error_during_execution on auth-shaped text", () => {

--- a/plugins/amp/test/session-orb-routing.test.ts
+++ b/plugins/amp/test/session-orb-routing.test.ts
@@ -26,8 +26,15 @@ interface ThreadLinkDelta {
   };
 }
 
-async function* oneTurn(ampThreadId: string): AsyncGenerator<AmpEventBatch> {
-  yield { ampThreadId, terminal: true, events: [] };
+async function* oneTurn(
+  ampThreadId: string,
+  onClose: () => void = () => {},
+): AsyncGenerator<AmpEventBatch> {
+  try {
+    yield { ampThreadId, terminal: true, events: [] };
+  } finally {
+    onClose();
+  }
 }
 
 function fakeConversation(sends: string[]): AmpConversation {
@@ -52,6 +59,8 @@ function harness(target: "local" | "orb" = "local") {
   const writes: AmpSessionRecord[] = [];
   const localSends: string[] = [];
   const orbPrompts: string[] = [];
+  const orbAborts: string[] = [];
+  const orbOutputsClosed: string[] = [];
 
   const writer = {
     emit: (batch: readonly unknown[]) => {
@@ -122,8 +131,10 @@ function harness(target: "local" | "orb" = "local") {
       runOrb: (runArgs) => {
         orbPrompts.push(runArgs.prompt);
         return {
-          batches: () => oneTurn("T-orb-1"),
-          abort: () => {},
+          batches: () => oneTurn("T-orb-1", () => orbOutputsClosed.push("closed")),
+          abort: () => {
+            orbAborts.push("aborted");
+          },
         } as unknown as OrbRun;
       },
       threadCommand: () => Promise.resolve({ ok: true, stderr: "" }),
@@ -131,7 +142,17 @@ function harness(target: "local" | "orb" = "local") {
     },
   });
 
-  return { session, record, deltas, failures, writes, localSends, orbPrompts };
+  return {
+    session,
+    record,
+    deltas,
+    failures,
+    writes,
+    localSends,
+    orbPrompts,
+    orbAborts,
+    orbOutputsClosed,
+  };
 }
 
 function turn(text: string): TurnStartArgs {
@@ -150,6 +171,8 @@ test("an orb record routes every turn to runOrb and never touches Local", async 
   assert.deepEqual(h.failures, []);
   assert.equal(h.localSends.length, 0);
   assert.deepEqual(h.orbPrompts, ["do the thing", "continue"]);
+  assert.equal(h.orbAborts.length, 2);
+  assert.equal(h.orbOutputsClosed.length, 2);
   assert.equal(h.record.ampThreadId, "T-orb-1");
   assert.equal(h.writes[0]?.ampThreadId, "T-orb-1");
 });

--- a/plugins/amp/test/session-recovery.test.ts
+++ b/plugins/amp/test/session-recovery.test.ts
@@ -1,0 +1,402 @@
+import assert from "node:assert/strict";
+import { mock, test } from "bun:test";
+import type {
+  BridgeExecutionOptions,
+  ProviderRecoveryHint,
+} from "@get-bb/plugin-sdk/provider-bridge";
+import type { AmpConversation } from "../src/bridge/conversation.ts";
+import { parseAmpBatch, type AmpEventBatch } from "../src/bridge/events.ts";
+import type { OracleReports } from "../src/bridge/project.ts";
+import {
+  createAmpSession,
+  type AmpSessionRecord,
+  type SessionDeps,
+  type SessionStore,
+  type TurnStartArgs,
+} from "../src/bridge/session.ts";
+import type { ThreadWriter, TurnScribe } from "../src/bridge/timeline.ts";
+
+const SOCKET_CLOSED =
+  "OpenAI WebSocket closed: 1006 . If this persists, deactivate your ChatGPT subscription: https://ampcode.com/settings/model-routing";
+
+interface FakeConversation extends AmpConversation {
+  readonly sends: string[];
+  readonly abortReasons: Array<Parameters<AmpConversation["abort"]>[0]>;
+  readonly outputClosed: boolean;
+}
+
+function fakeConversation(script: readonly AmpEventBatch[], streamError?: Error): FakeConversation {
+  const sends: string[] = [];
+  const abortReasons: Array<Parameters<AmpConversation["abort"]>[0]> = [];
+  let closed = false;
+  let aborted = false;
+  let outputClosed = false;
+  const output = (async function* (): AsyncGenerator<AmpEventBatch> {
+    try {
+      yield* script;
+      if (streamError !== undefined) throw streamError;
+    } finally {
+      outputClosed = true;
+    }
+  })();
+
+  return {
+    sends,
+    abortReasons,
+    send: (text) => {
+      sends.push(text);
+      return Promise.resolve();
+    },
+    batches: () => output,
+    ampThreadId: script.at(-1)?.ampThreadId ?? null,
+    committed: script.length > 0,
+    get closed() {
+      return closed;
+    },
+    get aborted() {
+      return aborted;
+    },
+    get outputClosed() {
+      return outputClosed;
+    },
+    closeInput: () => {
+      closed = true;
+    },
+    abort: (reason) => {
+      abortReasons.push(reason);
+      aborted = true;
+      closed = true;
+    },
+  };
+}
+
+function terminalOnAbortConversation(): {
+  conversation: FakeConversation;
+  waiting: Promise<void>;
+} {
+  const sends: string[] = [];
+  const abortReasons: Array<Parameters<AmpConversation["abort"]>[0]> = [];
+  let aborted = false;
+  let closed = false;
+  let releaseBatch: ((batch: AmpEventBatch) => void) | null = null;
+  let markWaiting: (() => void) | null = null;
+  const waiting = new Promise<void>((resolve) => {
+    markWaiting = resolve;
+  });
+  const batch = new Promise<AmpEventBatch>((resolve) => {
+    releaseBatch = resolve;
+  });
+  const output = (async function* (): AsyncGenerator<AmpEventBatch> {
+    markWaiting?.();
+    yield await batch;
+  })();
+
+  return {
+    waiting,
+    conversation: {
+      sends,
+      abortReasons,
+      send: (text) => {
+        sends.push(text);
+        return Promise.resolve();
+      },
+      batches: () => output,
+      ampThreadId: null,
+      committed: false,
+      get closed() {
+        return closed;
+      },
+      get aborted() {
+        return aborted;
+      },
+      get outputClosed() {
+        return false;
+      },
+      closeInput: () => {
+        closed = true;
+      },
+      abort: (reason) => {
+        abortReasons.push(reason);
+        aborted = true;
+        closed = true;
+        releaseBatch?.({ ampThreadId: null, terminal: true, events: [] });
+      },
+    },
+  };
+}
+
+function turn(text: string): TurnStartArgs {
+  return {
+    input: [{ type: "text", text }],
+    clientRequestId: null,
+    options: {} as BridgeExecutionOptions,
+  };
+}
+
+function harness(
+  conversations: FakeConversation[],
+  write: SessionStore["write"] = () => Promise.resolve(),
+) {
+  const createConversation = mock<SessionDeps["createConversation"]>(() => {
+    const conversation = conversations.shift();
+    assert.ok(conversation, "unexpected extra Local conversation");
+    return conversation;
+  });
+  const failures: Array<Parameters<TurnScribe["fail"]>[0]> = [];
+  const settlements: Array<Parameters<TurnScribe["settle"]>[0]> = [];
+  const replacements: unknown[] = [];
+  const recoveries: ProviderRecoveryHint[] = [];
+  const writer = {
+    emit: () => {},
+    flush: () => {},
+    addUsage: () => {},
+    replaced: (notice: unknown) => {
+      replacements.push(notice);
+    },
+    recovery: (hint: ProviderRecoveryHint) => {
+      recoveries.push(hint);
+    },
+    raw: () => {},
+    scribe: (): TurnScribe => {
+      let settled = false;
+      return {
+        accept: () => {},
+        open: () => {},
+        say: () => {},
+        think: () => {},
+        warn: () => {},
+        openItem: () => {
+          throw new Error("no timeline items expected in this test");
+        },
+        closeItem: () => {},
+        recordItem: () => {},
+        progress: () => {},
+        state: () => {},
+        fail: (failure) => {
+          failures.push(failure);
+          if (failure.settlesTurn) settled = true;
+        },
+        settle: (status) => {
+          settlements.push(status);
+          settled = true;
+        },
+        mintKey: (family) => `${family}:test`,
+        get settled() {
+          return settled;
+        },
+      } as TurnScribe;
+    },
+  } as ThreadWriter;
+  const store: SessionStore = {
+    read: () => Promise.resolve(null),
+    write,
+    delete: () => Promise.resolve(),
+  };
+  const record: AmpSessionRecord = {
+    ampThreadId: null,
+    executionTarget: "local",
+    threadId: "thr_test",
+  };
+  const session = createAmpSession({
+    threadId: "thr_test",
+    providerThreadId: "amp-test",
+    cwd: "/tmp",
+    record,
+    writer,
+    store,
+    disallowedTools: [],
+    mcpConfigDigest: "",
+    bbToolIds: new Set(),
+    deps: {
+      createConversation,
+      runOrb: () => {
+        throw new Error("Orb is not expected in this test");
+      },
+      threadCommand: () => Promise.resolve({ ok: true, stderr: "" }),
+      oracle: null as unknown as OracleReports,
+    },
+  });
+
+  return {
+    session,
+    record,
+    createConversation,
+    failures,
+    settlements,
+    replacements,
+    recoveries,
+  };
+}
+
+function assistantStop(ampThreadId: string): AmpEventBatch {
+  return {
+    ampThreadId,
+    terminal: false,
+    events: [{ kind: "assistantStop", reason: "end_turn" }],
+  };
+}
+
+function socketDisconnect(): AmpEventBatch {
+  return parseAmpBatch({
+    type: "result",
+    subtype: "error_during_execution",
+    session_id: "T-prod",
+    is_error: true,
+    error: SOCKET_CLOSED,
+  });
+}
+
+test("a terminal WebSocket error resumes Local with --continue and only the new prompt", async () => {
+  const disconnected = socketDisconnect();
+  assert.deepEqual(disconnected, {
+    ampThreadId: "T-prod",
+    terminal: true,
+    events: [
+      {
+        kind: "resultError",
+        subtype: "stream_disconnected",
+        message: SOCKET_CLOSED,
+        denials: [],
+      },
+    ],
+  });
+  const first = fakeConversation([disconnected]);
+  const second = fakeConversation([assistantStop("T-prod")]);
+  const h = harness([first, second]);
+
+  await h.session.startTurn(turn("original prompt"));
+
+  assert.deepEqual(h.failures, [
+    {
+      message: SOCKET_CLOSED,
+      settlesTurn: true,
+      category: "stream-disconnected",
+      willRetry: false,
+    },
+  ]);
+  assert.deepEqual(h.recoveries, [
+    {
+      kind: "restartRecommended",
+      message: "Amp disconnected from OpenAI. Retry to continue this thread in a fresh process.",
+      retryable: true,
+    },
+  ]);
+  assert.equal(h.record.ampThreadId, "T-prod");
+  assert.deepEqual(first.abortReasons, ["restart"]);
+  assert.equal(first.outputClosed, true);
+
+  await h.session.startTurn(turn("continue"));
+
+  assert.equal(h.createConversation.mock.calls.length, 2);
+  assert.equal(h.createConversation.mock.calls[1]?.[0].continueFrom, "T-prod");
+  assert.deepEqual(first.sends, ["original prompt"]);
+  assert.deepEqual(second.sends, ["continue"]);
+  assert.equal(h.failures.length, 1);
+  assert.deepEqual(h.replacements, [
+    {
+      providerThreadId: "amp-test",
+      reason: "the Amp process ended",
+      contextLost: false,
+    },
+  ]);
+});
+
+test("a nonterminal assistant stop keeps the Local conversation warm", async () => {
+  const conversation = fakeConversation([assistantStop("T-warm"), assistantStop("T-warm")]);
+  const h = harness([conversation]);
+
+  await h.session.startTurn(turn("one"));
+  await h.session.startTurn(turn("two"));
+
+  assert.equal(h.createConversation.mock.calls.length, 1);
+  assert.deepEqual(conversation.sends, ["one", "two"]);
+  assert.deepEqual(conversation.abortReasons, []);
+  assert.equal(conversation.outputClosed, false);
+  assert.deepEqual(h.failures, []);
+  assert.deepEqual(h.settlements, ["completed", "completed"]);
+});
+
+test("natural iterator completion retires the Local conversation", async () => {
+  const conversation = fakeConversation([]);
+  const replacement = fakeConversation([assistantStop("T-new")]);
+  const h = harness([conversation, replacement]);
+
+  await h.session.startTurn(turn("one"));
+
+  assert.deepEqual(h.failures, [
+    { message: "Amp ended without reporting a result", settlesTurn: true },
+  ]);
+  assert.deepEqual(conversation.abortReasons, ["restart"]);
+  assert.equal(conversation.outputClosed, true);
+  assert.deepEqual(h.replacements, []);
+
+  await h.session.startTurn(turn("two"));
+
+  assert.deepEqual(h.replacements, [
+    {
+      providerThreadId: "amp-test",
+      reason: "the Amp process ended",
+      contextLost: true,
+    },
+  ]);
+});
+
+test("an iterator throw retires the Local conversation", async () => {
+  const conversation = fakeConversation([], new Error("stream broke"));
+  const h = harness([conversation]);
+
+  await h.session.startTurn(turn("one"));
+
+  assert.deepEqual(h.failures, [{ message: "Amp failed: stream broke", settlesTurn: true }]);
+  assert.deepEqual(conversation.abortReasons, ["restart"]);
+  assert.equal(conversation.outputClosed, true);
+  assert.deepEqual(h.replacements, []);
+});
+
+test("a stream disconnect still recommends retry when the Amp thread write fails", async () => {
+  const conversation = fakeConversation([socketDisconnect()]);
+  const h = harness([conversation], () => Promise.reject(new Error("disk full")));
+
+  await h.session.startTurn(turn("one"));
+
+  assert.equal(h.record.ampThreadId, "T-prod");
+  assert.deepEqual(h.recoveries, [
+    {
+      kind: "restartRecommended",
+      message: "Amp disconnected from OpenAI. Retry to continue this thread in a fresh process.",
+      retryable: true,
+    },
+  ]);
+  assert.deepEqual(conversation.abortReasons, ["restart"]);
+  assert.equal(conversation.outputClosed, true);
+});
+
+test("a failed Amp thread write is attempted only once per session", async () => {
+  const write = mock<SessionStore["write"]>(() => Promise.reject(new Error("disk full")));
+  const conversation = fakeConversation([
+    { ampThreadId: "T-prod", terminal: false, events: [] },
+    { ampThreadId: "T-prod", terminal: true, events: [] },
+  ]);
+  const h = harness([conversation], write);
+
+  await h.session.startTurn(turn("one"));
+
+  assert.equal(write.mock.calls.length, 1);
+});
+
+test("a buffered terminal batch honors release and interrupt stops", async () => {
+  for (const [intent, expected] of [
+    ["release", []],
+    ["interrupt", ["interrupted"]],
+  ] as const) {
+    const { conversation, waiting } = terminalOnAbortConversation();
+    const h = harness([conversation]);
+    const started = h.session.startTurn(turn(intent));
+    await waiting;
+
+    await h.session.stop(intent);
+    await started;
+
+    assert.deepEqual(h.settlements, expected);
+  }
+});


### PR DESCRIPTION
Summary:
- classify OpenAI WebSocket 1006 closures as recoverable disconnects
- retire the failed CLI and resume with the persisted Amp thread
- preserve stop semantics and report context loss on replacement

Tests:
- bun test plugins/amp/test --timeout 30000
- bun run typecheck
- bun run lint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Amp's recovery from OpenAI WebSocket 1006 disconnects. Previously these failures ended the turn without any retry; now they're classified as recoverable, the failed CLI is retired, and the next turn resumes with the persisted Amp thread. Stop semantics are preserved and context loss is reported when the thread ID wasn't persisted.

**Bug Fixes**
- Classifies 1006 closure errors as `stream_disconnected` and emits a non-retrying provider error.
- Retires the failed Local CLI and announces a session replacement with the correct `contextLost` flag.
- Persists the Amp thread ID on the first stream write and writes it through once so recovery can resume even after a crash.

<sup>Written for commit 4b13a132ac5c6b340e890c6a33ddbb09117bd220. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/smsunarto/bb-plugins/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

