### PR TITLE
fix(gtd-sidebar): pass GitButler virtual branch names through the host

### DIFF
--- a/plugins/gtd-sidebar/host.ts
+++ b/plugins/gtd-sidebar/host.ts
@@ -20,11 +20,15 @@ export default experimental_defineHostEntry({
           signal: context.signal,
           timeout: 5_000,
         });
-        return { label: parseGitButlerBranchSummary(stdout)?.label ?? null };
+        const summary = parseGitButlerBranchSummary(stdout);
+        return {
+          label: summary?.label ?? null,
+          branchNames: summary?.branchNames ?? [],
+        };
       } catch {
         // A regular repository, a host without `but`, and a stopped GitButler
         // project all keep bb's own branch label. This probe is an enhancement.
-        return { label: null };
+        return { label: null, branchNames: [] };
       }
     },
     "ai.inference.complete": async (input) => {

--- a/plugins/gtd-sidebar/lib/gitbutler.ts
+++ b/plugins/gtd-sidebar/lib/gitbutler.ts
@@ -6,6 +6,7 @@ export const gitButlerHostContract = defineRpcContract({
     input: z.object({ cwd: z.string().trim().min(1) }),
     output: z.object({
       label: z.string().nullable(),
+      branchNames: z.array(z.string().trim().min(1)).max(16).default([]),
     }),
   },
 });
@@ -61,6 +62,32 @@ export function resolveSidebarBranchLabel(
 ): string | null {
   if (environmentId === null) return branchName;
   return gitButlerLabels.get(environmentId) ?? branchName;
+}
+
+const GITBUTLER_WORKSPACE_REF = "gitbutler/workspace";
+const GITBUTLER_COUNT_LABEL = /^\d+ GitButler branches$/u;
+
+/**
+ * Names that can match a GitHub head ref. The sidebar display label for a
+ * multi-branch GitButler workspace is a count, and bb's raw ref is
+ * `gitbutler/workspace` — both of those fail PR matching. The host's parsed
+ * virtual-branch names are the ones that can hit.
+ */
+export function gitButlerBranchNamesFor(
+  branchName: string | null,
+  environmentId: string | null,
+  gitButlerBranches: ReadonlyMap<string, readonly string[]>,
+): string[] {
+  if (environmentId !== null) {
+    const fromHost = gitButlerBranches.get(environmentId);
+    if (fromHost !== undefined && fromHost.length > 0) {
+      return [...fromHost];
+    }
+  }
+  const raw = branchName?.trim() ?? "";
+  if (raw.length === 0) return [];
+  if (raw === GITBUTLER_WORKSPACE_REF || GITBUTLER_COUNT_LABEL.test(raw)) return [];
+  return [raw];
 }
 
 export function gitButlerLabelsMatch(

--- a/plugins/gtd-sidebar/server.ts
+++ b/plugins/gtd-sidebar/server.ts
@@ -49,6 +49,7 @@ export const gtdSidebarRpcContract = defineRpcContract({
         z.object({
           environmentId: z.string(),
           label: z.string(),
+          branchNames: z.array(z.string().trim().min(1)).max(16).default([]),
         }),
       ),
     }),
@@ -219,6 +220,7 @@ export default function plugin(bb: BbPluginApi) {
             return {
               environmentId,
               label: summary.label,
+              branchNames: summary.branchNames ?? [],
             };
           } catch {
             // The card keeps bb's own branch label when the environment or its

--- a/plugins/gtd-sidebar/test/gitbutler.test.ts
+++ b/plugins/gtd-sidebar/test/gitbutler.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  gitButlerBranchNamesFor,
   gitButlerLabelsMatch,
   parseGitButlerBranchSummary,
   resolveSidebarBranchLabel,
@@ -97,5 +98,31 @@ describe("resolveSidebarBranchLabel", () => {
       resolveSidebarBranchLabel("gitbutler/workspace", "env_unknown", labels),
       "gitbutler/workspace",
     );
+  });
+});
+
+describe("gitButlerBranchNamesFor", () => {
+  it("uses the host's virtual branch names, not the count label", () => {
+    const branches = new Map([["env_local", ["scott/api", "scott/ui", "scott/docs"]]]);
+    assert.deepEqual(
+      gitButlerBranchNamesFor("gitbutler/workspace", "env_local", branches),
+      ["scott/api", "scott/ui", "scott/docs"],
+    );
+    assert.deepEqual(
+      gitButlerBranchNamesFor("3 GitButler branches", "env_local", branches),
+      ["scott/api", "scott/ui", "scott/docs"],
+    );
+  });
+
+  it("drops GitButler workspace refs when the host has not answered", () => {
+    assert.deepEqual(
+      gitButlerBranchNamesFor("gitbutler/workspace", "env_unknown", new Map()),
+      [],
+    );
+    assert.deepEqual(gitButlerBranchNamesFor("3 GitButler branches", "env_x", new Map()), []);
+  });
+
+  it("keeps a real git branch when GitButler is not in play", () => {
+    assert.deepEqual(gitButlerBranchNamesFor("feat/ship", "env_x", new Map()), ["feat/ship"]);
   });
 });


### PR DESCRIPTION
Rebased onto current `main`. The original poll-coalesce stack conflicted because this plugin no longer talks to `gh` — PR badges come from `experimental_useSidebarThreadPullRequest`. Re-adding that poller would have undone that.

What still applies from the review:

`but status --json` already parses real virtual branch names, but the host RPC only returned the display label (`3 GitButler branches` / `gitbutler/workspace`), which cannot match a PR head. This forwards `branchNames` from the host probe through `listEnvironmentBranches`.

The live machine still runs the fork poller (rate-limit coalescing) from a separate worktree; that code is not in this PR.

150 plugin tests pass.